### PR TITLE
Fix invalid license.bzl load

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("//tools/build_defs/license:license.bzl", "license")
+load("@rules_license//rules:license.bzl", "license")
 
 package(
     default_applicable_licenses = ["//third_party/bazel_rules/rules_cc:license"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.6")
+bazel_dep(name = "rules_license", version = "0.0.4")
 
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure")
 use_repo(cc_configure, "local_config_cc_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,15 @@ http_archive(
 )
 
 http_archive(
+    name = "rules_license",
+    sha256 = "6157e1e68378532d0241ecd15d3c45f6e5cfd98fc10846045509fb2a7cc9e381",
+    urls = [
+        "https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_googletest",
     sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
     strip_prefix = "googletest-release-1.12.1",


### PR DESCRIPTION
Looks like an internal google automation exported a bad path, but really to fix this we need this new dep on rules_license

https://github.com/bazelbuild/rules_cc/commit/0d68932a68bcd6f332b14ccc561990586de2318d