### PR TITLE
Fix docs for capabilities

### DIFF
--- a/cc/toolchains/tool_capability.bzl
+++ b/cc/toolchains/tool_capability.bzl
@@ -69,8 +69,12 @@ cc_tool(
 
 cc_args(
     name = "pic",
-    requires = [
-        "//cc/toolchains/capabilities:supports_pic"
+    actions = [
+        # Applies to all C/C++ compile actions.
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    requires_any_of = [
+        "@rules_cc//cc/toolchains/capabilities:supports_pic"
     ],
     args = ["-fPIC"],
 )

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -444,8 +444,12 @@ cc_tool(
 
 cc_args(
     name = "pic",
-    requires = [
-        "@rules_cc//cc/toolchains/capabilities:supports_pic"
+    actions = [
+        # Applies to all C/C++ compile actions.
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    requires_any_of = [
+        "//cc/toolchains/capabilities:supports_pic"
     ],
     args = ["-fPIC"],
 )

--- a/examples/rule_based_toolchain/toolchain/args/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchain/args/BUILD.bazel
@@ -50,3 +50,15 @@ cc_args(
     args = ["-no-canonical-prefixes"],
     visibility = ["//visibility:public"],
 )
+
+cc_args(
+    name = "pic",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:c_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    args = ["-fPIC"],
+    requires_any_of = [
+        "@rules_cc//cc/toolchains/capabilities:supports_pic",
+    ],
+)

--- a/examples/rule_based_toolchain/toolchain/tools/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchain/tools/BUILD.bazel
@@ -60,6 +60,9 @@ cc_tool(
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang",
     }),
+    capabilities = [
+        "@rules_cc//cc/toolchains/capabilities:supports_pic",
+    ],
     data = [
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
@@ -72,6 +75,9 @@ cc_tool(
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang++",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang++",
     }),
+    capabilities = [
+        "@rules_cc//cc/toolchains/capabilities:supports_pic",
+    ],
     data = [
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",


### PR DESCRIPTION
The docs for capabilities did not contain everything that is required and use a non existing attribute `requires`. I tried to fixed the docs and added this to the rule based toolchain example, which does not work. Maybe someone can help me to fix how this should be used in the examples.