### PR TITLE
cc_shared_library publishes CcInfo

### DIFF
--- a/examples/experimental_cc_shared_library.bzl
+++ b/examples/experimental_cc_shared_library.bzl
@@ -365,7 +365,7 @@ def _cc_shared_library_impl(ctx):
         runfiles = runfiles.merge(dep[DefaultInfo].data_runfiles)
 
     for export in ctx.attr.roots:
-        exports[str(export.label)] = export
+        exports[str(export.label)] = True
 
     linker_input = cc_common.create_linker_input(
         owner = ctx.label,


### PR DESCRIPTION
The core mechanism of cc_shared_library is nice in that it decouples the libraries you actually depend on from the linking and library structure.  However I run into several cases where I'd really just like cc_shared_library to behave like a fancy cc_library:

* Passing to rulesets not aware of dynamic_deps such as rules_foreign_cc
* A package wanting to expose its cc_shared_library transparently for consumers to pick up, without having to edit the definition of every downstream cc_binary to have both the cc_library in deps and cc_shared_library in dynamic_deps.

This adds a CcInfo provider to cc_shared_library so it can be used anywhere an existing cc_library can.  Separately, I'll PR to bazel to detect a CcSharedLibraryInfo provider in deps and automatically add it to dynamic_deps.