### PR TITLE
Added `clang-format` rules

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,6 +15,7 @@ x_defaults:
     - "//examples/my_c_archive:all"
     - "//examples/my_c_compile:all"
     - "//examples/write_cc_toolchain_cpu:all"
+    - "//tools/clang_format/..."
     - "//tools/migration:all"
     - "//tools/runfiles:all"
     test_flags:
@@ -28,6 +29,7 @@ x_defaults:
     - "//examples/my_c_archive:all"
     - "//examples/my_c_compile:all"
     - "//examples/write_cc_toolchain_cpu:all"
+    - "//tools/clang_format/..."
     - "//tools/migration:all"
     - "//tools/runfiles:all"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,3 +63,5 @@ local_repository(
     name = "test_repo",
     path = "examples/test_cc_shared_library2",
 )
+
+register_toolchains("//tools/clang_format:clang_format_toolchain")

--- a/tools/clang_format/BUILD
+++ b/tools/clang_format/BUILD
@@ -1,0 +1,91 @@
+load("//tools/clang_format:clang_format.bzl", "clang_format", "clang_format_toolchain", "current_clang_format_toolchain")
+load("//tools/clang_format/private:clang_format_utils.bzl", "string_list_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "clang-format.yaml",
+    "clang_format.bzl",
+])
+
+toolchain_type(name = "toolchain_type")
+
+current_clang_format_toolchain(
+    name = "current_clang_format_toolchain",
+    tags = ["manual"],
+)
+
+label_flag(
+    name = "clang_format_config",
+    build_setting_default = "//tools/clang_format:clang-format.yaml",
+    visibility = ["//visibility:public"],
+)
+
+string_list_flag(
+    name = "clang_format_source_attrs",
+    build_setting_default = [
+        "srcs",
+        "hdrs",
+        "textual_hdrs",
+    ],
+)
+
+string_list_flag(
+    name = "clang_format_extensions",
+    build_setting_default = [
+        "asm",
+        "bc",
+        "c",
+        "c++",
+        "cc",
+        "cl",
+        "cpp",
+        "cu",
+        "cxx",
+        "h",
+        "h++",
+        "hh",
+        "hpp",
+        "hxx",
+        "i",
+        "ii",
+        "inc",
+        "inc",
+        "inl",
+        "ipb",
+        "ipp",
+        "m",
+        "mm",
+        "opb",
+        "pch",
+        "s",
+        "tcc",
+        "tlh",
+        "tli",
+    ],
+)
+
+clang_format(
+    name = "clang_format",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob([
+        "**/*.bzl",
+    ]) + [
+        "//tools/clang_format/private:bzl_srcs",
+    ],
+)
+
+clang_format_toolchain(
+    name = "clang_format_toolchain_impl",
+    clang_format_path = "clang-format",
+)
+
+toolchain(
+    name = "clang_format_toolchain",
+    toolchain = "clang_format_toolchain_impl",
+    toolchain_type = "@rules_cc//tools/clang_format:toolchain_type",
+)

--- a/tools/clang_format/clang-format.yaml
+++ b/tools/clang_format/clang-format.yaml
@@ -1,0 +1,3 @@
+---
+BasedOnStyle: Google
+...

