### PR TITLE
Added `bzl_srcs` targets which only contain `.bzl` files

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -46,6 +46,17 @@ filegroup(
 )
 
 filegroup(
+    name = "bzl_srcs",
+    srcs = glob([
+        "**/*.bzl",
+    ]) + [
+        "//cc/private/rules_impl:bzl_srcs",
+        "//cc/private/toolchain:bzl_srcs",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "srcs",
     srcs = glob([
         "**/*.bzl",

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -3,6 +3,13 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 filegroup(
+    name = "bzl_srcs",
+    srcs = glob([
+        "**/*.bzl",
+    ]),
+)
+
+filegroup(
     name = "srcs",
     srcs = glob([
         "**/*.bzl",

--- a/cc/private/toolchain/BUILD
+++ b/cc/private/toolchain/BUILD
@@ -66,6 +66,11 @@ filegroup(
 )
 
 filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+)
+
+filegroup(
     name = "srcs",
     srcs = glob(["**"]),
 )

--- a/tools/migration/BUILD
+++ b/tools/migration/BUILD
@@ -132,7 +132,10 @@ filegroup(
     ],
 )
 
-exports_files(["ctoolchain_compare.bzl"])
+exports_files([
+    "cc_toolchain_config_comparator.bzl",
+    "ctoolchain_compare.bzl",
+])
 
 bzl_library(
     name = "ctoolchain_compare_bzl",


### PR DESCRIPTION
This adds support for generating documentation for `.bzl` files which load these via [stardoc](https://github.com/bazelbuild/stardoc).