### PR TITLE
Also include xcode_configure in cc_configure module extension

### DIFF
--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Module extension for cc auto configuration."""
 
+load("@bazel_tools//tools/osx:xcode_configure.bzl", "xcode_configure")
 load("//cc/private/toolchain:cc_configure.bzl", "cc_autoconf", "cc_autoconf_toolchains")
 
 def _cc_configure_impl(ctx):
     cc_autoconf_toolchains(name = "local_config_cc_toolchains")
     cc_autoconf(name = "local_config_cc")
+    xcode_configure("@bazel_tools//tools/osx:xcode_locator.m")
 
 cc_configure = module_extension(implementation = _cc_configure_impl)


### PR DESCRIPTION
This is needed for cc toolchain on macOS.