### PR TITLE
Add //cc:toolchain_type alias to allow forward migration with Bazel 0.27

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,1 +1,4 @@
-# Intentionally left empty
+alias(
+    name = "toolchain_type",
+    actual = "@bazel_tools//tools/cpp:toolchain_type",
+)


### PR DESCRIPTION
This target will eventually be the canonical place for C++ toolchain
type. Currently the actual target resides in @bazel_tools, but that will
soon change.