### PR TITLE
Add bzl_library targets

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,3 +75,54 @@ cc_toolchain_alias(name = "current_cc_toolchain")
 cc_host_toolchain_alias(name = "current_cc_host_toolchain")
 
 cc_libc_top_alias(name = "current_libc_top")
+
+bzl_library(
+    name = "action_names",
+    srcs = ["action_names.bzl"],
+)
+
+bzl_library(
+    name = "cc_toolchain_config_lib",
+    srcs = ["cc_toolchain_config_lib.bzl"],
+)
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    deps = [
+        "@rules_cc//cc/private/rules_impl:cc_flags_supplier",
+        "@rules_cc//cc/private/rules_impl:compiler_flag",
+    ],
+)
+
+bzl_library(
+    name = "find_cc_toolchain",
+    srcs = ["find_cc_toolchain.bzl"],
+)
+
+bzl_library(
+    name = "repositories",
+    srcs = ["repositories.bzl"],
+    # Temporarily omit @bazel_tools targets that can't be imported because they
+    # are not exported in the production version of Bazel.
+    # https://github.com/bazelbuild/bazel/pull/12258
+    deps = [
+        #"@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@rules_cc//cc/private/toolchain:cc_configure",
+    ],  # keep
+)
+
+bzl_library(
+    name = "system_library",
+    srcs = ["system_library.bzl"],
+)
+
+bzl_library(
+    name = "toolchain_utils",
+    srcs = ["toolchain_utils.bzl"],
+)
+
+bzl_library(
+    name = "version",
+    srcs = ["version.bzl"],
+)

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
@@ -8,4 +10,25 @@ filegroup(
         "**/*.bzl",
         "**/BUILD",
     ]),
+)
+
+bzl_library(
+    name = "cc_flags_supplier",
+    srcs = ["cc_flags_supplier.bzl"],
+    deps = [
+        "@rules_cc//cc:action_names",
+        "@rules_cc//cc:find_cc_toolchain",
+        "@rules_cc//cc/private/rules_impl:cc_flags_supplier_lib",
+    ],
+)
+
+bzl_library(
+    name = "cc_flags_supplier_lib",
+    srcs = ["cc_flags_supplier_lib.bzl"],
+)
+
+bzl_library(
+    name = "compiler_flag",
+    srcs = ["compiler_flag.bzl"],
+    deps = ["@rules_cc//cc:find_cc_toolchain"],
 )

--- a/cc/private/toolchain/BUILD
+++ b/cc/private/toolchain/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//cc:defs.bzl", "cc_flags_supplier", "cc_library", "compiler_flag")
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
@@ -93,3 +94,72 @@ filegroup(
 compiler_flag(name = "compiler")
 
 cc_flags_supplier(name = "cc_flags")
+
+bzl_library(
+    name = "armeabi_cc_toolchain_config",
+    srcs = ["armeabi_cc_toolchain_config.bzl"],
+    deps = ["@rules_cc//cc:cc_toolchain_config_lib"],
+)
+
+bzl_library(
+    name = "cc_configure",
+    srcs = ["cc_configure.bzl"],
+    deps = ["@bazel_tools//tools/osx:xcode_configure.bzl"],
+)
+
+bzl_library(
+    name = "cc_toolchain_config",
+    srcs = ["cc_toolchain_config.bzl"],
+    deps = [
+        "@rules_cc//cc:action_names",
+        "@rules_cc//cc:cc_toolchain_config_lib",
+    ],
+)
+
+bzl_library(
+    name = "empty_cc_toolchain_config",
+    srcs = ["empty_cc_toolchain_config.bzl"],
+)
+
+bzl_library(
+    name = "freebsd_cc_toolchain_config",
+    srcs = ["freebsd_cc_toolchain_config.bzl"],
+    deps = [
+        "@rules_cc//cc:action_names",
+        "@rules_cc//cc:cc_toolchain_config_lib",
+    ],
+)
+
+bzl_library(
+    name = "osx_cc_configure",
+    srcs = ["osx_cc_configure.bzl"],
+    deps = ["@bazel_tools//tools/osx:xcode_configure.bzl"],
+)
+
+bzl_library(
+    name = "unix_cc_configure",
+    srcs = ["unix_cc_configure.bzl"],
+)
+
+bzl_library(
+    name = "unix_cc_toolchain_config",
+    srcs = ["unix_cc_toolchain_config.bzl"],
+    deps = [
+        "@rules_cc//cc:action_names",
+        "@rules_cc//cc:cc_toolchain_config_lib",
+    ],
+)
+
+bzl_library(
+    name = "windows_cc_configure",
+    srcs = ["windows_cc_configure.bzl"],
+)
+
+bzl_library(
+    name = "windows_cc_toolchain_config",
+    srcs = ["windows_cc_toolchain_config.bzl"],
+    deps = [
+        "@rules_cc//cc:action_names",
+        "@rules_cc//cc:cc_toolchain_config_lib",
+    ],
+)

--- a/tools/migration/BUILD
+++ b/tools/migration/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,3 +133,13 @@ filegroup(
 )
 
 exports_files(["ctoolchain_compare.bzl"])
+
+bzl_library(
+    name = "cc_toolchain_config_comparator",
+    srcs = ["cc_toolchain_config_comparator.bzl"],
+)
+
+bzl_library(
+    name = "ctoolchain_compare",
+    srcs = ["ctoolchain_compare.bzl"],
+)


### PR DESCRIPTION
This is to allow people who transitively depend on this repo to use
stardoc to generate documentation for their Bazel targets.

For the origin of this commit, please see
https://github.com/bazelbuild/bazel-gazelle/pull/760#issuecomment-712961346
and the linked PRs in that thread.

This PR is dependent on https://github.com/bazelbuild/bazel-federation/pull/124