### PR TITLE
Use clang-cl assembler in clang-cl toolchain again

### DIFF
--- a/cc/private/toolchain/windows_cc_configure.bzl
+++ b/cc/private/toolchain/windows_cc_configure.bzl
@@ -827,8 +827,7 @@ def _get_clang_cl_vars(repository_ctx, paths, msvc_vars, target_arch):
         "%{clang_cl_cl_path_" + target_arch + "}": clang_cl_path,
         "%{clang_cl_link_path_" + target_arch + "}": lld_link_path,
         "%{clang_cl_lib_path_" + target_arch + "}": llvm_lib_path,
-        # clang-cl does not support assembly files as input.
-        "%{clang_cl_ml_path_" + target_arch + "}": msvc_vars["%{msvc_ml_path_" + target_arch + "}"],
+        "%{clang_cl_ml_path_" + target_arch + "}": clang_cl_path,
         # LLVM's lld-link.exe doesn't support /DEBUG:FASTLINK.
         "%{clang_cl_dbg_mode_debug_flag_" + target_arch + "}": "/DEBUG",
         "%{clang_cl_fastbuild_mode_debug_flag_" + target_arch + "}": "/DEBUG",


### PR DESCRIPTION
This essentially reverts bazelbuild/bazel#23337 now that the toolchain configuration has been moved here. clang-cl does support assembly just like other clang variants and unlike MASM supports assembly using native AT&T syntax as with regular clang. MSVC-style assembly requires using MASM, which continues to be available in the MSVC toolchain.

This has previously been discussed in bazelbuild/bazel#24152 and reverted for Bazel 7.4.1 in bazelbuild/bazel#24211. Ideally, we'd want to have some mechanism to make assembler selection configurable and support several kinds of asm syntax in the future.

CC @meteorcloudy @michaelsiegrist