### PR TITLE
add emscripten compiler config_setting

### DIFF
--- a/cc/compiler/BUILD
+++ b/cc/compiler/BUILD
@@ -69,3 +69,8 @@ config_setting(
     name = "msvc-cl",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "msvc-cl"},
 )
+
+config_setting(
+    name = "emscripten",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "emscripten"},
+)


### PR DESCRIPTION
I'm using emscripten for compiling some wasm and they use a different compiler identifier for their bazel toolchain. I think emscripten is different enough that it warrants it's own compiler setting dispite the recommendation that other toolchains use the already established identifiers.

Here's where it's being set in their toolchain: https://github.com/emscripten-core/emsdk/blob/93360d3670018769b424e4e8f1d3d9b26d32c977/bazel/emscripten_toolchain/toolchain.bzl#L68

