### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/cc/private/rules_impl/cc_flags_supplier.bzl
+++ b/cc/private/rules_impl/cc_flags_supplier.bzl
@@ -31,6 +31,5 @@ cc_flags_supplier = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],  # copybara-use-repo-external-label
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/cc/private/rules_impl/compiler_flag.bzl
+++ b/cc/private/rules_impl/compiler_flag.bzl
@@ -28,5 +28,4 @@ compiler_flag = rule(
     toolchains = [
         "@bazel_tools//tools/cpp:toolchain_type",  # copybara-use-repo-external-label
     ],
-    incompatible_use_toolchain_transition = True,
 )

--- a/examples/my_c_archive/my_c_archive.bzl
+++ b/examples/my_c_archive/my_c_archive.bzl
@@ -96,5 +96,4 @@ my_c_archive = rule(
     },
     fragments = ["cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],  # copybara-use-repo-external-label
-    incompatible_use_toolchain_transition = True,
 )

--- a/examples/my_c_compile/my_c_compile.bzl
+++ b/examples/my_c_compile/my_c_compile.bzl
@@ -77,6 +77,5 @@ my_c_compile = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],  # copybara-use-repo-external-label
-    incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
 )

--- a/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
+++ b/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
@@ -29,5 +29,4 @@ write_cc_toolchain_cpu = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],  # copybara-use-repo-external-label
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.