### PR TITLE
Remove redundant with_feature_set for sanitizers

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -223,17 +223,11 @@ def _sanitizer_feature(name = "", specific_compile_flags = [], specific_link_fla
                         "-fno-sanitize-recover=all",
                     ] + specific_compile_flags),
                 ],
-                with_features = [
-                    with_feature_set(features = [name]),
-                ],
             ),
             flag_set(
                 actions = all_link_actions,
                 flag_groups = [
                     flag_group(flags = specific_link_flags),
-                ],
-                with_features = [
-                    with_feature_set(features = [name]),
                 ],
             ),
         ],


### PR DESCRIPTION
It uses the same name as the feature itself.