### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
     "extends": [
-        "config:base",
-    ],
+        "config:base"
+    ]
 }


### PR DESCRIPTION
Apparently formatting json with buildifier results in something that is not json. Who would have thought.

Fixes https://github.com/bazelbuild/rules_cc/issues/42