### PR TITLE
Fetch dependencies through the Bazel federation.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/b6b856d3e2b0cf43f599107e5d76f018510ad270.zip",
-    sha256 = "ecff5df354527b0f6ac470912cd4a57342900aa5a92379f5da3ef6ed79e6537e",
-    strip_prefix = "bazel-federation-b6b856d3e2b0cf43f599107e5d76f018510ad270",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/01dc3f937696174c9764e23978f9d2e7105fd855.zip",
+    sha256 = "64229f859bb0465fcdb654b31b3e547bbd5462005beaebbc09eb0ec735044cdd",
+    strip_prefix = "bazel-federation-01dc3f937696174c9764e23978f9d2e7105fd855",
     type = "zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/01dc3f937696174c9764e23978f9d2e7105fd855.zip",
-    sha256 = "64229f859bb0465fcdb654b31b3e547bbd5462005beaebbc09eb0ec735044cdd",
-    strip_prefix = "bazel-federation-01dc3f937696174c9764e23978f9d2e7105fd855",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/a3e140a91ea9ea25b01ad0cc6fbfcaf74f65498f.zip",
+    sha256 = "026149d1273a87c634d2270004865fd7474420f88d5bd6ea8d8cd71f4b0f0542",
+    strip_prefix = "bazel-federation-a3e140a91ea9ea25b01ad0cc6fbfcaf74f65498f",
     type = "zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,85 +3,24 @@ workspace(name = "rules_cc")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "six_archive",
-    urls = [
-        "https://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-        "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
-    ],
-    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
-    strip_prefix = "six-1.10.0",
-    build_file = "@//third_party:six.BUILD",
+    name = "bazel_federation",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/b6b856d3e2b0cf43f599107e5d76f018510ad270.zip",
+    sha256 = "ecff5df354527b0f6ac470912cd4a57342900aa5a92379f5da3ef6ed79e6537e",
+    strip_prefix = "bazel-federation-b6b856d3e2b0cf43f599107e5d76f018510ad270",
+    type = "zip",
 )
 
-bind(
-    name = "six",
-    actual = "@six_archive//:six",
-)
+load("@bazel_federation//:repositories.bzl", "rules_cc_deps")
+rules_cc_deps()
 
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "3e933375ecc58d01e52705479b82f155aea2d02cc55d833f8773213e74f88363",
-    strip_prefix = "protobuf-3.7.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/protobuf-all-3.7.0.tar.gz",
-        "https://github.com/protocolbuffers/protobuf/releases/download/v3.7.0/protobuf-all-3.7.0.tar.gz",
-    ],
-)
+load("@bazel_federation//setup:rules_cc.bzl", "rules_cc_setup")
+rules_cc_setup()
 
-http_archive(
-    name = "io_abseil_py",
-    sha256 = "74a2203a9b4681851f4f1dfc17f2832e0a16bae0369b288b18b431cea63f0ee9",
-    strip_prefix = "abseil-py-pypi-v0.6.1",
-    urls = [
-        "https://mirror.bazel.build/github.com/abseil/abseil-py/archive/pypi-v0.6.1.zip",
-        "https://github.com/abseil/abseil-py/archive/pypi-v0.6.1.zip",
-    ],
-)
+#
+# Dependencies for development of rules_cc itself.
+#
+load("//:internal_deps.bzl", "rules_cc_internal_deps")
+rules_cc_internal_deps()
 
-http_archive(
-    name = "py_mock",
-    sha256 = "b839dd2d9c117c701430c149956918a423a9863b48b09c90e30a6013e7d2f44f",
-    urls = [
-        "https://mirror.bazel.build/pypi.python.org/packages/source/m/mock/mock-1.0.1.tar.gz",
-        "https://pypi.python.org/packages/source/m/mock/mock-1.0.1.tar.gz",
-    ],
-    strip_prefix = "mock-1.0.1",
-    patch_cmds = [
-        "mkdir -p py/mock",
-        "mv mock.py py/mock/__init__.py",
-        """echo 'licenses(["notice"])' > BUILD""",
-        "touch py/BUILD",
-        """echo 'py_library(name = "mock", srcs = ["__init__.py"], visibility = ["//visibility:public"],)' > py/mock/BUILD""",
-    ],
-)
-
-# TODO(https://github.com/protocolbuffers/protobuf/issues/5918: Remove when protobuf releases protobuf_deps.bzl)
-http_archive(
-    name = "net_zlib",
-    build_file = "@com_google_protobuf//examples:third_party/zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-)
-
-bind(
-    name = "zlib",
-    actual = "@net_zlib//:zlib"
-)
-
-# Go rules and proto support
-http_archive(
-    name = "io_bazel_rules_go",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-    ],
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
-go_rules_dependencies()
-go_register_toolchains()
-
-load("//cc:repositories.bzl", "rules_cc_dependencies")
-rules_cc_dependencies()
+load("//:internal_setup.bzl", "rules_cc_internal_setup")
+rules_cc_internal_setup()

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -1,5 +1,13 @@
 """Repository rules entry point module for rules_cc."""
 
+# WARNING: This file only exists for backwards-compatibility.
+# rules_cc uses the Bazel federation, so please add any new dependencies to
+# rules_cc_deps() in
+# https://github.com/bazelbuild/bazel-federation/blob/master/repositories.bzl
+# Third party dependencies can be added to
+# https://github.com/bazelbuild/bazel-federation/blob/master/third_party_repositories.bzl
+# Ideally we'd delete this entire file.
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def rules_cc_dependencies():

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,0 +1,12 @@
+load("@bazel_federation//:repositories.bzl", "bazel_skylib", "protobuf", "rules_go")
+load("@bazel_federation//:third_party_repositories.bzl", "abseil_py", "py_mock", "six", "zlib")
+
+def rules_cc_internal_deps():
+    bazel_skylib()
+    protobuf()
+    rules_go()
+
+    abseil_py()
+    py_mock()
+    six()
+    zlib()

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,0 +1,9 @@
+# TODO(fweikert): Add setup.bzl file for skylib to the federation and load it instead of workspace.bzl
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+# TODO(fweikert): Also load rules_go's setup.bzl file from the federation once it exists
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+def rules_cc_internal_setup():
+    bazel_skylib_workspace()
+    go_rules_dependencies()
+    go_register_toolchains()


### PR DESCRIPTION
As a result of this commit, rules_cc now contains the required bzl files to be tested as part of the Bazel federation.