### PR TITLE
Fix sha hash of the skylib release, and put mirror first

### DIFF
--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -6,11 +6,11 @@ def rules_cc_dependencies():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
         strip_prefix = "bazel-skylib-0.8.0",
         urls = [
-            "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
I have no clue what happened, but it seems skylib release on github was
changed after rules_cc started to depend on it.