--- a/tools/clang_format/clang_format.bzl
+++ b/tools/clang_format/clang_format.bzl
@@ -1,0 +1,400 @@
+"""## Overview
+Rules related to [clang-format][cf]
+
+### Setup
+
+The first thing that needs to be setup is the toolchain. To do so, add something like the following snippet
+to set one up:
+
+```python
+load("@rules_cc//tools/clang_format:clang_format.bzl", "clang_format_toolchain")
+
+clang_format_toolchain(
+    name = "clang_format_toolchain_impl",
+    # This path matches the common linux path though it may vary from system to system.
+    # `clang_format_path` is the easiest way to setup the toolchain though the `clang_format`
+    # label attribute is going to be the most consistent and is thus recommended where possible.
+    clang_format_path = "/usr/bin/clang-format",
+)
+
+toolchain(
+    name = "clang_format_toolchain",
+    toolchain = "clang_format_toolchain_impl",
+    toolchain_type = "@rules_cc//tools/clang_format:toolchain_type",
+)
+```
+
+With a toolchain setup, formatting your C/C++ targets source code requires no additional setup outside of 
+loading `rules_cc` in your workspace. Simply run `bazel run @rules_cc//tools/clang_format` to format source code.
+
+In addition to this formatter, a check can be added to your build phase using the [clang_format_aspect](#clang_format_aspect)
+aspect. Simply add the following to a `.bazelrc` file to enable this check.
+
+```text
+build --aspects=@rules_cc//tools/clang_format:clang_format.bzl%clang_format_aspect
+build --output_groups=+clang_format_checks
+```
+
+It's recommended to only enable this aspect in your CI environment so formatting issues do not
+impact user's ability to rapidly iterate on changes.
+
+The `clang_format_aspect` also uses a `--@rules_cc//tools/clang_format:clang_format_config` setting which determines
+the [configuration file][so] used by the formatter (`@rules_cc//tools/clang_format`) and the aspect
+(`clang_format_aspect`). This flag can be added to your `.bazelrc` file to ensure a consistent config file is used
+whenever `clang-format` is run:
+
+```text
+build --@rules_cc//tools/clang_format:clang_format_config=//:.clang-format
+```
+[cf]: https://clang.llvm.org/docs/ClangFormat.html
+[so]: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//tools/clang_format/private:clang_format_utils.bzl", "BuildSettingInfo")
+
+_WINDOWS_WRAPPER = """\
+@ECHO OFF
+{} %*
+"""
+
+_UNIX_WRAPPER = """\
+#!/usr/bin/env bash
+set -euo pipefail
+eval exec "{}" "$@"
+"""
+
+def _create_wrapper(ctx, path, name, is_windows):
+    """Create a wrapper script for executing an executable at a provided path
+
+    Args:
+        ctx (ctx): The rule's context object
+        path (str): The path of the tool to execute
+        name (str): The name of the wrapper script (minus a `.sh` or `.bat` extension)
+        is_windows (bool): Whether or not the execution platform is Windows.
+
+
+    Returns:
+        path: The generated wrapper script
+    """
+
+    if is_windows:
+        extension = ".bat"
+        template = _WINDOWS_WRAPPER
+    else:
+        extension = ".sh"
+        template = _UNIX_WRAPPER
+
+    wrapper = ctx.actions.declare_file(name + extension)
+    ctx.actions.write(
+        wrapper,
+        template.format(path),
+        is_executable = True,
+    )
+
+    return wrapper
+
+def _clang_format_toolchain_impl(ctx):
+    is_windows = ctx.attr._is_windows[BuildSettingInfo].value
+
+    if ctx.attr.clang_format:
+        clang_format = ctx.executable.clang_format
+    elif ctx.attr.clang_format_path:
+        name = "{}.clang-format".format(ctx.label.name)
+        clang_format = _create_wrapper(ctx, ctx.attr.clang_format_path, name, is_windows)
+    else:
+        fail("No clang-format binary provided. Please either set `clang_format` or `clang_format_path`")
+
+    diff_tool = ctx.executable.diff_tool
+    if not diff_tool and ctx.attr.diff_tool_path:
+        name = "{}.diff".format(ctx.label.name)
+        diff_tool = _create_wrapper(ctx, ctx.attr.diff_tool_path, name, is_windows)
+
+    make_variables = {
+        "CLANG_FORMAT": clang_format.path,
+    }
+
+    if diff_tool:
+        make_variables.update({"CLANG_FORMAT_DIFF_TOOL": diff_tool.path})
+
+    return [platform_common.ToolchainInfo(
+        clang_format = clang_format,
+        diff_tool = diff_tool,
+        make_variables = platform_common.TemplateVariableInfo(make_variables),
+    )]
+
+clang_format_toolchain = rule(
+    doc = "A toolchain providing binaries required for `clang-format` rules.",
+    implementation = _clang_format_toolchain_impl,
+    attrs = {
+        "clang_format": attr.label(
+            doc = "A `clang-format` binary",
+            allow_files = True,
+            cfg = "exec",
+            executable = True,
+        ),
+        "clang_format_path": attr.string(
+            doc = (
+                "Either an absolute path to a `clang-format` binary or the " +
+                "name of a binary located in the `PATH` environment variable"
+            ),
+        ),
+        "diff_tool": attr.label(
+            doc = (
+                "A diff binary used to produce diffs. Thus must conform to " +
+                "the `{diff_tool} {src1} {src2}` api"
+            ),
+            allow_files = True,
+            cfg = "exec",
+            executable = True,
+        ),
+        "diff_tool_path": attr.string(
+            doc = (
+                "Either an absolute path to a diff tool binary or the name " +
+                "of a binary located in the `PATH` environment variable. " +
+                "Must conform to the `{diff_tool} {src1} {src2}` api"
+            ),
+        ),
+        "_is_windows": attr.label(
+            doc = "A `bool_setting` identifying whether or not the exec platform is windows",
+            cfg = "exec",
+            default = Label("//tools/clang_format/private:is_windows"),
+        ),
+    },
+)
+
+def _current_clang_format_toolchain_impl(ctx):
+    toolchain = ctx.toolchains[str(Label("//tools/clang_format:toolchain_type"))]
+
+    return [
+        toolchain,
+        toolchain.make_variables,
+        DefaultInfo(
+            files = depset([
+                toolchain.clang_format,
+            ]),
+            runfiles = ctx.runfiles(files = [toolchain.clang_format]),
+        ),
+    ]
+
+current_clang_format_toolchain = rule(
+    doc = "A rule for exposing the current registered `clang_format_toolchain`.",
+    implementation = _current_clang_format_toolchain_impl,
+    toolchains = [
+        str(Label("//tools/clang_format:toolchain_type")),
+    ],
+    incompatible_use_toolchain_transition = True,
+)
+
+def _find_formattable_srcs(target, aspect_ctx):
+    """Parse a target for clang-format formattable sources.
+
+    Args:
+        target (Target): The target the aspect is running on.
+        aspect_ctx (ctx, optional): The aspect's context object.
+
+    Returns:
+        list: A list of formattable sources (`File`).
+    """
+    if CcInfo not in target:
+        return []
+
+    # Ignore external targets
+    if target.label.workspace_root.startswith("external"):
+        return []
+
+    # Targets tagged to indicate "don't format" will not be formatted
+    if aspect_ctx:
+        for tag in ["noformat", "no-format", "no-clang-format"]:
+            if tag in aspect_ctx.rule.attr.tags:
+                return []
+
+    # Collect all source files
+    srcs = []
+    for attr in aspect_ctx.attr._source_attrs[BuildSettingInfo].value:
+        srcs.extend(getattr(aspect_ctx.rule.files, attr, list()))
+
+    # Filter out any duplicate or generated files
+    srcs = [src for src in depset(srcs).to_list() if src.is_source]
+
+    # Filter out any sources that don't match the correct extension
+    srcs = [src for src in srcs if src.extension in aspect_ctx.attr._extensions[BuildSettingInfo].value]
+
+    return sorted(srcs)
+
+def _perform_check(ctx, target, srcs):
+    """Run `clang-format` and errors out if a defect is detected
+
+    Args:
+        ctx (ctx): The rule's or aspect's context object
+        target (target): The aspect target
+        srcs (list): A list of File objects
+
+    Returns:
+        path: An indicator that `clang-format` ran successfully.
+    """
+    toolchain = ctx.toolchains[Label("//tools/clang_format:toolchain_type")]
+
+    marker = ctx.actions.declare_file(ctx.label.name + ".clang_format.ok")
+    config = ctx.file._config
+
+    tools = [toolchain.clang_format]
+    args = ctx.actions.args()
+    args.add("--touch-file", marker)
+
+    args.add("--config-file", config)
+    for src in srcs:
+        args.add("--source-file", src)
+
+    if toolchain.diff_tool:
+        tools.append(toolchain.diff_tool)
+        args.add("--diff-tool-file", toolchain.diff_tool)
+        args.add("--")
+        args.add(toolchain.clang_format)
+        args.add("-style=file")
+        args.add("-i")
+    else:
+        args.add("--")
+        args.add(toolchain.clang_format)
+        args.add("-style=file")
+        args.add("-Werror")
+        args.add("-dry-run")
+
+    ctx.actions.run(
+        executable = ctx.executable._process_wrapper,
+        inputs = srcs + [config],
+        outputs = [marker],
+        tools = tools,
+        arguments = [args],
+        mnemonic = "ClangFormat",
+        progress_message = "Running clang-format on '{}'".format(
+            target.label,
+        ),
+        use_default_shell_env = True,
+    )
+
+    return marker
+
+def _clang_format_aspect_impl(target, ctx):
+    srcs = _find_formattable_srcs(target, ctx)
+
+    # If there are no formattable sources, do nothing.
+    if not srcs:
+        return []
+
+    marker = _perform_check(ctx, target, srcs)
+
+    return [
+        OutputGroupInfo(
+            clang_format_checks = depset([marker]),
+        ),
+    ]
+
+clang_format_aspect = aspect(
+    implementation = _clang_format_aspect_impl,
+    doc = """\
+This aspect is used to gather information about a target for use with [clang-format] and perform a formatting check
+
+Output Groups:
+- `clang_format_checks`: Executes `clang-format` checks on the specified target.
+
+The build setting `@rules_cc//tools/clang_format:clang_format_config` is used to control the `clang-format` 
+[configuration settings][cs] used at runtime.
+
+This aspect is executed on any target which provides the [CcInfo][ci] provider. However users may tag a target with
+`noformat`, `no-format`, or `no-clang-format` to have it skipped. Additionally, there are two flags which can be used
+to futher control how source files are detected by this aspect:
+- `@rules_cc//tools/clang_format:clang_format_extensions`: An allow list of source file extensions to be formatted
+- `@rules_cc//tools/clang_format:clang_format_source_attrs`: Attributes on rules which provide [CcInfo][ci].
+
+Generated source files are also ignored by this aspect.
+
+[cf]: https://clang.llvm.org/docs/ClangFormat.html
+[cs]: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+[ci]: https://docs.bazel.build/versions/main/skylark/lib/CcInfo.html
+""",
+    attrs = {
+        "_config": attr.label(
+            doc = "The `.clang-format` file used for formatting",
+            allow_single_file = True,
+            default = Label("//tools/clang_format:clang_format_config"),
+        ),
+        "_extensions": attr.label(
+            doc = (
+                "A list of file extensions to formattable sources. This " +
+                "flag enables accommodations for other rules which consume " +
+                "C/C++ source files."
+            ),
+            default = Label("//tools/clang_format:clang_format_extensions"),
+        ),
+        "_process_wrapper": attr.label(
+            doc = "A process wrapper for running clang-format on all platforms",
+            cfg = "exec",
+            executable = True,
+            default = Label("//tools/clang_format/private:clang_format_process_wrapper"),
+        ),
+        "_source_attrs": attr.label(
+            doc = (
+                "A list of attributes on the target that contain " +
+                "formattable sources. These attributes must satisfy the " +
+                "`files` api (meaning `allow_files = True` is set). This " +
+                "flag enables accommodations for other rules which consume " +
+                "C/C++ source files."
+            ),
+            default = Label("//tools/clang_format:clang_format_source_attrs"),
+        ),
+    },
+    incompatible_use_toolchain_transition = True,
+    fragments = ["cpp"],
+    host_fragments = ["cpp"],
+    toolchains = [
+        str(Label("//tools/clang_format:toolchain_type")),
+    ],
+)
+
+def clang_format(
+        name,
+        config = Label("//tools/clang_format:clang_format_config"),
+        types = "^cc_",
+        **kwargs):
+    """A rule for running `clang-format` on all formattable sources being tracked by Bazel
+
+    Args:
+        name (str): The name of the generated target
+        config (Label, optional): The `.clang-format` file used for formatting.
+        types (str, optional): The condition value to pass to `bazel query 'kind({types}, //...:all)'`.
+        **kwargs (dict): Additional keyword arguments to pass to the underlying `cc_binary`.
+    """
+
+    current_toolchain = Label("//tools/clang_format:current_clang_format_toolchain")
+    extensions_manifest = Label("//tools/clang_format/private:clang_format_extensions_file")
+
+    args = [
+        "--clang_format",
+        "$(rootpath {})".format(current_toolchain),
+        "--config",
+        "$(rootpath {})".format(config),
+        "--extensions_manifest",
+        "$(rootpath {})".format(extensions_manifest),
+        "--types",
+        types,
+        "--",
+    ] + kwargs.pop("args", [])
+
+    cc_binary(
+        name = name,
+        srcs = [
+            Label("//tools/clang_format/private:clang_format_runner.cc"),
+        ],
+        args = args,
+        data = [
+            config,
+            current_toolchain,
+            extensions_manifest,
+        ],
+        deps = [
+            Label("@bazel_tools//tools/cpp/runfiles"),
+            Label("//tools/clang_format/private:clang_format_utils"),
+        ],
+        **kwargs
+    )

--- a/tools/clang_format/private/BUILD
+++ b/tools/clang_format/private/BUILD
@@ -1,0 +1,59 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load(":clang_format_utils.bzl", "bool_setting", "build_setting_file", "workspace_header")
+
+exports_files(
+    [
+        "clang_format_runner.cc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+workspace_header(
+    name = "clang_format_workspace.h",
+)
+
+cc_library(
+    name = "clang_format_utils",
+    srcs = ["clang_format_utils.cc"],
+    hdrs = [
+        "clang_format_utils.h",
+        "clang_format_workspace.h",
+    ],
+    defines = [
+        "WORKSPACE_HEADER=\\\"{}{}\\\"".format(
+            package_name() + "/" if package_name() else "",
+            "clang_format_workspace.h",
+        ),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "clang_format_process_wrapper",
+    srcs = ["clang_format_process_wrapper.cc"],
+    visibility = ["//visibility:public"],
+    deps = [":clang_format_utils"],
+)
+
+build_setting_file(
+    name = "clang_format_extensions_file",
+    setting = "//tools/clang_format:clang_format_extensions",
+    visibility = ["//visibility:public"],
+)
+
+bool_setting(
+    name = "is_windows",
+    value = select({
+        "@platforms//os:windows": True,
+        "//conditions:default": False,
+    }),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob([
+        "**/*.bzl",
+    ]),
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/clang_format/private/clang_format_process_wrapper.cc
+++ b/tools/clang_format/private/clang_format_process_wrapper.cc
@@ -1,0 +1,215 @@
+#include <stdio.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "clang_format_utils.h"
+
+#if defined(_WIN32) || defined(WIN32)
+#define FILE_SEP "\\"
+#else
+#define FILE_SEP "/"
+#endif
+
+using namespace clang_format_utils;
+
+/**
+ * @brief Run a command within a requested directory.
+ *
+ * @param exec_path
+ *  The binary to execute.
+ * @param arguments
+ *  Arugments for the binary at `exec_path`.
+ * @param cwd
+ *  The working directory for the new process.
+ * @return int
+ *  The exit code of the subprocess.
+ */
+int execute(const std::string &exec_path,
+            const std::vector<std::string> &arguments, const std::string &cwd) {
+  std::string pwd = get_working_path();
+  std::string command = exec_path;
+
+  for (const std::string &arg : arguments) {
+    command += " " + arg;
+  }
+
+  int chdir_exit_code = 0;
+
+  chdir_exit_code = set_current_dir(cwd);
+  if (chdir_exit_code) {
+    return chdir_exit_code;
+  }
+
+  int exit_code = system(command.c_str());
+
+  chdir_exit_code = set_current_dir(pwd);
+  if (chdir_exit_code) {
+    return chdir_exit_code;
+  }
+
+  return exit_code;
+}
+
+/**
+ * @brief Run clang-format on a list of source files
+ *
+ * @param clang_format_file
+ *  The path to a clang-format binary
+ * @param clang_format_arguments
+ *  Arguments for clang-format
+ * @param config_file
+ *  The clang-format config file (`.clang-format` file).
+ * @param sources
+ *  A list of source files to format.
+ * @param diff_tool_file
+ *  The path to a diff tool with which to inspect formatting changes
+ * @return int
+ *  The exit code of the clang-format process.
+ */
+int run_clang_format(const std::string &clang_format_file,
+                     const std::vector<std::string> &clang_format_arguments,
+                     const std::string &config_file,
+                     const std::vector<std::string> &sources,
+                     const std::string &diff_tool_file) {
+  std::string working_dir = "__clang_format__";
+
+  // Install the config file if one was provided
+  if (!config_file.empty()) {
+    std::string dest = working_dir + "/.clang-format";
+    int exit_code = copy_file(config_file, dest);
+    if (exit_code) {
+      return exit_code;
+    }
+  }
+
+  // If a diff tool was given, a series of additional commands
+  // will be run to ensure there are no differences while also
+  // allowing nicely formatted errors to propogate to users.
+  bool use_diff_tool = !diff_tool_file.empty();
+  std::vector<std::string> diff_commands = {};
+  if (use_diff_tool) {
+    diff_commands.reserve(sources.size());
+  }
+
+  // Create copies of of the source files to format
+  for (const std::string &src : sources) {
+    std::string dest = working_dir + "/" + src;
+    int exit_code = copy_file(src, dest);
+    if (exit_code) {
+      return exit_code;
+    }
+
+    if (use_diff_tool) {
+      diff_commands.push_back(diff_tool_file + " " + src + " " + dest);
+    }
+  }
+
+  std::string pwd = get_working_path();
+  std::string clang_format_path = pwd + FILE_SEP + clang_format_file;
+
+  // Run clang-format
+  int format_exit_code =
+      execute(clang_format_path, clang_format_arguments, working_dir);
+  if (format_exit_code || !use_diff_tool) {
+    return format_exit_code;
+  }
+
+  // Show diffs
+  int diff_exit_code = 0;
+  for (std::string &command : diff_commands) {
+    int exit_code = system(command.c_str());
+    diff_exit_code = diff_exit_code ? diff_exit_code : exit_code;
+  }
+  if (diff_exit_code) {
+    return diff_exit_code;
+  }
+
+  return 0;
+}
+
+/**
+ * @brief The main entry point for the clang-fromat rule's process wrapper.
+ *
+ * @param argc
+ *  The number of command line arguments.
+ * @param argv
+ *  A pointer to the list of command line arguments.
+ * @return int
+ *  The exit code for the program.
+ */
+int main(int argc, char **argv) {
+  std::string exec_path, diff_tool_file, config_file, touch_file = {};
+  std::vector<std::string> arguments, diff_commands, sources = {};
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (++i == argc) {
+      std::cerr << "process wrapper error: argument \"" << arg
+                << "\" missing parameter.\n";
+      return -1;
+    } else if (arg == "--touch-file") {
+      if (!touch_file.empty()) {
+        std::cerr << "process wrapper error: \"--touch-file\" can only "
+                     "appear "
+                     "once.\n";
+        return -1;
+      }
+      touch_file = argv[i];
+    } else if (arg == "--diff-tool-file") {
+      if (!diff_tool_file.empty()) {
+        std::cerr << "process wrapper error: \"--diff-tool-file\" can "
+                     "only appear "
+                     "once.\n";
+        return -1;
+      }
+      diff_tool_file = argv[i];
+    } else if (arg == "--config-file") {
+      if (!config_file.empty()) {
+        std::cerr << "process wrapper error: \"--config-file\" can "
+                     "only appear "
+                     "once.\n";
+        return -1;
+      }
+      config_file = argv[i];
+    } else if (arg == "--source-file") {
+      sources.push_back(argv[i]);
+    } else if (arg == "--") {
+      exec_path = argv[i];
+      for (++i; i < argc; ++i) {
+        arguments.push_back(argv[i]);
+      }
+      break;
+    } else {
+      std::cerr << "process wrapper error: unknown argument \"" << arg << "\"."
+                << '\n';
+      return -1;
+    }
+  }
+
+  arguments.reserve(sources.size());
+  for (const std::string &src : sources) {
+    arguments.push_back(src);
+  }
+
+  int exit_code = run_clang_format(exec_path, arguments, config_file, sources,
+                                   diff_tool_file);
+  if (exit_code) {
+    return exit_code;
+  }
+
+  if (!touch_file.empty()) {
+    std::ofstream file(touch_file);
+    if (file.fail()) {
+      std::cerr << "process wrapper error: failed to create touch file: \""
+                << touch_file << "\"\n";
+      return -1;
+    }
+    file.close();
+  }
+
+  return 0;
+}

--- a/tools/clang_format/private/clang_format_runner.cc
+++ b/tools/clang_format/private/clang_format_runner.cc
@@ -1,0 +1,396 @@
+#if defined(_WIN32) || defined(WIN32)
+#include <stdio.h>
+#endif
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "clang_format_utils.h"
+#include "tools/cpp/runfiles/runfiles.h"
+
+#if defined(_WIN32) || defined(WIN32)
+#define FILE_SEP "\\"
+#define popen _popen
+#define pclose _pclose
+#else
+#define FILE_SEP "/"
+#endif
+
+using bazel::tools::cpp::runfiles::Runfiles;
+using namespace clang_format_utils;
+
+/**
+ * @brief Parsable arguments for the clang-format runner program.
+ *
+ */
+struct Args {
+  // --config
+  std::string config_path;
+
+  // --clang_format
+  std::string clang_format_path;
+
+  // --types
+  std::string types;
+
+  // --extensions_manifest
+  std::string extensions_manifest_path;
+
+  // Trailing args after `--`. Defaults to `//...:all`
+  std::string scope;
+
+  // Environment variable BAZEL_REAL. Defaults to `bazel`.
+  std::string bazel_path;
+
+  // Environment variable BUILD_WORKSPACE_DIRECTORY.
+  std::string build_workspace_directory;
+};
+
+/**
+ * @brief Parse command line arguments.
+ *
+ * @param argc
+ *  The number of command line arguments
+ * @param argv
+ *  A pointer to the list of command line arguments
+ * @param out_args
+ *  A reference variable in which to parse arguments into.
+ * @return int
+ *  The exit code for parsing command line arguments.
+ */
+int parse_args(int argc, char **argv, Args &out_args) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (++i == argc) {
+      if (arg == "--") {
+        out_args.scope = "//...:all";
+        break;
+      }
+
+      std::cerr << "argument parser error: argument \"" << arg
+                << "\" missing parameter.\n";
+      return -1;
+    } else if (arg == "--clang_format") {
+      out_args.clang_format_path = argv[i];
+    } else if (arg == "--config") {
+      out_args.config_path = argv[i];
+    } else if (arg == "--extensions_manifest") {
+      out_args.extensions_manifest_path = argv[i];
+    } else if (arg == "--types") {
+      out_args.types = argv[i];
+    } else if (arg == "--") {
+      out_args.scope = argv[i];
+      for (++i; i < argc; ++i) {
+        out_args.scope = out_args.scope + " " + argv[i];
+      }
+      break;
+    } else {
+      std::cerr << "argument parser error: unknow argument \"" << arg << "\"."
+                << '\n';
+      return -1;
+    }
+  }
+
+  if (out_args.config_path.empty()) {
+    std::cerr
+        << "argument parser error: missing required argument `--config`\n";
+    return -1;
+  }
+
+  if (out_args.scope.empty()) {
+    std::cerr << "argument parser error: missing required argument `--scope`\n";
+    return -1;
+  }
+
+  const char *bazel_real_var = std::getenv("BAZEL_REAL");
+  std::string bazel_real(bazel_real_var ? bazel_real_var : "");
+  if (!bazel_real.empty()) {
+    out_args.bazel_path = bazel_real;
+  } else {
+    out_args.bazel_path = "bazel";
+  }
+
+  // Query the environment for the path on the filesystem to the Bazel
+  // workspace directory.
+  const char *build_workspace_directory_var =
+      std::getenv("BUILD_WORKSPACE_DIRECTORY");
+  std::string build_workspace_directory(
+      build_workspace_directory_var ? build_workspace_directory_var : "");
+  if (build_workspace_directory.empty()) {
+    std::cerr << "argument parser error: BUILD_WORKSPACE_DIRECTORY is not set. "
+                 "Is the process running under Bazel? \"\n";
+    return -1;
+  }
+  out_args.build_workspace_directory = build_workspace_directory;
+
+  // Load the Runfiles library
+  std::string error = {};
+  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], &error));
+  if (runfiles == nullptr) {
+    std::cerr << "argument parser error: \"" << error << "\n";
+    return -1;
+  }
+
+  std::string workspace_name = WORKSPACE_NAME;
+
+  // Generate absolute paths to all important runfiles.
+  out_args.extensions_manifest_path = runfiles->Rlocation(
+      workspace_name + "/" + out_args.extensions_manifest_path);
+  out_args.config_path =
+      runfiles->Rlocation(workspace_name + "/" + out_args.config_path);
+  out_args.clang_format_path =
+      runfiles->Rlocation(workspace_name + "/" + out_args.clang_format_path);
+
+  return 0;
+}
+
+/**
+ * @brief Spawn a process while waiting for it's completion and capturing
+ * stdout.
+ *
+ * @param cmd
+ *  The command to run.
+ * @param out_stream
+ *  A reference variable in which to write the stdout stream.
+ * @return int
+ *  The processes exit code.
+ */
+int exec(const char *cmd, std::string &out_stream) {
+  char buffer[1024];
+  FILE *pipe = popen(cmd, "r");
+  if (!pipe) throw std::runtime_error("popen() failed!");
+  try {
+    while (fgets(buffer, sizeof buffer, pipe) != NULL) {
+      out_stream += buffer;
+    }
+  } catch (...) {
+    pclose(pipe);
+    throw;
+  }
+  return pclose(pipe);
+}
+
+/**
+ * @brief Run a command within a requested directory while capturing stdout.
+ *
+ * @param exec_path
+ *  The binary to execute.
+ * @param arguments
+ *  Arugments for the binary at `exec_path`.
+ * @param cwd
+ *  The working directory for the new process.
+ * @param out_stream
+ *  A reference variable in which to write the stdout stream.
+ * @return int
+ *  The exit code of the subprocess.
+ */
+int execute(const std::string &exec_path,
+            const std::vector<std::string> &arguments, const std::string &cwd,
+            std::string &out_stream) {
+  std::string pwd = get_working_path();
+  std::string command = exec_path;
+
+  for (const std::string &arg : arguments) {
+    command += " " + arg;
+  }
+
+  int chdir_exit_code = 0;
+
+  chdir_exit_code = set_current_dir(cwd);
+  if (chdir_exit_code) {
+    return chdir_exit_code;
+  }
+
+  int exit_code = exec(command.c_str(), out_stream);
+
+  chdir_exit_code = set_current_dir(pwd);
+  if (chdir_exit_code) {
+    return chdir_exit_code;
+  }
+
+  return exit_code;
+}
+
+/**
+ * @brief Replace text within a string.
+ *
+ * @param out_str
+ *  The string to replace text in.
+ * @param from
+ *  The substring to remove.
+ * @param to
+ *  The string to put in place of `from`.
+ */
+void str_replace(std::string &out_str, const std::string &from,
+                 const std::string &to) {
+  for (size_t pos = 0;; pos += to.length()) {
+    // Locate the substring to replace
+    pos = out_str.find(from, pos);
+    if (pos == std::string::npos) break;
+    // Replace by erasing and inserting
+    out_str.erase(pos, from.length());
+    out_str.insert(pos, to);
+  }
+}
+
+/**
+ * @brief Split a string into an array, separated by a give delimiter.
+ *
+ * @param s
+ *  The string to split.
+ * @param delimiter
+ *  The text to split the string by.
+ * @return std::vector<std::string>
+ *  The list of all substrings separated by the delimiter.
+ */
+std::vector<std::string> str_split(const std::string &s,
+                                   const std::string delimiter) {
+  size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+  std::string token;
+  std::vector<std::string> res;
+
+  while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
+    token = s.substr(pos_start, pos_end - pos_start);
+    pos_start = pos_end + delim_len;
+    res.push_back(token);
+  }
+
+  return res;
+}
+
+/**
+ * @brief Query for all formattable source targets within the current Bazel
+ * workspace.
+ *
+ * @param bazel_path
+ *  The path to a Bazel executable.
+ * @param extensions_manifest_path
+ *  The path to a `build_setting_file` target containing formattable extensions.
+ * @param scope
+ *  Package or target labels filtering what should be formatted.
+ * @param types
+ *  A regex pattern of what rules to gather source dependencies from for
+ * formatting.
+ * @param workspace_dir
+ *  The directory of the workspace in which to run the query.
+ * @param out_sources
+ *  A reference variable where source files will be collected.
+ * @return int
+ *  The exit code of the query
+ */
+int query_sources(const std::string &bazel_path,
+                  const std::string &extensions_manifest_path,
+                  const std::string &scope, const std::string &types,
+                  const std::string &workspace_dir,
+                  std::vector<std::string> &out_sources) {
+  std::string query_template =
+      "\"filter('^//.*\\.({extensions})$', kind('source file', "
+      "deps(kind('{types}', set({scope}) except attr(tags, '(^\\[|, "
+      ")(noformat|no-format|no-clang-format)(, |\\]$)', set({scope}))), 1)))\"";
+
+  // Read in the list of formattable extensions and covert it to a regex string
+  std::ifstream ifs(extensions_manifest_path);
+  std::string extensions((std::istreambuf_iterator<char>(ifs)),
+                         (std::istreambuf_iterator<char>()));
+  str_replace(extensions, "\n", "|");
+  str_replace(extensions, "+", "\\+");
+
+  // Resolve all the template arguments in the query string
+  std::string query_arg = query_template;
+  str_replace(query_arg, "{extensions}", extensions);
+  str_replace(query_arg, "{scope}", scope);
+  str_replace(query_arg, "{types}", types);
+
+  std::string stream;
+  std::vector<std::string> query_args = {
+      "query",
+      query_arg,
+      "--keep_going",
+      "--noimplicit_deps",
+  };
+  int exit_code = execute(bazel_path, query_args, workspace_dir, stream);
+
+  if (exit_code) {
+    return exit_code;
+  }
+
+  out_sources = str_split(stream, "\n");
+
+  return 0;
+}
+
+/**
+ * @brief The main entry point for the clang-fromat runner tool.
+ *
+ * @param argc
+ *  The number of command line arguments.
+ * @param argv
+ *  A pointer to the list of command line arguments.
+ * @return int
+ *  The exit code for the program.
+ */
+int main(int argc, char **argv) {
+  // Parse command line arguments
+  Args args = {};
+  int arg_parse_exit_code = parse_args(argc, argv, args);
+  if (arg_parse_exit_code) {
+    return arg_parse_exit_code;
+  }
+
+  // Gather formattable sources from targets
+  std::vector<std::string> targets{};
+  int query_exit_code =
+      query_sources(args.bazel_path, args.extensions_manifest_path, args.scope,
+                    args.types, args.build_workspace_directory, targets);
+  if (query_exit_code) {
+    return query_exit_code;
+  }
+
+  // Create a directory with a config file in which to run clang-format
+  std::string format_dir =
+      get_working_path() + FILE_SEP + ".clang_format_workdir";
+  int config_copy_exit_code =
+      copy_file(args.config_path, format_dir + FILE_SEP + ".clang-format");
+  if (config_copy_exit_code) {
+    return config_copy_exit_code;
+  }
+
+  // Recreate the directory tree in a new directory to ensure no onther
+  // clang-format configs are used when formatting
+  for (const std::string &target : targets) {
+    std::string src = target;
+    str_replace(src, "//", "");
+    str_replace(src, ":", "/");
+
+    std::string real_src = args.build_workspace_directory + FILE_SEP + src;
+    std::string dest_src = format_dir + FILE_SEP + src;
+
+    int src_copy_exit_code = copy_file(real_src, dest_src);
+    if (src_copy_exit_code) {
+      return src_copy_exit_code;
+    }
+
+    // Format all available sources
+    std::string stream;
+    std::vector<std::string> clang_format_args = {
+        "-style=file",
+        "-i",
+        dest_src,
+    };
+    int exit_code =
+        execute(args.clang_format_path, clang_format_args, format_dir, stream);
+    if (exit_code) {
+      return exit_code;
+    }
+
+    // Copy all sources back to the repo
+    src_copy_exit_code = copy_file(dest_src, real_src);
+    if (src_copy_exit_code) {
+      return src_copy_exit_code;
+    }
+  }
+
+  return 0;
+}

--- a/tools/clang_format/private/clang_format_utils.bzl
+++ b/tools/clang_format/private/clang_format_utils.bzl
@@ -1,0 +1,99 @@
+"""Helpers for the `clang-format` rules"""
+
+BuildSettingInfo = provider(
+    doc = "A singleton provider that contains the raw value of a build setting",
+    fields = {
+        "value": "The value of the build setting in the current configuration. " +
+                 "This value may come from the command line or an upstream transition, " +
+                 "or else it will be the build setting's default.",
+    },
+)
+
+def _impl(ctx):
+    if hasattr(ctx.attr, "value"):
+        value = ctx.attr.value
+    else:
+        value = ctx.build_setting_value
+    return BuildSettingInfo(value = value)
+
+bool_setting = rule(
+    implementation = _impl,
+    attrs = {
+        "value": attr.bool(
+            doc = "The setting's value",
+            default = False,
+        ),
+    },
+    doc = "A bool-typed build setting that cannot be set on the command line",
+)
+
+string_list_flag = rule(
+    implementation = _impl,
+    build_setting = config.string_list(flag = True),
+    doc = "A string list-typed build setting that can be set on the command line",
+)
+
+def _build_setting_file_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name)
+
+    value = ctx.attr.setting[BuildSettingInfo].value
+    content = None
+    if type(value) == "str":
+        content = value
+    elif type(value) == "list":
+        content = "\n".join(value)
+    else:
+        fail("Unexpected type: {} for {}".format(
+            type(value),
+            ctx.attr.setting.label,
+        ))
+
+    ctx.actions.write(
+        output = output,
+        content = content,
+    )
+
+    return DefaultInfo(
+        files = depset([output]),
+        runfiles = ctx.runfiles(files = [output]),
+    )
+
+build_setting_file = rule(
+    implementation = _build_setting_file_impl,
+    doc = "A rule for writing the values of build settings to file",
+    attrs = {
+        "setting": attr.label(
+            doc = "A build setting target to write to disk",
+            providers = [BuildSettingInfo],
+            mandatory = True,
+        ),
+    },
+)
+
+_HEADER_TEMPLATE = """\
+#ifndef _CLANG_FORMAT_WORKSPACE_H_INCLUDE_
+#define _CLANG_FORMAT_WORKSPACE_H_INCLUDE_
+namespace clang_format_utils {{
+    static const char* WORKSPACE_NAME = "{}";
+}}
+#endif  // _CLANG_FORMAT_WORKSPACE_H_INCLUDE_
+"""
+
+def _workspace_header_impl(ctx):
+    output = ctx.actions.declare_file(ctx.label.name)
+
+    ctx.actions.write(
+        output = output,
+        content = _HEADER_TEMPLATE.format(
+            ctx.workspace_name,
+        ),
+    )
+
+    return DefaultInfo(
+        files = depset([output]),
+    )
+
+workspace_header = rule(
+    implementation = _workspace_header_impl,
+    doc = "A rule for generating a header file with the workspace name embedded in it",
+)

--- a/tools/clang_format/private/clang_format_utils.cc
+++ b/tools/clang_format/private/clang_format_utils.cc
@@ -1,0 +1,78 @@
+#include "clang_format_utils.h"
+
+#include <stdio.h>
+#if defined(_WIN32) || defined(WIN32)
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+#if defined(_WIN32) || defined(WIN32)
+#define IS_WINDOWS true
+#define getcwd _getcwd
+#define chdir _chdir
+#else
+#define IS_WINDOWS false
+#endif
+
+namespace clang_format_utils {
+
+std::string get_working_path() {
+  char temp[1024];
+  return (getcwd(temp, sizeof(temp)) ? std::string(temp) : std::string(""));
+}
+
+int set_current_dir(const std::string& path) { return chdir(path.c_str()); }
+
+int copy_file(const std::string& src, const std::string& dest) {
+  if (IS_WINDOWS) {
+    // Normalize paths on windows
+    std::string win_src = src;
+    size_t src_pos;
+    while ((src_pos = win_src.find('/')) != std::string::npos) {
+      win_src.replace(src_pos, 1, "\\");
+    }
+    std::string win_dest = dest;
+    size_t dest_pos;
+    while ((dest_pos = win_dest.find('/')) != std::string::npos) {
+      win_dest.replace(dest_pos, 1, "\\");
+    }
+
+    // Create parent directory
+    size_t sep_pos = win_dest.rfind("\\");
+    if (sep_pos != std::string::npos) {
+      std::string parent_dir = win_dest.substr(0, sep_pos);
+
+      std::string mkdir_command = std::string("mkdir " + parent_dir);
+      int exit_code = system(mkdir_command.c_str());
+      if (exit_code) {
+        return exit_code;
+      }
+    }
+  } else {
+    // Create parent directory
+    size_t sep_pos = dest.rfind("/");
+    if (sep_pos != std::string::npos) {
+      std::string parent_dir = dest.substr(0, sep_pos);
+
+      std::string mkdir_command = std::string("mkdir -p " + parent_dir);
+      int exit_code = system(mkdir_command.c_str());
+      if (exit_code) {
+        return exit_code;
+      }
+    }
+  }
+
+  // Write the bytes of the source file to the dest file.
+  std::ifstream src_stream(src, std::ios::binary);
+  std::ofstream dst_stream(dest, std::ios::binary);
+  dst_stream << src_stream.rdbuf();
+
+  return 0;
+}
+
+}  // namespace clang_format_utils

--- a/tools/clang_format/private/clang_format_utils.h
+++ b/tools/clang_format/private/clang_format_utils.h
@@ -1,0 +1,45 @@
+#ifndef _CLANG_FORMAT_UTILS_H_INCLUDE_
+#define _CLANG_FORMAT_UTILS_H_INCLUDE_
+
+#include <string>
+#include <vector>
+
+#include WORKSPACE_HEADER
+
+namespace clang_format_utils {
+
+/**
+ * @brief Get the working path object
+ *
+ * @return std::string
+ *  The current working directory.
+ */
+std::string get_working_path();
+
+/**
+ * @brief Changes the current working directory to the specified path.
+ *
+ * @param path
+ *  The path to change the workign directory to.
+ * @return int
+ *  The exit code of the command.
+ */
+int set_current_dir(const std::string& path);
+
+/**
+ * @brief Copy a file to a new destination.
+ *
+ * If the parent directory of `dest` does not exist, it will be made.
+ *
+ * @param src
+ *  The file to copy.
+ * @param dest
+ *  The location where to copy the file to.
+ * @return int
+ *  The exit code of the copy command.
+ */
+int copy_file(const std::string& src, const std::string& dest);
+
+}  // namespace clang_format_utils
+
+#endif


### PR DESCRIPTION
I get the feeling these changes may not be desirable for `rules_cc` but thought I'd share them none the less.

This PR introduces rules for running [clang-format](https://clang.llvm.org/docs/ClangFormat.html).