### PR TITLE
Add well-known compiler `config_setting`s

### DIFF
--- a/cc/compiler/BUILD
+++ b/cc/compiler/BUILD
@@ -1,0 +1,71 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config settings for compilers identified by Bazel.
+
+Targets that require compiler-specific flags can use the config_settings defined
+in this package in their select() statements.
+
+*Note*: Before Bazel 6, gcc on Linux and clang on macOS would not match their
+specific config_setting, but only the fallback case of a select expression.
+
+Toolchains not shipped with Bazel are encouraged to use the same names to
+identify compilers as used below, but this is not enforced.
+
+Example:
+
+  cc_binary(
+    name = "foo",
+    srcs = ["foo.cc"],
+    copts = select({
+        "@rules_cc//cc/compiler:gcc": [...],
+        "@rules_cc//cc/compiler:clang": [...],
+        "@rules_cc//cc/compiler:msvc-cl": [...],
+        # Fallback case for an undetected compiler.
+        "//conditions:default": [...],
+    }),
+  )
+
+If multiple targets use the same set of conditionally enabled flags, this can be
+simplified by extracting the select expression into a Starlark constant.
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+config_setting(
+    name = "clang",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+)
+
+config_setting(
+    name = "clang-cl",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
+)
+
+config_setting(
+    name = "gcc",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "gcc"},
+)
+
+config_setting(
+    name = "mingw-gcc",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "mingw-gcc"},
+)
+
+config_setting(
+    name = "msvc-cl",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
+)

--- a/tests/compiler_settings/BUILD
+++ b/tests/compiler_settings/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//cc:defs.bzl", "cc_binary")
+
+licenses(["notice"])
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+    local_defines = select(
+        {
+            "//cc/compiler:clang": ["COMPILER=clang"],
+            "//cc/compiler:clang-cl": ["COMPILER=clang-cl"],
+            "//cc/compiler:gcc": ["COMPILER=gcc"],
+            "//cc/compiler:mingw-gcc": ["COMPILER=mingw-gcc"],
+            "//cc/compiler:msvc-cl": ["COMPILER=msvc-cl"],
+        },
+        no_match_error = "Compiler not detected by Bazel",
+    ),
+)

--- a/tests/compiler_settings/main.cc
+++ b/tests/compiler_settings/main.cc
@@ -1,0 +1,22 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#define STRINGIFY(x) #x
+#define TO_STRING(x) STRINGIFY(x)
+
+int main() {
+  std::cout << "Hello, " << TO_STRING(COMPILER) << "!" << std::endl;
+}


### PR DESCRIPTION
As of Bazel 6.0.0, all Bazel-provided toolchains report consistent compiler names that can be matched on with `select`. Having a central place for `config_setting`s that can be used for this purpose makes it so that rulesets don't have to define them themselves and moving the compiler flag out of `@bazel_tools` becomes easier as it is no longer referenced directly.

Fixes https://github.com/bazelbuild/bazel/issues/14914