### PR TITLE
Make sysroot macro work when depending on these rules as a git repository

### DIFF
--- a/cc/toolchains/args/sysroot.bzl
+++ b/cc/toolchains/args/sysroot.bzl
@@ -29,9 +29,9 @@ def cc_sysroot(name, sysroot, **kwargs):
     cc_args(
         name = name,
         actions = [
-            "//cc/toolchains/actions:cpp_compile_actions",
-            "//cc/toolchains/actions:c_compile",
-            "//cc/toolchains/actions:link_actions",
+            "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+            "@rules_cc//cc/toolchains/actions:c_compile",
+            "@rules_cc//cc/toolchains/actions:link_actions",
         ],
         args = ["--sysroot={sysroot}"],
         format = {"sysroot": sysroot},


### PR DESCRIPTION
I don't understand why, but if those targets are not fully qualified, you get: 
> no such package 'cc/toolchains/actions': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
when using this macro.