### PR TITLE
fix: feature sanity check in rule based toolchains

### DIFF
--- a/cc/toolchains/impl/toolchain_config_info.bzl
+++ b/cc/toolchains/impl/toolchain_config_info.bzl
@@ -59,7 +59,7 @@ def _get_known_features(features, capability_features, fail):
     for ft in capability_features + features:
         if ft.name in feature_names:
             other = feature_names[ft.name]
-            if other.overrides != ft and ft.overrides != other:
+            if ft != other and other.overrides != ft and ft.overrides != other:
                 fail(_FEATURE_NAME_ERR.format(
                     name = ft.name,
                     lhs = ft.label,


### PR DESCRIPTION
This check ensures feature names are not duplicated. It does this by collecting all features. Including those from capabilities from tools from the `tool_map`.

If we now annotate a `gcc` tool with `@rules_cc//cc/toolchains/capabilities:supports_pic` and that tool is used for `c_compile_actions`, `cpp_compile_actions` and `link_actions`, the capability is collected multiple times and so is the feature.

If we extend the test here, we exclude the override check on the same feature.