### PR TITLE
Find `libtool` when using `BAZEL_USE_CPP_ONLY_TOOLCHAIN`.

### DIFF
--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -166,6 +166,7 @@ cc_autoconf = repository_rule(
         "CC_TOOLCHAIN_NAME",
         "CPLUS_INCLUDE_PATH",
         "GCOV",
+        "LIBTOOL",
         "HOMEBREW_RUBY_PATH",
         "SYSTEMROOT",
     ] + MSVC_ENVVARS,

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -353,7 +353,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overriden_tools):
     )
     if darwin:
         overriden_tools["gcc"] = "cc_wrapper.sh"
-        overriden_tools["ar"] = "/usr/bin/libtool"
+        overriden_tools["ar"] = _find_generic(repository_ctx, "libtool", "LIBTOOL", overriden_tools)
     auto_configure_warning_maybe(repository_ctx, "CC used: " + str(cc))
     tool_paths = _get_tool_paths(repository_ctx, overriden_tools)
     cc_toolchain_identifier = escape_string(get_env_var(


### PR DESCRIPTION
Instead of hardcoding `/usr/bin/libtool` which requires Xcode / Xcode CLT installed, which `BAZEL_USE_CPP_ONLY_TOOLCHAIN` is meant to avoid.

Related to https://github.com/bazelbuild/rules_cc/issues/134.