### PR TITLE
Fix MODULE.bazel formatting

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,4 +11,4 @@ use_repo(cc_configure, "local_config_cc_toolchains")
 
 register_toolchains("@local_config_cc_toolchains//:all")
 
-bazel_dep(name = "bazel_skylib", dev_dependency = True, version = "1.3.0")
+bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)


### PR DESCRIPTION
Required due to a new buildifier release.