### PR TITLE
Deduplicate capability features

### DIFF
--- a/cc/toolchains/impl/toolchain_config_info.bzl
+++ b/cc/toolchains/impl/toolchain_config_info.bzl
@@ -115,7 +115,7 @@ def _validate_feature(self, known_features, fail):
 def _validate_toolchain(self, fail = fail):
     capabilities = []
     for tool in self.tool_map.configs.values():
-        capabilities.extend([cap.feature for cap in tool.capabilities])
+        capabilities.extend([cap.feature for cap in tool.capabilities if cap.feature not in capabilities])
     known_features = _get_known_features(self.features, capabilities, fail = fail)
 
     for feature in self.features:


### PR DESCRIPTION
Under the covers, features are used to communicate tool capabilities to the underlying code.  If multiple tools provide the same capabilities, this ends up generating duplicate features and failing.

C++ and C tools is a really easy example, and they both have "supports_dynamic_linker" as a capability very reasonably.