### PR TITLE
Add rules_cc_toolchains to repositories.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,3 +54,6 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 rules_proto_dependencies()
 
 rules_proto_toolchains()
+
+load("//cc:repositories.bzl", "rules_cc_toolchains")
+rules_proto_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,4 +56,4 @@ rules_proto_dependencies()
 rules_proto_toolchains()
 
 load("//cc:repositories.bzl", "rules_cc_toolchains")
-rules_proto_toolchains()
+rules_cc_toolchains()

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -252,7 +252,7 @@ def _get_no_canonical_prefixes_opt(repository_ctx, cc):
         )
     return opt
 
-def _get_env(repository_ctx):
+def get_env(repository_ctx):
     """Convert the environment in a list of export if in Homebrew. Doesn't %-escape the result!
 
     Args:

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -9,6 +9,7 @@
 # Ideally we'd delete this entire file.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//cc/private/toolchain:cc_configure.bzl", "cc_configure")
 
 def rules_cc_dependencies():
     _maybe(
@@ -21,6 +22,9 @@ def rules_cc_dependencies():
             "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
         ],
     )
+
+def rules_cc_toolchains(*args):
+  cc_configure(*args)
 
 def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):


### PR DESCRIPTION
This is the new entry point for registering C++ toolchains (replacing
implicit cc_configure()).

While at it, fix one misnamed function and port bazelbuild/bazel@2682688.