### PR TITLE
Fix `ends_with()` for runfiles

### DIFF
--- a/cc/runfiles/runfiles.cc
+++ b/cc/runfiles/runfiles.cc
@@ -73,6 +73,9 @@ bool ends_with(const string& s, const string& suffix) {
   if (s.empty()) {
     return false;
   }
+  if (suffix.size() > s.size()) {
+    return false;
+  }
   return s.rfind(suffix) == s.size() - suffix.size();
 }
 


### PR DESCRIPTION
This erroneously failed for single character path queries like `Rlocation("a")`.
This queries `ends_with("a", "/.")` under the hood which was erroneously returning `true` and hitting the early abort in https://github.com/bazelbuild/rules_cc/blob/5be90a4e04e64df0e9d26382e1006d3df21aaa91/cc/runfiles/runfiles.cc#L218-L222

Erroneous logic:
```cpp
std::string s = "a"; // any single character
s.rfind("/.") == std::string::npos == -1 == s.size()-suffix.size()
```