### PR TITLE
Remove -undefined dynamic_lookup.

### DIFF
--- a/cc/private/toolchain/cc_toolchain_config.bzl
+++ b/cc/private/toolchain/cc_toolchain_config.bzl
@@ -385,8 +385,6 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "-lstdc++",
-                                "-undefined",
-                                "dynamic_lookup",
                                 "-headerpad_max_install_names",
                                 "-no-canonical-prefixes",
                             ],


### PR DESCRIPTION
This is equivalent to https://github.com/bazelbuild/bazel/pull/16414.

Fixes #229