### PR TITLE
Apply -no-canonical-prefixes to all compile actions

### DIFF
--- a/examples/rule_based_toolchain/toolchain/args/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchain/args/BUILD.bazel
@@ -44,8 +44,7 @@ cc_args(
 cc_args(
     name = "no_canonical_prefixes",
     actions = [
-        "@rules_cc//cc/toolchains/actions:c_compile",
-        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+        "@rules_cc//cc/toolchains/actions:compile_actions",
     ],
     args = ["-no-canonical-prefixes"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
In the rule_based_toolchain example, updates the no_canonical_prefixes arguments to apply to all compile actions. Previously, assembly actions were not properly included.