### PR TITLE
Override legacy features with cc_feature_set

### DIFF
--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -1,4 +1,5 @@
 load("//cc/toolchains:feature.bzl", "cc_feature")
+load("//cc/toolchains:feature_set.bzl", "cc_feature_set")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -11,16 +12,21 @@ package(default_visibility = ["//visibility:public"])
 # Note that some other legacy features are still hidden and enabled by default,
 # and others exist that are NOT enabled at all by default. As args are built
 # out, the `implies` entry should be removed and then moved into `args`.
-cc_feature(
+cc_feature_set(
     name = "experimental_replace_legacy_action_config_features",
-    args = [
-        "//cc/toolchains/args/archiver_flags",
-        "//cc/toolchains/args/force_pic_flags",
-        "//cc/toolchains/args/libraries_to_link",
-        "//cc/toolchains/args/linker_param_file",
-        "//cc/toolchains/args/runtime_library_search_directories",
-        "//cc/toolchains/args/shared_flag",
+    all_of = [
+        ":backfill_legacy_args",
+        "//cc/toolchains/args/archiver_flags:feature",
+        "//cc/toolchains/args/force_pic_flags:feature",
+        "//cc/toolchains/args/libraries_to_link:feature",
+        "//cc/toolchains/args/linker_param_file:feature",
+        "//cc/toolchains/args/runtime_library_search_directories:feature",
+        "//cc/toolchains/args/shared_flag:feature",
     ],
+)
+
+cc_feature(
+    name = "backfill_legacy_args",
     feature_name = "experimental_replace_legacy_action_config_features",
     # TODO: Convert remaining items in this list into their actual args.
     implies = [
@@ -39,4 +45,5 @@ cc_feature(
         "//cc/toolchains/features/legacy:user_compile_flags",
         "//cc/toolchains/features/legacy:user_link_flags",
     ],
+    visibility = ["//visibility:private"],
 )

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -1,8 +1,16 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":archiver_flags"],
+    overrides = "//cc/toolchains/features/legacy:archiver_flags",
+    visibility = ["//visibility:public"],
+)
 
 cc_args_list(
     name = "archiver_flags",

--- a/cc/toolchains/args/force_pic_flags/BUILD
+++ b/cc/toolchains/args/force_pic_flags/BUILD
@@ -1,6 +1,14 @@
 load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":force_pic_flags"],
+    overrides = "//cc/toolchains/features/legacy:force_pic_flags",
+    visibility = ["//visibility:public"],
+)
 
 cc_args(
     name = "force_pic_flags",

--- a/cc/toolchains/args/libraries_to_link/BUILD
+++ b/cc/toolchains/args/libraries_to_link/BUILD
@@ -1,8 +1,16 @@
 load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
 load("//cc/toolchains/args/libraries_to_link/private:library_link_args.bzl", "library_link_args")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":libraries_to_link"],
+    overrides = "//cc/toolchains/features/legacy:libraries_to_link",
+    visibility = ["//visibility:public"],
+)
 
 cc_args(
     name = "libraries_to_link",

--- a/cc/toolchains/args/linker_param_file/BUILD
+++ b/cc/toolchains/args/linker_param_file/BUILD
@@ -1,7 +1,15 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":linker_param_file"],
+    overrides = "//cc/toolchains/features/legacy:linker_param_file",
+    visibility = ["//visibility:public"],
+)
 
 cc_args_list(
     name = "linker_param_file",

--- a/cc/toolchains/args/runtime_library_search_directories/BUILD
+++ b/cc/toolchains/args/runtime_library_search_directories/BUILD
@@ -1,9 +1,17 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":runtime_library_search_directories"],
+    overrides = "//cc/toolchains/features/legacy:runtime_library_search_directories",
+    visibility = ["//visibility:public"],
+)
 
 # TODO: b/27153401 - The implementation of this is particularly complex because
 # of what appears to be a workaround where macOS cc_test targets with

--- a/cc/toolchains/args/shared_flag/BUILD
+++ b/cc/toolchains/args/shared_flag/BUILD
@@ -1,6 +1,14 @@
 load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 
 package(default_visibility = ["//visibility:private"])
+
+cc_feature(
+    name = "feature",
+    args = [":shared_flag"],
+    overrides = "//cc/toolchains/features/legacy:shared_flag",
+    visibility = ["//visibility:public"],
+)
 
 cc_args(
     name = "shared_flag",


### PR DESCRIPTION
Modifies experimental_replace_legacy_action_config_features slightly to make it override legacy features rather than just reimplement them as args. This should prevent duplicate arguments for the features that are re-implemented.