### PR TITLE
add missing include features on macOS

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1863,6 +1863,8 @@ def _impl(ctx):
             default_link_flags_feature,
             user_link_flags_feature,
             default_link_libs_feature,
+            includes_feature,
+            include_paths_feature,
             external_include_paths_feature,
             fdo_optimize_feature,
             dbg_feature,


### PR DESCRIPTION
When testing https://github.com/bazelbuild/bazel/pull/22553 on macOS, I noticed that several include features were missing. This patch addresses that issue by adding the missing include features to `unix_cc_toolchain_config.bzl`. 

Additionally, it may be beneficial to introduce an array of common features to help prevent similar omissions in the future.
