### PR TITLE
Add objc_execution to all link actions

### DIFF
--- a/cc/action_names.bzl
+++ b/cc/action_names.bzl
@@ -164,6 +164,7 @@ ALL_CC_LINK_ACTION_NAMES = [
     ACTION_NAMES.lto_index_for_executable,
     ACTION_NAMES.lto_index_for_dynamic_library,
     ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+    ACTION_NAMES.objc_executable,
 ]
 
 # Names of actions that link entire programs.
@@ -193,6 +194,7 @@ TRANSITIVE_LINK_ACTION_NAMES = [
     ACTION_NAMES.cpp_link_dynamic_library,
     ACTION_NAMES.lto_index_for_executable,
     ACTION_NAMES.lto_index_for_dynamic_library,
+    ACTION_NAMES.objc_executable,
 ]
 
 ACTION_NAME_GROUPS = struct(

--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -254,6 +254,7 @@ cc_action_type_set(
     actions = [
         ":cpp_link_executable",
         ":lto_index_for_executable",
+        ":objc_executable",
     ],
 )
 
@@ -281,6 +282,7 @@ cc_action_type_set(
         ":cpp_link_dynamic_library",
         ":lto_index_for_executable",
         ":lto_index_for_dynamic_library",
+        ":objc_executable",
     ],
 )
 

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/force_pic_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/force_pic_flags.textproto
@@ -2,6 +2,7 @@ enabled: false
 flag_sets {
   actions: "c++-link-executable"
   actions: "lto-index-for-executable"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "force_pic"
     flags: "-Wl,-pie"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/libraries_to_link.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/libraries_to_link.textproto
@@ -6,6 +6,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     flag_groups {
       expand_if_available: "thinlto_param_file"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/runtime_library_search_directories.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/runtime_library_search_directories.textproto
@@ -6,6 +6,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "runtime_library_search_directories"
     flag_groups {
@@ -37,6 +38,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "runtime_library_search_directories"
     flag_groups {

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/force_pic_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/force_pic_flags.textproto
@@ -2,6 +2,7 @@ enabled: false
 flag_sets {
   actions: "c++-link-executable"
   actions: "lto-index-for-executable"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "force_pic"
     flags: "-pie"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/libraries_to_link.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/libraries_to_link.textproto
@@ -6,6 +6,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     flag_groups {
       expand_if_available: "thinlto_param_file"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
@@ -7,6 +7,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "linker_param_file"
     flags: "@%{linker_param_file}"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/runtime_library_search_directories.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/runtime_library_search_directories.textproto
@@ -6,6 +6,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "runtime_library_search_directories"
     flag_groups {
@@ -37,6 +38,7 @@ flag_sets {
   actions: "lto-index-for-dynamic-library"
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
   flag_groups {
     expand_if_available: "runtime_library_search_directories"
     flag_groups {


### PR DESCRIPTION
Without this it's not possible to create a rules based toolchain that
supports linking top level binaries which are linked through the Apple
specific bazel APIs.
