### PR TITLE
Add missing objc arc variable extensions

### DIFF
--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -305,6 +305,18 @@ cc_variable(
 )
 
 cc_variable(
+    name = "no_objc_arc",
+    actions = ["//cc/toolchains/actions:compile_actions"],
+    type = types.option(types.string),
+)
+
+cc_variable(
+    name = "objc_arc",
+    actions = ["//cc/toolchains/actions:compile_actions"],
+    type = types.option(types.string),
+)
+
+cc_variable(
     name = "output_assembly_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
     type = types.file,
@@ -509,6 +521,8 @@ cc_builtin_variables(
         ":module_files",
         ":module_map_file",
         ":module_name",
+        ":no_objc_arc",
+        ":objc_arc",
         ":output_assembly_file",
         ":output_execpath",
         ":output_file",


### PR DESCRIPTION
ObjC compilation in bazel has a separate set of variables that can be
used by the crosstool

https://github.com/bazelbuild/bazel/blob/4d295906bd144f4bcbf89342d3d3cd7cc5de15ca/src/main/starlark/builtins_bzl/common/objc/compilation_support.bzl#L37-L40
