### PR TITLE
[toolchain] Mark some more variables as optional

### DIFF
--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -484,7 +484,7 @@ cc_variable(
 cc_variable(
     name = "user_link_flags",
     actions = ["//cc/toolchains/actions:link_actions"],
-    type = types.list(types.string),
+    type = types.option(types.list(types.string)),
 )
 
 cc_builtin_variables(

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -151,7 +151,7 @@ cc_variable(
 cc_variable(
     name = "legacy_link_flags",
     actions = ["//cc/toolchains/actions:link_actions"],
-    type = types.list(types.string),
+    type = types.option(types.list(types.string)),
 )
 
 cc_variable(

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -8,7 +8,7 @@ cc_variable(
         "//cc/toolchains/actions:link_actions",
         "//cc/toolchains/actions:compile_actions",
     ],
-    type = types.directory,
+    type = types.option(types.directory),
 )
 
 cc_variable(
@@ -20,7 +20,7 @@ cc_variable(
 cc_variable(
     name = "dependency_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
@@ -41,19 +41,19 @@ cc_variable(
         "//cc/toolchains/actions:link_actions",
         "//cc/toolchains/actions:compile_actions",
     ],
-    type = types.directory,
+    type = types.option(types.directory),
 )
 
 cc_variable(
     name = "fdo_prefetch_hints_path",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
     name = "fdo_profile_path",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
@@ -103,7 +103,7 @@ cc_variable(
 cc_variable(
     name = "input_file",
     actions = ["//cc/toolchains/actions:strip"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
@@ -319,7 +319,7 @@ cc_variable(
 cc_variable(
     name = "output_assembly_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
@@ -343,13 +343,13 @@ cc_variable(
 cc_variable(
     name = "output_preprocess_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
     name = "per_object_debug_info_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(
@@ -397,7 +397,7 @@ cc_variable(
 cc_variable(
     name = "source_file",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    type = types.file,
+    type = types.option(types.file),
 )
 
 cc_variable(


### PR DESCRIPTION
All of these are used with `expand_if_{,not_}available` in `unix_cc_toolchain_config.bzl` and I've seen failures with unconditionally expanding `source_file` in some cases in our internal build.

```
ERROR: /.../external/rules_go+/BUILD.bazel:88:17: in cgo_context_data rule @@rules_go+//:cgo_context_data:
Traceback (most recent call last):
        File "/.../external/rules_go+/go/private/context.bzl", line 737, column 54, in _cgo_context_data_impl
                cc_common.get_memory_inefficient_command_line(
        File "/virtual_builtins_bzl/common/cc/cc_common.bzl", line 205, column 66, in _get_memory_inefficient_command_line
Error in get_memory_inefficient_command_line: Invalid toolchain configuration: Cannot find variable named 'source_file'.
ERROR: /.../external/rules_go+/BUILD.bazel:88:17: Analysis of target '@@rules_go+//:cgo_context_data' failed
```