### PR TITLE
Disable `unnamed-macro` for `cc-configure`.

### DIFF
--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -173,6 +173,7 @@ cc_autoconf = repository_rule(
     configure = True,
 )
 
+# buildifier: disable=unnamed-macro
 def cc_configure():
     """A C++ configuration rules that generate the crosstool file."""
     cc_autoconf_toolchains(name = "local_config_cc_toolchains")

--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -173,13 +173,17 @@ cc_autoconf = repository_rule(
     configure = True,
 )
 
-# buildifier: disable=unnamed-macro
-def cc_configure():
-    """A C++ configuration rules that generate the crosstool file."""
-    cc_autoconf_toolchains(name = "local_config_cc_toolchains")
-    cc_autoconf(name = "local_config_cc")
-    native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
+def cc_configure(name = "local_config_cc"):
+    """A C++ configuration rules that generate the crosstool file.
+
+    Args:
+      name: name of the repository
+    """
+    cc_autoconf_toolchains(name = name + "_toolchains")
+    cc_autoconf(name = name)
+    if name == "local_config_cc":
+        native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
     native.register_toolchains(
         # Use register_toolchain's target pattern expansion to register all toolchains in the package.
-        "@local_config_cc_toolchains//:all",
+        "@" + name + "_toolchains//:all",
     )

--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -173,17 +173,13 @@ cc_autoconf = repository_rule(
     configure = True,
 )
 
-def cc_configure(name = "local_config_cc"):
-    """A C++ configuration rules that generate the crosstool file.
-
-    Args:
-      name: name of the repository
-    """
-    cc_autoconf_toolchains(name = name + "_toolchains")
-    cc_autoconf(name = name)
-    if name == "local_config_cc":
-        native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
+# buildifier: disable=unnamed-macro
+def cc_configure():
+    """A C++ configuration rules that generate the crosstool file."""
+    cc_autoconf_toolchains(name = "local_config_cc_toolchains")
+    cc_autoconf(name = "local_config_cc")
+    native.bind(name = "cc_toolchain", actual = "@local_config_cc//:toolchain")
     native.register_toolchains(
         # Use register_toolchain's target pattern expansion to register all toolchains in the package.
-        "@" + name + "_toolchains//:all",
+        "@local_config_cc_toolchains//:all",
     )

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -23,8 +23,8 @@ def rules_cc_dependencies():
         ],
     )
 
-def rules_cc_toolchains(*args):
-    cc_configure(*args)
+def rules_cc_toolchains(name, *args):
+    cc_configure(name, *args)
 
 def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -23,7 +23,7 @@ def rules_cc_dependencies():
         ],
     )
 
-def rules_cc_toolchains(name, *args):
+def rules_cc_toolchains(name = "local_config_cc", *args):
     cc_configure(name, *args)
 
 def _maybe(repo_rule, name, **kwargs):

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -23,8 +23,9 @@ def rules_cc_dependencies():
         ],
     )
 
-def rules_cc_toolchains(name = "local_config_cc", *args):
-    cc_configure(name, *args)
+# buildifier: disable=unnamed-macro
+def rules_cc_toolchains(*args):
+    cc_configure(*args)
 
 def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):


### PR DESCRIPTION
To make the build green again.

Adding `name` attribute to `cc_configure` properly requires synchronization with Bazel and passing the name through to places where we didn't expect before (e.g. hardcoded labels in non-templated BUILD files etc.). I leave that to another day.