### PR TITLE
Use rules_pkg for building releases

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,8 +6,8 @@ exports_files(["LICENSE"])
 
 filegroup(
     name = "distribution",
-    srcs = glob([
+    srcs = [
         "LICENSE",
-    ]),
+    ],
     visibility = ["@//distro:__pkg__"],
 )

--- a/BUILD
+++ b/BUILD
@@ -3,3 +3,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 exports_files(["LICENSE"])
+
+filegroup(
+    name = "distribution",
+    srcs = glob([
+        "LICENSE",
+    ]),
+    visibility = ["@//distro:__pkg__"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/ed880c20ec6112984caa47ddc6489028dbcc66e2.zip",
-    sha256 = "95339d2002756bdde910c93b6c42248725a7c2b61629585f08580cc4f07d1805",
-    strip_prefix = "bazel-federation-ed880c20ec6112984caa47ddc6489028dbcc66e2",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/f0e5eda7f0cbfe67f126ef4dacb18c89039b0506.zip", # 2019-09-30
+    sha256 = "33222ab7bcc430f1ff1db8788c2e0118b749319dd572476c4fd02322d7d15792",
+    strip_prefix = "bazel-federation-f0e5eda7f0cbfe67f126ef4dacb18c89039b0506",
     type = "zip",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/a3e140a91ea9ea25b01ad0cc6fbfcaf74f65498f.zip",
-    sha256 = "026149d1273a87c634d2270004865fd7474420f88d5bd6ea8d8cd71f4b0f0542",
-    strip_prefix = "bazel-federation-a3e140a91ea9ea25b01ad0cc6fbfcaf74f65498f",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/ed880c20ec6112984caa47ddc6489028dbcc66e2.zip",
+    sha256 = "95339d2002756bdde910c93b6c42248725a7c2b61629585f08580cc4f07d1805",
+    strip_prefix = "bazel-federation-ed880c20ec6112984caa47ddc6489028dbcc66e2",
     type = "zip",
 )
 

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -44,3 +44,14 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
+
+# TODO(aiuto): Find a way to strip this rule from the distribution tarball.
+filegroup(
+    name = "distribution",
+    srcs = glob([
+        "**",
+    ]),
+    visibility = [
+        "//distro:__pkg__",
+    ],
+)

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -19,6 +19,8 @@ load("@rules_cc//cc/private/rules_impl:compiler_flag.bzl", _compiler_flag = "com
 
 _MIGRATION_TAG = "__CC_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
+version = "0.0.1"
+
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:
         attrs["tags"] += [_MIGRATION_TAG]

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -19,8 +19,6 @@ load("@rules_cc//cc/private/rules_impl:compiler_flag.bzl", _compiler_flag = "com
 
 _MIGRATION_TAG = "__CC_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__"
 
-version = "0.0.1"
-
 def _add_tags(attrs):
     if "tags" in attrs and attrs["tags"] != None:
         attrs["tags"] += [_MIGRATION_TAG]

--- a/cc/version.bzl
+++ b/cc/version.bzl
@@ -1,0 +1,17 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Information about the present version of rules_cc."""
+
+version = "0.0.1"

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -2,7 +2,7 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-load("@rules_cc//cc:defs.bzl", "version")
+load("@rules_cc//cc:version.bzl", "version")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
 

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -1,0 +1,30 @@
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+load("@rules_cc//cc:defs.bzl", "version")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
+
+# Build the artifact to put on the github release page.
+pkg_tar(
+    name = "rules_cc-%s" % version,
+    srcs = [
+        "//:distribution",
+        "//cc:distribution",
+    ],
+    extension = "tar.gz",
+    # It is all source code, so make it read-only.
+    mode = "0444",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = ".",
+    strip_prefix = ".",
+)
+
+print_rel_notes(
+    name = "relnotes",
+    outs = ["relnotes.txt"],
+    repo = "rules_cc",
+    version = version,
+)

--- a/distro/README.md
+++ b/distro/README.md
@@ -1,0 +1,11 @@
+# Package rules_cc
+
+```bash
+bazel build :relnotes
+cat ../bazel-bin/distro/relnotes.txt
+tar tzf ../bazel-bin/distro/rules_cc-*.tar.gz
+```
+
+- Create a new release
+- Copy/paste relnotes.txt into the notes. Adjust as needed.
+- Upload the tar.gz file as an artifact.

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -14,7 +14,7 @@
 
 """Dependencies that are needed for rules_cc tests and tools."""
 
-load("@bazel_federation//:repositories.bzl", "bazel_skylib", "protobuf", "rules_go")
+load("@bazel_federation//:repositories.bzl", "bazel_skylib", "protobuf", "rules_go", "rules_pkg")
 load("@bazel_federation//:third_party_repositories.bzl", "abseil_py", "py_mock", "six", "zlib")
 
 def rules_cc_internal_deps():
@@ -22,6 +22,7 @@ def rules_cc_internal_deps():
     bazel_skylib()
     protobuf()
     rules_go()
+    rules_pkg()
 
     abseil_py()
     py_mock()

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -20,7 +20,10 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 # TODO(fweikert): Also load rules_go's setup.bzl file from the federation once it exists
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
+load("@bazel_federation//setup:rules_pkg.bzl", "rules_pkg_setup")
+
 def rules_cc_internal_setup():
     bazel_skylib_workspace()
     go_rules_dependencies()
     go_register_toolchains()
+    rules_pkg_setup()

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -19,7 +19,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 # TODO(fweikert): Also load rules_go's setup.bzl file from the federation once it exists
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
 load("@bazel_federation//setup:rules_pkg.bzl", "rules_pkg_setup")
 
 def rules_cc_internal_setup():


### PR DESCRIPTION
This commit allows the creation of distributions, with 0.0.1 being the first version.
See distro/README.md for details on how to build a release.

This commit also uses a new version of the Bazel federation that contains rules_pkg 0.2.2 instead of 0.2.1.

There are still some problems with the WORKSPACE stanza that is being printed by the release notes generation script, though:
- It references a //cc:deps.bzl file, which doesn't exist. I have to modify the scripts in rules_pkg to support a flag like 'has_deps'.
- It doesn't support the Bazel federation yet, since it always tells users to download code from the rules_cc repository.

NOTE: This PR is not yet ready to be merged, since I'll address the aforementioned TODOs first.