### PR TITLE
Placed GitHub release first for @skylib.

### DIFF
--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -9,8 +9,8 @@ def rules_cc_dependencies():
         sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
         strip_prefix = "bazel-skylib-0.8.0",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
See bazelbuild/bazel-skylib#164.