### PR TITLE
Revert "Automatic code cleanup."

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,14 +1,4 @@
-load("//tools/build_defs/license:license.bzl", "license")
-
-package(
-    default_applicable_licenses = ["//third_party/bazel_rules/rules_cc:license"],
-    default_visibility = ["//visibility:public"],
-)
-
-license(
-    name = "license",
-    package_name = "rules_cc",
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 


### PR DESCRIPTION
Looks like an internal google automation exported a bad path and it references a google internal license

This reverts commit 0d68932a68bcd6f332b14ccc561990586de2318d.