### PR TITLE
Add macro to register toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ For the list of C++ rules, see the Bazel
 
 # Getting Started
 
-There is no need to use rules from this repository just yet. If you want to use
-rules\_cc anyway, add the following to your WORKSPACE file:
+To get started with rules\_cc, add the following to your WORKSPACE file:
 
 ```
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -21,6 +20,9 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/archive/TODO"],
     sha256 = "TODO",
 )
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+rules_cc_dependencies()
+rules_cc_toolchains()
 ```
 
 Then, in your BUILD files, import and use the rules:
@@ -40,7 +42,7 @@ project for Bazel incompatible changes.
 ## Legacy fields migrator
 
 Script that migrates legacy crosstool fields into features
-([incompatible flag](https://github.com/bazelbuild/bazel/issues/6861), 
+([incompatible flag](https://github.com/bazelbuild/bazel/issues/6861),
 [tracking issue](https://github.com/bazelbuild/bazel/issues/5883)).
 
 TLDR:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,5 +83,6 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 go_register_toolchains()
 
-load("//cc:repositories.bzl", "rules_cc_dependencies")
+load("//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
 rules_cc_dependencies()
+rules_cc_toolchains()

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -14,6 +14,10 @@ def rules_cc_dependencies():
         ],
     )
 
+def rules_cc_toolchains():
+    # Nothing to do here (yet).
+    pass
+
 def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)


### PR DESCRIPTION
While we don't have any toolchains to register today, we will have them
later, e.g., for `cc_proto_library`. This change adds a macro for that and
tells users to include it in their WORKSPACE to make future additions to
the required toolchains a no-op for our users.