### PR TITLE
Update googletest to 1.10.x

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,14 +25,12 @@ rules_cc_internal_deps()
 load("//:internal_setup.bzl", "rules_cc_internal_setup")
 rules_cc_internal_setup()
 
-# We're pinning to a commit because this project does not have a recent release.
-# Nothing special about this commit, though.
 http_archive(
     name = "com_google_googletest",
-    sha256 = "0fb00ff413f6b9b80ccee44a374ca7a18af7315aea72a43c62f2acd1ca74e9b5",
-    strip_prefix = "googletest-f13bbe2992d188e834339abe6f715b2b2f840a77",
+    sha256 = "4d7cd95cdb0ef420eed163696a906cccd70964801ea611b2020f31177432c27d",
+    strip_prefix = "googletest-1.10.x",
     urls = [
-        "https://mirror.bazel.build/github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz",
-        "https://github.com/google/googletest/archive/f13bbe2992d188e834339abe6f715b2b2f840a77.tar.gz",
+        "https://mirror.bazel.build/github.com/google/googletest/archive/v1.10.x.tar.gz",
+        "https://github.com/google/googletest/archive/v1.10.x.tar.gz",
     ],
 )


### PR DESCRIPTION
@fweikert - shouldn't googletest be updated in the federation as well? It's only a development dependency of rules_cc, so I'm not sure.

@Yannic - FYI, so you don't duplicate work updating rules_cc.