### PR TITLE
Remove COMPILER_MSVC define

### DIFF
--- a/cc/private/toolchain/cc_toolchain_config.bzl
+++ b/cc/private/toolchain/cc_toolchain_config.bzl
@@ -798,7 +798,6 @@ def _impl(ctx):
                             flags = [
                                 "-m64",
                                 "/D__inline__=__inline",
-                                "/DCOMPILER_MSVC",
                                 "/DNOGDI",
                                 "/DNOMINMAX",
                                 "/DPRAGMA_SUPPORTED",

--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -751,7 +751,6 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                "/DCOMPILER_MSVC",
                                 "/DNOMINMAX",
                                 "/D_WIN32_WINNT=0x0601",
                                 "/D_CRT_SECURE_NO_DEPRECATE",


### PR DESCRIPTION
This causes issues with code using this string for other purposes like [glib](https://github.com/frida/glib/blob/main/gio/glib-compile-resources.c#L718).

This flag has previously been removed from other parts of the Bazel ecosystem (see https://github.com/bazelbuild/bazel/issues/5351).