### PR TITLE
Stop using the deprecated items parameter. 

### DIFF
--- a/examples/my_c_compile/my_c_compile.bzl
+++ b/examples/my_c_compile/my_c_compile.bzl
@@ -60,7 +60,7 @@ def _my_c_compile_impl(ctx):
         arguments = command_line,
         env = env,
         inputs = depset(
-            items = [source_file],
+            [source_file],
             transitive = [cc_toolchain.all_files],
         ),
         outputs = [output_file],


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/9017 for details