### PR TITLE
shebang: changed scripts shebang to better support systems like bsd and nixos

### DIFF
--- a/cc/private/toolchain/build_interface_so
+++ b/cc/private/toolchain/build_interface_so
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# != 2 ]]; then
    echo "Usage: $0 <so> <interface so>" 1>&2

--- a/cc/private/toolchain/gcc_deps_scanner_wrapper.sh.tpl
+++ b/cc/private/toolchain/gcc_deps_scanner_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Ship the environment to the C++ action
 #

--- a/cc/private/toolchain/generate_system_module_map.sh
+++ b/cc/private/toolchain/generate_system_module_map.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cc/private/toolchain/grep-includes.sh
+++ b/cc/private/toolchain/grep-includes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/link_dynamic_library.sh
+++ b/cc/private/toolchain/link_dynamic_library.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/linux_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/linux_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/osx_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/cc/system_library.bzl
+++ b/cc/system_library.bzl
@@ -39,7 +39,7 @@ def _get_list_from_env_var(repo_ctx, var_name, key):
     return _split_env_var(repo_ctx, var_name).get(key, default = [])
 
 def _execute_bash(repo_ctx, cmd):
-    return repo_ctx.execute(["/bin/bash", "-c", cmd]).stdout.strip("\n")
+    return repo_ctx.execute(["/usr/bin/env", "bash", "-c", cmd]).stdout.strip("\n")
 
 def _find_linker(repo_ctx):
     ld = _execute_bash(repo_ctx, "which ld")

--- a/examples/custom_toolchain/sample_compiler
+++ b/examples/custom_toolchain/sample_compiler
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Sample script demonstrating custom C++ toolchain selection: handles
 # the command that translates a cc_library's .cc (source file) into .o  (object

--- a/examples/custom_toolchain/sample_linker
+++ b/examples/custom_toolchain/sample_linker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Sample script demonstrating custom C++ toolchain selection: handles
 # the command that translates a cc_library's .o (object file) into

--- a/tests/rule_based_toolchain/testdata/bin
+++ b/tests/rule_based_toolchain/testdata/bin
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running unwrapped tool"

--- a/tests/rule_based_toolchain/testdata/bin_wrapper.sh
+++ b/tests/rule_based_toolchain/testdata/bin_wrapper.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running tool wrapper"

--- a/tests/system_library/unittest.bash
+++ b/tests/system_library/unittest.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -21,7 +21,7 @@
 # A typical test suite looks like so:
 #
 #   ------------------------------------------------------------------------
-#   #!/bin/bash
+#   #!/usr/bin/env bash
 #
 #   source path/to/unittest.bash || exit 1
 #


### PR DESCRIPTION
The assumption that bash is always located at /bin/bash does not always hold true.
In POSIX systems, it is recommended to avoid relying on common paths. Instead, one should either:

- Hardcode the full absolute path to the executable, or
- Locate the command in the PATH.

A more portable approach is to use `#!/usr/bin/env bash`, which resolves binaries through the PATH.

This patch updates the default shebang string in this repository to improve portability on systems like NixOS or BSD.