### PR TITLE
Move static library validation helper to `ar_files`

### DIFF
--- a/cc/private/toolchain/BUILD.tpl
+++ b/cc/private/toolchain/BUILD.tpl
@@ -68,6 +68,11 @@ filegroup(
     srcs = glob(["extra_tools/**"], allow_empty = True) + [%{cc_compiler_deps}],
 )
 
+filegroup(
+    name = "ar_files",
+    srcs = [":compiler_deps"] + [%{ar_deps}],
+)
+
 # This is the entry point for --crosstool_top.  Toolchains are found
 # by lopping off the name of --crosstool_top and searching for
 # the "${CPU}" entry in the toolchains attribute.

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -628,9 +628,8 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
                 ":builtin_include_directory_paths",
                 ":cc_wrapper",
                 ":deps_scanner_wrapper",
-            ] + (
-                [":validate_static_library"] if "validate_static_library" in tool_paths else []
-            )),
+            ]),
+            "%{ar_deps}": get_starlark_list([":validate_static_library"] if "validate_static_library" in tool_paths else []),
             "%{cc_toolchain_identifier}": cc_toolchain_identifier,
             "%{compile_flags}": get_starlark_list(
                 [


### PR DESCRIPTION
It doesn't need to be staged for every compile or link action. The action that uses it stages `all_files`.