### PR TITLE
Move target-specific capabilities back to features

### DIFF
--- a/cc/toolchains/capabilities/BUILD
+++ b/cc/toolchains/capabilities/BUILD
@@ -9,11 +9,3 @@ cc_tool_capability(
 cc_tool_capability(
     name = "supports_interface_shared_libraries",
 )
-
-cc_tool_capability(
-    name = "supports_dynamic_linker",
-)
-
-cc_tool_capability(
-    name = "supports_pic",
-)

--- a/cc/toolchains/features/BUILD
+++ b/cc/toolchains/features/BUILD
@@ -42,9 +42,23 @@ cc_external_feature(
 )
 
 cc_external_feature(
+    name = "supports_dynamic_linker",
+    feature_name = "supports_dynamic_linker",
+    # This is a sentinel feature with no associated implementation.
+    overridable = False,
+)
+
+cc_external_feature(
     name = "static_link_cpp_runtimes",
     feature_name = "static_link_cpp_runtimes",
     overridable = True,
+)
+
+cc_external_feature(
+    name = "supports_pic",
+    feature_name = "supports_pic",
+    # This is a sentinel feature with no associated implementation.
+    overridable = False,
 )
 
 cc_feature_set(
@@ -56,7 +70,9 @@ cc_feature_set(
         ":static_linking_mode",
         ":dynamic_linking_mode",
         ":per_object_debug_info",
+        ":supports_dynamic_linker",
         ":static_link_cpp_runtimes",
+        ":supports_pic",
     ],
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
Some features with the "supports_*" naming style were moved to be tool capabilites despite being target capabilities rather than toolchain tool capabilities. This change restores them to their original location so they can be enabled at the cc_toolchain level instead.