### PR TITLE
Add partial support for external_include_paths

### DIFF
--- a/cc/toolchains/args/external_include_paths/BUILD
+++ b/cc/toolchains/args/external_include_paths/BUILD
@@ -1,0 +1,22 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
+
+cc_args(
+    name = "external_include_paths",
+    actions = ["//cc/toolchains/actions:compile_actions"],
+    nested = [":search_dir_args"],
+    requires_not_none = "//cc/toolchains/variables:external_include_paths",
+    visibility = ["//visibility:public"],
+)
+
+cc_nested_args(
+    name = "search_dir_args",
+    args = [
+        "-isystem",
+        "{search_dir}",
+    ],
+    format = {
+        "search_dir": "//cc/toolchains/variables:external_include_paths",
+    },
+    iterate_over = "//cc/toolchains/variables:external_include_paths",
+)


### PR DESCRIPTION
external_include_paths is an interesting feature + variable, that when
enabled, puts include paths into a separate external_include_paths
variable (separate as in not included in the default includes features).
It's also notably not in the legacy features java code. With this change
it is never activated unless users manually create the feature and add
it to their know features.
