### PR TITLE
Migrate away from legacy struct returns

### DIFF
--- a/cc/private/toolchain/armeabi_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/armeabi_cc_toolchain_config.bzl
@@ -56,7 +56,7 @@ def _impl(ctx):
         tool_path(name = "strip", path = "/bin/false"),
     ]
 
-    return cc_common.create_cc_toolchain_config_info(
+    return [cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         features = features,
         action_configs = action_configs,
@@ -74,7 +74,7 @@ def _impl(ctx):
         make_variables = make_variables,
         builtin_sysroot = builtin_sysroot,
         cc_target_os = cc_target_os,
-    )
+    )]
 
 armeabi_cc_toolchain_config = rule(
     implementation = _impl,

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1888,7 +1888,7 @@ def _impl(ctx):
     if symbol_check:
         features.append(symbol_check)
 
-    return cc_common.create_cc_toolchain_config_info(
+    return [cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         features = features,
         action_configs = action_configs,
@@ -1904,7 +1904,7 @@ def _impl(ctx):
         abi_libc_version = ctx.attr.abi_libc_version,
         tool_paths = tool_paths,
         builtin_sysroot = ctx.attr.builtin_sysroot,
-    )
+    )]
 
 cc_toolchain_config = rule(
     implementation = _impl,

--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -1618,7 +1618,7 @@ def _impl(ctx):
         ],
         enabled = True,
     )
-    return cc_common.create_cc_toolchain_config_info(
+    return [cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         features = features + [cpp_modules_feature, cpp_module_modmap_file_feature, cpp20_module_compile_flags_feature],
         action_configs = action_configs,
@@ -1634,7 +1634,7 @@ def _impl(ctx):
         abi_libc_version = ctx.attr.abi_libc_version,
         tool_paths = tool_paths,
         make_variables = make_variables,
-    )
+    )]
 
 cc_toolchain_config = rule(
     implementation = _impl,

--- a/examples/custom_toolchain/toolchain_config.bzl
+++ b/examples/custom_toolchain/toolchain_config.bzl
@@ -55,7 +55,7 @@ def _impl(ctx):
     #
     # create_cc_toolchain_config_info is the public interface for registering
     # C++ toolchain behavior.
-    return cc_common.create_cc_toolchain_config_info(
+    return [cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         toolchain_identifier = "custom-toolchain-identifier",
         host_system_name = "local",
@@ -66,7 +66,7 @@ def _impl(ctx):
         abi_version = "unknown",
         abi_libc_version = "unknown",
         tool_paths = tool_paths,
-    )
+    )]
 
 cc_toolchain_config = rule(
     implementation = _impl,


### PR DESCRIPTION
According to https://bazel.build/extending/rules, implementation functions of rules should return lists of providers. Returning a bare provider is legacy behavior and should be migrated away from.