### PR TITLE
Allow extra args to cc_sysroot

### DIFF
--- a/cc/toolchains/args/sysroot.bzl
+++ b/cc/toolchains/args/sysroot.bzl
@@ -17,13 +17,14 @@ load("//cc/toolchains:args.bzl", "cc_args")
 
 visibility("public")
 
-def cc_sysroot(name, sysroot, **kwargs):
+def cc_sysroot(name, sysroot, args = [], **kwargs):
     """Creates args for a sysroot.
 
     Args:
       name: (str) The name of the target
       sysroot: (bazel_skylib's directory rule) The directory that should be the
         sysroot.
+      args: (List[str]) Extra command-line args to add.
       **kwargs: kwargs to pass to cc_args.
     """
     cc_args(
@@ -33,7 +34,7 @@ def cc_sysroot(name, sysroot, **kwargs):
             Label("//cc/toolchains/actions:c_compile"),
             Label("//cc/toolchains/actions:link_actions"),
         ],
-        args = ["--sysroot={sysroot}"],
+        args = ["--sysroot={sysroot}"] + args,
         format = {"sysroot": sysroot},
         **kwargs
     )


### PR DESCRIPTION
It's possible for there to be some arguments that are naturally associated with the sysroot flag, for example on macOS there are associated framework search paths that should be added with `-F{sysroot}/Library/Frameworks`. There are also warnings flags you might want to add such as `-Werror=missing-sysroot`. In this case I think it's nicer to provide them alongside the sysroot definition, instead of having to create a custom cc_args for them.