### PR TITLE
Move examples from deprecated @rules_cc//cc:find_cpp_toolchain -> @bazel_tools//tools/cpp:toolchain_utils.bzl

### DIFF
--- a/cc/private/rules_impl/cc_flags_supplier.bzl
+++ b/cc/private/rules_impl/cc_flags_supplier.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Rule that provides the CC_FLAGS Make variable."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//cc:action_names.bzl", "CC_FLAGS_MAKE_VARIABLE_ACTION_NAME")
-load("//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//cc/private/rules_impl:cc_flags_supplier_lib.bzl", "build_cc_flags")
 
 def _cc_flags_supplier_impl(ctx):
-    cc_toolchain = find_cc_toolchain(ctx)
+    cc_toolchain = find_cpp_toolchain(ctx)
     cc_flags = build_cc_flags(ctx, cc_toolchain, CC_FLAGS_MAKE_VARIABLE_ACTION_NAME)
     variables = platform_common.TemplateVariableInfo({
         "CC_FLAGS": cc_flags,

--- a/cc/private/rules_impl/compiler_flag.bzl
+++ b/cc/private/rules_impl/compiler_flag.bzl
@@ -14,16 +14,16 @@
 
 """Rule that allows select() to differentiate between compilers."""
 
-load("//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _compiler_flag_impl(ctx):
-    toolchain = find_cc_toolchain(ctx)
+    toolchain = find_cpp_toolchain(ctx)
     return [config_common.FeatureFlagInfo(value = toolchain.compiler)]
 
 compiler_flag = rule(
     implementation = _compiler_flag_impl,
     attrs = {
-        "_cc_toolchain": attr.label(default = Label("//cc:current_cc_toolchain")),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = [
         "@bazel_tools//tools/cpp:toolchain_type",  # copybara-use-repo-external-label

--- a/examples/my_c_archive/my_c_archive.bzl
+++ b/examples/my_c_archive/my_c_archive.bzl
@@ -15,11 +15,11 @@
 """Example showing how to create a rule that rules_cc can depend on."""
 
 load("@rules_cc//cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME")
-load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//examples/my_c_compile:my_c_compile.bzl", "MyCCompileInfo")
 
 def _my_c_archive_impl(ctx):
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     object_file = ctx.attr.object[MyCCompileInfo].object
     output_file = ctx.actions.declare_file(ctx.label.name + ".a")
 

--- a/examples/my_c_archive/my_c_archive.bzl
+++ b/examples/my_c_archive/my_c_archive.bzl
@@ -14,12 +14,12 @@
 
 """Example showing how to create a rule that rules_cc can depend on."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME")
-load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//examples/my_c_compile:my_c_compile.bzl", "MyCCompileInfo")
 
 def _my_c_archive_impl(ctx):
-    cc_toolchain = find_cc_toolchain(ctx)
+    cc_toolchain = find_cpp_toolchain(ctx)
     object_file = ctx.attr.object[MyCCompileInfo].object
     output_file = ctx.actions.declare_file(ctx.label.name + ".a")
 

--- a/examples/my_c_compile/my_c_compile.bzl
+++ b/examples/my_c_compile/my_c_compile.bzl
@@ -14,8 +14,8 @@
 
 """Example showing how to create a rule that just compiles C sources."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
-load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 
 MyCCompileInfo = provider(doc = "", fields = ["object"])
 
@@ -24,7 +24,7 @@ DISABLED_FEATURES = [
 ]
 
 def _my_c_compile_impl(ctx):
-    cc_toolchain = find_cc_toolchain(ctx)
+    cc_toolchain = find_cpp_toolchain(ctx)
     source_file = ctx.file.src
     output_file = ctx.actions.declare_file(ctx.label.name + ".o")
     feature_configuration = cc_common.configure_features(

--- a/examples/my_c_compile/my_c_compile.bzl
+++ b/examples/my_c_compile/my_c_compile.bzl
@@ -15,7 +15,7 @@
 """Example showing how to create a rule that just compiles C sources."""
 
 load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
-load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 
 MyCCompileInfo = provider(doc = "", fields = ["object"])
 
@@ -24,7 +24,7 @@ DISABLED_FEATURES = [
 ]
 
 def _my_c_compile_impl(ctx):
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     source_file = ctx.file.src
     output_file = ctx.actions.declare_file(ctx.label.name + ".o")
     feature_configuration = cc_common.configure_features(

--- a/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
+++ b/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
@@ -14,10 +14,10 @@
 
 """Example showing how to get CcToolchainInfo in a custom rule."""
 
-load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _write_cc_toolchain_cpu_impl(ctx):
-    cc_toolchain = find_cc_toolchain(ctx)
+    cc_toolchain = find_cpp_toolchain(ctx)
     output = ctx.actions.declare_file(ctx.label.name + "_cpu")
     ctx.actions.write(output, cc_toolchain.cpu)
     return [DefaultInfo(files = depset([output]))]

--- a/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
+++ b/examples/write_cc_toolchain_cpu/write_cc_toolchain_cpu.bzl
@@ -14,10 +14,10 @@
 
 """Example showing how to get CcToolchainInfo in a custom rule."""
 
-load("@rules_cc//cc:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 
 def _write_cc_toolchain_cpu_impl(ctx):
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     output = ctx.actions.declare_file(ctx.label.name + "_cpu")
     ctx.actions.write(output, cc_toolchain.cpu)
     return [DefaultInfo(files = depset([output]))]


### PR DESCRIPTION
Hey wonderful Bazel folks,

I'd been following this example (linked from https://docs.bazel.build/versions/main/integrating-with-rules-cc.html). While doing, I happened to notice that the code was still calling the deprecated find_cpp_toolchain. This threw me for a quick loop on Bazel rolling, so I figured I'd toss up a quick PR to fix it. See discussion below about \@bazel_tools.

Deprecation comment here: https://github.com/bazelbuild/rules_cc/blob/main/cc/toolchain_utils.bzl

Thanks for all you do!
Chris
(ex-Googler)