### PR TITLE
Add armeabi_cc_toolchain_config.bzl to macOS config

### DIFF
--- a/cc/private/toolchain/osx_cc_configure.bzl
+++ b/cc/private/toolchain/osx_cc_configure.bzl
@@ -84,6 +84,7 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
       overriden_tools: dictionary of overriden tools.
     """
     paths = resolve_labels(repository_ctx, [
+        "@rules_cc//cc/private/toolchain:armeabi_cc_toolchain_config.bzl",
         "@rules_cc//cc/private/toolchain:osx_cc_wrapper.sh.tpl",
         "@rules_cc//cc/private/toolchain:libtool_check_unique.cc",
         "@bazel_tools//tools/objc:libtool.sh",
@@ -124,6 +125,10 @@ def configure_osx_toolchain(repository_ctx, overriden_tools):
                 "%{cc}": escape_string(cc_path),
                 "%{env}": escape_string(get_env(repository_ctx)),
             },
+        )
+        repository_ctx.symlink(
+            paths["@rules_cc//cc/private/toolchain:armeabi_cc_toolchain_config.bzl"],
+            "armeabi_cc_toolchain_config.bzl",
         )
         repository_ctx.symlink(
             paths["@bazel_tools//tools/objc:xcrunwrapper.sh"],


### PR DESCRIPTION
This is required since https://github.com/bazelbuild/bazel/pull/13449

Should fix https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2047#9b7530e6-d708-4852-938d-321d0af6e90c