### PR TITLE
extensions: gate `module_ctx.extension_metadata(reproducible = ...)` appropriately

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "27.0")
+bazel_dep(name = "bazel_features", version = "1.19.0")
 
 cc_configure = use_extension("//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,17 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 http_archive(
+    name = "bazel_features",
+    sha256 = "3646ffd447753490b77d2380fa63f4d55dd9722e565d84dfda01536b48e183da",
+    strip_prefix = "bazel_features-1.19.0",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+http_archive(
     name = "rules_testing",
     sha256 = "02c62574631876a4e3b02a1820cb51167bb9cdcdea2381b2fa9d9b8b11c407c4",
     strip_prefix = "rules_testing-0.6.0",

--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -13,11 +13,16 @@
 # limitations under the License.
 """Module extension for cc auto configuration."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc/private/toolchain:cc_configure.bzl", "cc_autoconf", "cc_autoconf_toolchains")
 
 def _cc_configure_extension_impl(ctx):
     cc_autoconf_toolchains(name = "local_config_cc_toolchains")
     cc_autoconf(name = "local_config_cc")
-    return ctx.extension_metadata(reproducible = True)
+
+    has_reproducible = bazel_features.external_deps.extension_metadata_has_reproducible
+    return ctx.extension_metadata(
+        **(dict(reproducible = True) if has_reproducible else {})
+    )
 
 cc_configure_extension = module_extension(implementation = _cc_configure_extension_impl)


### PR DESCRIPTION
`reproducible` was added in Bazel 7.1.0; gating this argument allows older Bazel versions to use `rules_cc` v0.0.13 and newer.

Note that this change (use of `reproducible`) came from Bazel itself in bazelbuild/bazel#22335; it made its way over to `rules_cc` via https://github.com/bazelbuild/rules_cc/commit/c2549f6eb07ce00e529b84f9b9f1b31135a9ff77 (see https://github.com/bazelbuild/bazel/commit/1c4e78a9ceab9794140324d64833c628e382a3da).

More context [here](https://github.com/bazel-contrib/toolchains_llvm/pull/389#issuecomment-2408125835).