### PR TITLE
Test allowing diamond inheritance of shared lib

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -51,6 +51,7 @@ tasks:
     bazel: last_downstream_green
     build_targets:
     - "//examples/test_cc_shared_library/..."
+    - "//examples/test_cc_shared_library/diamond_inheritance"
     build_flags:
     - "--experimental_cc_shared_library"
     - "--//examples:incompatible_link_once=True"
@@ -60,3 +61,4 @@ tasks:
     - "--//examples:incompatible_link_once=True"
     test_targets:
     - "//examples/test_cc_shared_library/..."
+    - "//examples/test_cc_shared_library/diamond_inheritance"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,7 +48,7 @@ tasks:
     <<: *common
   examples:
     platform: ubuntu1804
-    bazel: last_downstream_green
+    bazel: last_green
     build_targets:
     - "//examples/test_cc_shared_library/..."
     - "//examples/test_cc_shared_library/diamond_inheritance/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -51,7 +51,7 @@ tasks:
     bazel: last_downstream_green
     build_targets:
     - "//examples/test_cc_shared_library/..."
-    - "//examples/test_cc_shared_library/diamond_inheritance"
+    - "//examples/test_cc_shared_library/diamond_inheritance/..."
     build_flags:
     - "--experimental_cc_shared_library"
     - "--//examples:incompatible_link_once=True"
@@ -61,4 +61,4 @@ tasks:
     - "--//examples:incompatible_link_once=True"
     test_targets:
     - "//examples/test_cc_shared_library/..."
-    - "//examples/test_cc_shared_library/diamond_inheritance"
+    - "//examples/test_cc_shared_library/diamond_inheritance/..."

--- a/examples/test_cc_shared_library/BUILD
+++ b/examples/test_cc_shared_library/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//examples:experimental_cc_shared_library.bzl", "LINKABLE_MORE_THAN_ONCE", "cc_shared_library")
+load("//examples:experimental_cc_shared_library.bzl", "LINKABLE_MORE_THAN_ONCE", "cc_shared_library", "cc_shared_library_permissions")
 load(":starlark_tests.bzl", "additional_inputs_test", "build_failure_test", "linking_suffix_test", "paths_test")
 
 package(
@@ -201,4 +201,14 @@ bzl_library(
     name = "test_cc_shared_library_starlark_tests_bzl",
     srcs = ["starlark_tests.bzl"],
     visibility = ["//visibility:private"],
+)
+
+cc_shared_library_permissions(
+    name = "permissions",
+    targets = [
+        "//examples/test_cc_shared_library:a_suffix",
+        "//examples/test_cc_shared_library:qux",
+        "//examples/test_cc_shared_library:qux2",
+    ],
+    visibility = ["//examples/test_cc_shared_library/diamond_inheritance:__pkg__"],
 )

--- a/examples/test_cc_shared_library/diamond_inheritance/BUILD
+++ b/examples/test_cc_shared_library/diamond_inheritance/BUILD
@@ -1,0 +1,40 @@
+load("//cc:defs.bzl", "cc_binary")
+load("//examples:experimental_cc_shared_library.bzl", "cc_shared_library")
+
+cc_shared_library(
+    name = "baz_so",
+    roots = ["//examples/test_cc_shared_library:a_suffix"],
+     permissions = [
+        "//examples/test_cc_shared_library:permissions",
+    ],
+)
+
+cc_shared_library(
+    name = "qux_so",
+    dynamic_deps = [":baz_so"],
+    roots = ["//examples/test_cc_shared_library:qux"],
+    permissions = [
+        "//examples/test_cc_shared_library:permissions",
+    ],
+)
+
+cc_shared_library(
+    name = "qux2_so",
+    dynamic_deps = [":baz_so"],
+    roots = ["//examples/test_cc_shared_library:qux2"],
+    permissions = [
+        "//examples/test_cc_shared_library:permissions",
+    ],
+)
+
+cc_binary(
+    name = "diamond_inheritance",
+    srcs = ["main.cc"],
+    dynamic_deps = [
+        ":qux_so",
+        ":qux2_so",
+    ],
+    deps = [
+        "//examples/test_cc_shared_library:a_suffix"
+    ]
+)

--- a/examples/test_cc_shared_library/diamond_inheritance/main.cc
+++ b/examples/test_cc_shared_library/diamond_inheritance/main.cc
@@ -1,0 +1,8 @@
+#include <iostream>
+
+#include "examples/test_cc_shared_library/a_suffix.h"
+
+int main() {
+  std::cout << "hello " << a_suffix() << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This is a test of the scenario described in bazelbuild/bazel#12981.  Fails as described with the release version, and passes with HEAD now.

cc @oquenchil 