### PR TITLE
Fix empty glob in cc/private/BUILD

### DIFF
--- a/cc/private/BUILD
+++ b/cc/private/BUILD
@@ -15,7 +15,6 @@
 filegroup(
     name = "srcs",
     srcs = glob([
-        "**/*.bzl",
         "**/BUILD",
     ]) + [
         "//cc/private/rules_impl:srcs",


### PR DESCRIPTION
the glob pattern `**/*.bzl` doesn't match anything there, and this is bad for `--incompatible_disallow_empty_glob`. This PR removes the offending line.