### PR TITLE
Improve backwards compatibility

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -117,6 +117,17 @@ tasks:
       EXP_USE_CQUERY: 1 # Don't build incompatible targets
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
+  ubuntu2004_bazel_6_bzlmod:
+    name: Ubuntu 20.04 (Bazel 6, Bzlmod)
+    bazel: 6.5.0
+    platform: ubuntu2004
+    environment:
+      EXP_USE_CQUERY: 1 # Don't build incompatible targets
+    build_flags:
+      - "--enable_bzlmod"
+      - "--ignore_dev_dependency"
+    build_targets: *build_targets_bazel_6
+    test_targets: *test_targets_bazel_6
 
   ubuntu_rule_based_toolchains:
     name: Ubuntu rule-based toolchains

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,9 +4,10 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_features", version = "1.18.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "protobuf", version = "27.0")
+bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 
 cc_configure = use_extension("//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ http_archive(
 )
 
 http_archive(
-    name = "protobuf",
+    name = "com_google_protobuf",
     sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
     strip_prefix = "protobuf-27.0",
     url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Starlark rules for building C++ projects."""
 
-load("@protobuf//bazel:cc_proto_library.bzl", _cc_proto_library = "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", _cc_proto_library = "cc_proto_library")
 load("//cc:cc_binary.bzl", _cc_binary = "cc_binary")
 load("//cc:cc_import.bzl", _cc_import = "cc_import")
 load("//cc:cc_library.bzl", _cc_library = "cc_library")

--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -13,11 +13,14 @@
 # limitations under the License.
 """Module extension for cc auto configuration."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc/private/toolchain:cc_configure.bzl", "cc_autoconf", "cc_autoconf_toolchains")
 
 def _cc_configure_extension_impl(ctx):
     cc_autoconf_toolchains(name = "local_config_cc_toolchains")
     cc_autoconf(name = "local_config_cc")
-    return ctx.extension_metadata(reproducible = True)
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return ctx.extension_metadata(reproducible = True)
+    return None
 
 cc_configure_extension = module_extension(implementation = _cc_configure_extension_impl)


### PR DESCRIPTION
* Gate `module_ctx.extension_metadata(reproducible = True)` usage behind a `bazel_features` check for compatibility with Bazel 6.
* Use the "well-known" name `com_google_protobuf` instead of `protobuf` with WORKSPACE to avoid missing deps and duplication of protobuf targets.