### PR TITLE
Update WORKSPACE to account for bazel_tool//platforms going away.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,40 @@ workspace(name = "rules_cc")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+    ],
+    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "16e9fca53ed6bd4ff4ad76facc9b7b651a89db1689a2877d6fd7b82aa824e366",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.18.4")
+
+print(1)
+
+http_archive(
     name = "bazel_federation",
     sha256 = "0d6893f0d18f417a3324ce7f0ed2e6e5b825d6d5ab42f0f3d7877cb313f36453",
     strip_prefix = "bazel-federation-6ad33bc586701e9836a2bf4432c7aff1235b04d2",
     type = "zip",
     url = "https://github.com/bazelbuild/bazel-federation/archive/6ad33bc586701e9836a2bf4432c7aff1235b04d2.zip",  # 2019-09-30
 )
+
+print(2)
 
 load("@bazel_federation//:repositories.bzl", "rules_cc_deps")
 
@@ -18,12 +46,17 @@ load("@bazel_federation//setup:rules_cc.bzl", "rules_cc_setup")
 
 rules_cc_setup()
 
+print(10)
+
 #
 # Dependencies for development of rules_cc itself.
 #
 load("//:internal_deps.bzl", "rules_cc_internal_deps")
 
 rules_cc_internal_deps()
+
+print(20)
+
 
 load("//:internal_setup.bzl", "rules_cc_internal_setup")
 
@@ -63,3 +96,4 @@ local_repository(
     name = "test_repo",
     path = "examples/test_cc_shared_library2",
 )
+print(99)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,8 +26,6 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.18.4")
 
-print(1)
-
 http_archive(
     name = "bazel_federation",
     sha256 = "0d6893f0d18f417a3324ce7f0ed2e6e5b825d6d5ab42f0f3d7877cb313f36453",
@@ -35,8 +33,6 @@ http_archive(
     type = "zip",
     url = "https://github.com/bazelbuild/bazel-federation/archive/6ad33bc586701e9836a2bf4432c7aff1235b04d2.zip",  # 2019-09-30
 )
-
-print(2)
 
 load("@bazel_federation//:repositories.bzl", "rules_cc_deps")
 
@@ -46,17 +42,12 @@ load("@bazel_federation//setup:rules_cc.bzl", "rules_cc_setup")
 
 rules_cc_setup()
 
-print(10)
-
 #
 # Dependencies for development of rules_cc itself.
 #
 load("//:internal_deps.bzl", "rules_cc_internal_deps")
 
 rules_cc_internal_deps()
-
-print(20)
-
 
 load("//:internal_setup.bzl", "rules_cc_internal_setup")
 
@@ -96,4 +87,3 @@ local_repository(
     name = "test_repo",
     path = "examples/test_cc_shared_library2",
 )
-print(99)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "platforms",
+    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
         "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
     ],
-    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
 )
 
 http_archive(

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -27,6 +27,7 @@ filegroup(
 exports_files([
     "defs.bzl",
     "action_names.bzl",
+    "system_library.bzl",
 ])
 
 # The toolchain type used to distinguish cc toolchains.


### PR DESCRIPTION
- point to bazelbuild/platforms for @platforms
- Use a newer version of rules_go for our internal rules.
- Make a bzl file used in a test visible to the tests.

I believe this fixes a build breakage in bazel at head and 5.3.0  #140 

cc: @aranguyen