### PR TITLE
Add strip_flags

### DIFF
--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -24,7 +24,7 @@ cc_feature_set(
         "//cc/toolchains/args/runtime_library_search_directories:feature",
         "//cc/toolchains/args/shared_flag:feature",
         "//cc/toolchains/args/strip_debug_symbols:feature",
-        "//cc/toolchains/args/strip_flags",
+        "//cc/toolchains/args/strip_flags:feature",
     ],
 )
 

--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -24,6 +24,7 @@ cc_feature_set(
         "//cc/toolchains/args/runtime_library_search_directories:feature",
         "//cc/toolchains/args/shared_flag:feature",
         "//cc/toolchains/args/strip_debug_symbols:feature",
+        "//cc/toolchains/args/strip_flags",
     ],
 )
 

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -1,0 +1,45 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:args_list.bzl", "cc_args_list")
+
+cc_args_list(
+    name = "strip_flags",
+    args = [
+        ":strip_debug",
+        ":preserve_dates",
+        ":output_file",
+        ":input_file",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "strip_debug",
+    actions = ["//cc/toolchains/actions:strip"],
+    args = ["-S"],
+)
+
+cc_args(
+    name = "preserve_dates",
+    actions = ["//cc/toolchains/actions:strip"],
+    args = select({
+        "@platforms//os:macos": [],
+        "//conditions:default": ["-p"],
+    }),
+)
+
+cc_args(
+    name = "output_file",
+    actions = ["//cc/toolchains/actions:strip"],
+    args = [
+        "-o",
+        "{output_file}",
+    ],
+    format = {"output_file": "//cc/toolchains/variables:output_file"},
+)
+
+cc_args(
+    name = "input_file",
+    actions = ["//cc/toolchains/actions:strip"],
+    args = ["{input_file}"],
+    format = {"input_file": "//cc/toolchains/variables:input_file"},
+)

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -1,5 +1,8 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+package(default_visibility = ["//visibility:public"])
 
 cc_feature(
     name = "feature",

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -1,6 +1,11 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
 
+cc_feature(
+    name = "feature",
+    args = [":strip_flags"],
+)
+
 cc_args_list(
     name = "strip_flags",
     args = [

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -7,6 +7,7 @@ package(default_visibility = ["//visibility:public"])
 cc_feature(
     name = "feature",
     args = [":strip_flags"],
+    feature_name = "strip_flags_feature",
 )
 
 cc_args_list(

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -35,6 +35,7 @@ cc_args(
         "{output_file}",
     ],
     format = {"output_file": "//cc/toolchains/variables:output_file"},
+    requires_not_none = "//cc/toolchains/variables:output_file",
 )
 
 cc_args(

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -7,6 +7,8 @@ package(default_visibility = ["//visibility:public"])
 cc_feature(
     name = "feature",
     args = [":strip_flags"],
+    # This does not override a feature since these arguments are directly bound
+    # to the strip action in CppActionConfigs.java.
     feature_name = "strip_flags_feature",
 )
 


### PR DESCRIPTION
Previously the strip action appeared to be entirely invalid since no
flags were passed to strip. I believe this is because the strip action
was configured in the legacy feature code without any extra features,
just directly on the action.
