### PR TITLE
Make output_file variable optional

### DIFF
--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -325,7 +325,7 @@ cc_variable(
         "//cc/toolchains/actions:compile_actions",
         "//cc/toolchains/actions:strip",
     ],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(


### PR DESCRIPTION
There are use cases where callers attempt to get the command line flags
for something without having an output file, which makes any feature
that relies on this fail.

For example: https://github.com/bazel-contrib/rules_foreign_cc/blob/2dd6fe2aee33bf1a931ac18e5090c5476a229a02/foreign_cc/private/cc_toolchain_util.bzl#L250-L254

Currently this is unused directly but will be used in later changes and
must be optional to work correctly for this case.
