### PR TITLE
Stop using @local_config_platform

### DIFF
--- a/cc/private/toolchain/BUILD.toolchains.tpl
+++ b/cc/private/toolchain/BUILD.toolchains.tpl
@@ -1,4 +1,4 @@
-load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 
 toolchain(
     name = "cc-toolchain-%{name}",


### PR DESCRIPTION
Ever since Bazel 7.2, the officially documented method for accessing the host constraints is to load @platforms//host:constraints.bzl. More details:

https://bazel.build/extending/platforms#specifying-build-platform
https://bazel.build/concepts/platforms#default-platforms