### PR TITLE
Add preprocessor_defines args and feature

### DIFF
--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -20,6 +20,7 @@ cc_feature(
         "//cc/toolchains/args/linker_param_file",
         "//cc/toolchains/args/runtime_library_search_directories",
         "//cc/toolchains/args/shared_flag",
+        "//cc/toolchains/args/preprocessor_defines",
     ],
     feature_name = "experimental_replace_legacy_action_config_features",
     # TODO: Convert remaining items in this list into their actual args.

--- a/cc/toolchains/args/preprocessor_defines/BUILD
+++ b/cc/toolchains/args/preprocessor_defines/BUILD
@@ -1,0 +1,18 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_feature(
+    name = "feature",
+    args = [":preprocessor_defines"],
+    overrides = "//cc/toolchains/features/legacy:preprocessor_defines",
+)
+
+cc_args(
+    name = "preprocessor_defines",
+    actions = ["//cc/toolchains/actions:compile_actions"],
+    args = ["-D{preprocessor_defines}"],
+    format = {"preprocessor_defines": "//cc/toolchains/variables:preprocessor_defines"},
+    iterate_over = "//cc/toolchains/variables:preprocessor_defines",
+)


### PR DESCRIPTION
Using the feature allows you to make sure the legacy toolchain feature
is suppressed.

This is the diff in the action config:

```
 flag_set {
+  action: "assemble"
   action: "c++-compile"
   action: "c++-header-parsing"
+  action: "c++-module-codegen"
   action: "c++-module-compile"
   action: "c-compile"
   action: "clif-match"
   action: "linkstamp-compile"
+  action: "lto-backend"
+  action: "objc++-compile"
+  action: "objc-compile"
   action: "preprocess-assemble"
```

I intentionally made this apply to all compile actions since it can
affect them.
