### PR TITLE
Feature/additional link outputs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,7 @@ cc_configure = use_extension("//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")
 
 register_toolchains("@local_config_cc_toolchains//:all")
+register_toolchains("//examples/custom_toolchain:platform_based_toolchain")
 
 bazel_dep(name = "rules_shell", version = "0.2.0", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)

--- a/examples/custom_toolchain/BUILD
+++ b/examples/custom_toolchain/BUILD
@@ -29,6 +29,7 @@
 #
 # This example demonstrates both approaches.
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
 load("@rules_cc//cc/toolchains:cc_toolchain_suite.bzl", "cc_toolchain_suite")
@@ -43,6 +44,13 @@ load(":toolchain_config.bzl", "cc_toolchain_config")
 cc_library(
     name = "buildme",
     srcs = ["buildme.cc"],
+)
+
+# The binary we want to build. Building this calls two C++ actions: compile (.cc ->
+# .o) and link (.o -> executable).
+cc_binary(
+    name = "buildme-bin",
+    srcs = ["buildme-main.cc"],
 )
 
 # This example intentionally makes the cc_toolchain_config definition

--- a/examples/custom_toolchain/buildme-main.cc
+++ b/examples/custom_toolchain/buildme-main.cc
@@ -1,0 +1,4 @@
+
+int main() {
+  return 0;
+}

--- a/examples/custom_toolchain/sample_compiler
+++ b/examples/custom_toolchain/sample_compiler
@@ -2,7 +2,8 @@
 #
 # Sample script demonstrating custom C++ toolchain selection: handles
 # the command that translates a cc_library's .cc (source file) into .o  (object
-# file).
+# file) or the command used to link .o files into the final executable
+# (just like gcc is used as a front to the linker).
 
 echo "$0: running sample cc_library compiler (produces .o output)."
 
@@ -12,10 +13,26 @@ echo "$0: running sample cc_library compiler (produces .o output)."
 #
 # examples/custom_toolchain/sample_compiler <various compiler flags> -o bazel-out/x86-fastbuild/bin/examples/custom_toolchain/_objs/buildme/buildme.o.
 
-# The .o is the last parameter.
-OBJECT_FILE=${@: -1}
-# Swap out .o for .d to get expected .d (source dependency output).
-DOTD_FILE=${OBJECT_FILE%?}d
+# Get last command-line argument
+OUTFILE=${!#}
 
-echo "$0: sample .o output" > $OBJECT_FILE
-echo "sample .d output ($0)" > $DOTD_FILE
+if [[ "$OUTFILE" == @* ]]; then
+    # This means we are creating an executable.
+
+    # Remove leading @ and param file suffix.
+    OUTFILE=${OUTFILE#@}
+    OUTFILE=${OUTFILE%-*}
+    
+    # Do not create a .d file
+    DOTD_FILE=
+else
+    # This means we're creating a .o file
+    OUTFILE=${OUTFILE}
+    DOTD_FILE=${OUTFILE%.o}.d
+fi
+
+echo "$0: sample output" > $OUTFILE
+
+if [[ -n $DOTD_FILE ]]; then
+    echo "sample .d output ($0)" > $DOTD_FILE
+fi

--- a/examples/custom_toolchain/sample_compiler
+++ b/examples/custom_toolchain/sample_compiler
@@ -32,6 +32,7 @@ else
 fi
 
 echo "$0: sample output" > $OUTFILE
+echo "$0: sample output changed" > $OUTFILE.change
 
 if [[ -n $DOTD_FILE ]]; then
     echo "sample .d output ($0)" > $DOTD_FILE

--- a/examples/custom_toolchain/sample_linker
+++ b/examples/custom_toolchain/sample_linker
@@ -12,12 +12,17 @@ echo "$0: running sample cc_library linker (produces .a output)."
 #
 # examples/custom_toolchain/sample_linker @bazel-out/x86-fastbuild/bin/examples/custom_toolchain/libbuildme.a-2.params.
 
-# Get "@bazel-out/.../libbuildme.a-2.params".
-PARAMS_FILE=${@: -1}
-# Remove the "@" prefix.
-OUTFILE=${PARAMS_FILE#?}
-# Replace "libbuildme.a-2.params" with "libbuildme.a".
-OUTFILE=${OUTFILE%-*}
+# Find output file by looking for the argument with a '.a' suffix.
+for arg in "$@"; do
+    if [[ "$arg" == *.a ]]; then
+        OUTFILE="$arg"
+        break
+    fi
+done
 
-echo "$0: sample output"  >  $OUTFILE
+if [[ -z "$OUTFILE" ]]; then
+    echo "No '.a' file found in the arguments."
+    exit 255
+fi
 
+echo "$0: sample output" > $OUTFILE

--- a/examples/custom_toolchain/toolchain_config.bzl
+++ b/examples/custom_toolchain/toolchain_config.bzl
@@ -66,6 +66,9 @@ def _impl(ctx):
         abi_version = "unknown",
         abi_libc_version = "unknown",
         tool_paths = tool_paths,
+        additional_link_outputs = [
+            ".change",
+        ],
     )
 
 cc_toolchain_config = rule(


### PR DESCRIPTION
Part of #24990.

Tests the `additional_link_outputs` feature implemented in this [pull request](https://github.com/bazelbuild/bazel/pull/25091).
For this to work, the pull request needs to be merged. I tested it with a dev version for now.

I also had to fix some things in the `custom_toolchain` which were not up-to-date, in order to run the use-cases and test the feature. I separated it into different commits for better readability.