### PR TITLE
Fix attribute name in cc_tool docs

### DIFF
--- a/cc/toolchains/tool.bzl
+++ b/cc/toolchains/tool.bzl
@@ -125,7 +125,7 @@ load("//cc/toolchains:tool.bzl", "cc_tool")
 
 cc_tool(
     name = "clang_tool",
-    executable = "@llvm_toolchain//:bin/clang",
+    src = "@llvm_toolchain//:bin/clang",
     # Suppose clang needs libc to run.
     data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
     tags = ["requires-network"],

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -401,7 +401,7 @@ load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 
 cc_tool(
     name = "clang_tool",
-    executable = "@llvm_toolchain//:bin/clang",
+    src = "@llvm_toolchain//:bin/clang",
     # Suppose clang needs libc to run.
     data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
     tags = ["requires-network"],


### PR DESCRIPTION
The attribute [here](https://github.com/bazelbuild/rules_cc/blob/34f0e1f038cff9bf28d65d101c806b48f35bf92e/cc/toolchains/tool.bzl#L66) is named `src` while the example calls is `executable`. This PR renames the example to `src`.