### PR TITLE
`find_cc_toolchain`: Don't fail on missing toolchain if `mandatory = False`

### DIFF
--- a/cc/find_cc_toolchain.bzl
+++ b/cc/find_cc_toolchain.bzl
@@ -77,6 +77,8 @@ Returns the current `CcToolchainInfo`.
     # Check the incompatible flag for toolchain resolution.
     if hasattr(cc_common, "is_cc_toolchain_resolution_enabled_do_not_use") and cc_common.is_cc_toolchain_resolution_enabled_do_not_use(ctx = ctx):
         if not CC_TOOLCHAIN_TYPE in ctx.toolchains:
+            if not mandatory:
+                return None
             fail("In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.")
         toolchain_info = ctx.toolchains[CC_TOOLCHAIN_TYPE]
         if toolchain_info == None:


### PR DESCRIPTION
`find_cc_toolchain` is sometimes used by helper functions that may not have knowledge of the rule calling them. Making the function not fail if the calling rule did not use `use_cc_toolchain()` allows callers to avoid checking if `CC_TOOLCHAIN_TYPE` is in `ctx.toolchains` before calling `find_cc_toolchain`.