### PR TITLE
Remove cc toolchain registration from rules_cc in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,9 +6,4 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.7")
 
-cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")
-use_repo(cc_configure, "local_config_cc_toolchains")
-
-register_toolchains("@local_config_cc_toolchains//:all")
-
 bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)


### PR DESCRIPTION
The same toolchain is registered by `@bazel_tools` already, we should not register it again to prevent competing with the apple cc toolchain from `apple_support`.

Context: https://github.com/bazelbuild/rules_swift/issues/1115#issuecomment-1728219962