### PR TITLE
Fix cc toolchain autodetection to not error when BAZEL_DO_NOT_DETECT_…

### DIFF
--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -101,7 +101,7 @@ def cc_autoconf_impl(repository_ctx, overriden_tools = dict()):
             "@rules_cc//cc/private/toolchain:empty_cc_toolchain_config.bzl",
         ])
         repository_ctx.symlink(paths["@rules_cc//cc/private/toolchain:empty_cc_toolchain_config.bzl"], "cc_toolchain_config.bzl")
-        repository_ctx.symlink(paths("@rules_cc//cc/private/toolchain:BUILD.empty"), "BUILD")
+        repository_ctx.symlink(paths["@rules_cc//cc/private/toolchain:BUILD.empty"], "BUILD")
     elif cpu_value == "freebsd":
         paths = resolve_labels(repository_ctx, [
             "@rules_cc//cc/private/toolchain:BUILD.static.freebsd",


### PR DESCRIPTION
…CPP_TOOLCHAIN is set.

Copies the fix from https://github.com/bazelbuild/bazel/pull/10440.

Part of https://github.com/bazelbuild/bazel/issues/10439.