### PR TITLE
Add macOS support to examples/rule_based_toolchain

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -123,3 +123,12 @@ tasks:
       - "//..."
     test_targets:
       - "//..."
+
+  macos_rule_based_toolchains:
+    name: macOS rule-based toolchains
+    platform: macos
+    working_directory: examples/rule_based_toolchain
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//..."

--- a/examples/rule_based_toolchain/.bazelrc
+++ b/examples/rule_based_toolchain/.bazelrc
@@ -1,4 +1,8 @@
 # Do not use the default toolchain.
 build --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
+# Cross compile on macOS to avoid needing a macOS sysroot
+build --enable_platform_specific_config
+build:macos --platforms=//:linux_x86_64
+
 build:gcc --//toolchains:compiler_kind=gcc

--- a/examples/rule_based_toolchain/BUILD.bazel
+++ b/examples/rule_based_toolchain/BUILD.bazel
@@ -27,3 +27,19 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)

--- a/examples/rule_based_toolchain/MODULE.bazel
+++ b/examples/rule_based_toolchain/MODULE.bazel
@@ -31,6 +31,22 @@ http_archive(
 )
 
 http_archive(
+    name = "clang-macos-aarch64",
+    build_file = "//toolchains/clang:clang.BUILD",
+    sha256 = "3cc4425e1234b558adca120aa31abb994ed6b11e0f88e0f58c43ed1723e643a6",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:0cfd03ac0d3f9713090a581bda07584754c73a49",
+)
+
+http_archive(
+    name = "clang-macos-x86_64",
+    build_file = "//toolchains/clang:clang.BUILD",
+    sha256 = "001d510113e3b24844f6b9959fcd37cc9bf7faeb966f910a592363be99d228ea",
+    type = "zip",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:0cfd03ac0d3f9713090a581bda07584754c73a49",
+)
+
+http_archive(
     name = "linux_sysroot",
     build_file = "//toolchains/clang:linux_sysroot.BUILD",
     sha256 = "f45ca0d8b46810b94d2a7dbc65f9092337d6a9568b260b51173a5ab9314da25e",

--- a/examples/rule_based_toolchain/toolchains/args/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/args/BUILD.bazel
@@ -40,3 +40,16 @@ cc_args(
     }),
     visibility = ["//visibility:public"],
 )
+
+cc_args(
+    name = "target",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = select({
+        "//constraint:linux_aarch64": ["--target=aarch64-unknown-linux-gnu"],
+        "//constraint:linux_x86_64": ["--target=x86_64-unknown-linux-gnu"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/examples/rule_based_toolchain/toolchains/clang/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/clang/BUILD.bazel
@@ -33,6 +33,7 @@ cc_toolchain(
     }) + [
         "//toolchains/args:no_absolute_paths_for_builtins",
         "//toolchains/args:warnings",
+        "//toolchains/args:target",
     ],
     enabled_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     known_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],

--- a/examples/rule_based_toolchain/toolchains/clang/args/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/clang/args/BUILD.bazel
@@ -19,6 +19,7 @@ cc_sysroot(
     data = [
         "@linux_sysroot//:root",
         "@linux_sysroot//:usr-include",
+        "@linux_sysroot//:usr-include-aarch64-linux-gnu",
         "@linux_sysroot//:usr-include-x86_64-linux-gnu",
     ],
     sysroot = "@linux_sysroot//:root",

--- a/examples/rule_based_toolchain/toolchains/clang/linux_sysroot.BUILD
+++ b/examples/rule_based_toolchain/toolchains/clang/linux_sysroot.BUILD
@@ -25,6 +25,12 @@ directory(
 )
 
 subdirectory(
+    name = "usr-include-aarch64-linux-gnu",
+    parent = ":root",
+    path = "usr/include/aarch64-linux-gnu",
+)
+
+subdirectory(
     name = "usr-include-x86_64-linux-gnu",
     parent = ":root",
     path = "usr/include/x86_64-linux-gnu",

--- a/examples/rule_based_toolchain/toolchains/clang/tools/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/clang/tools/BUILD.bazel
@@ -26,6 +26,7 @@ alias(
         "@platforms//os:macos": ":macos_tools",
         "//conditions:default": ":default_tools",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )
 
@@ -40,6 +41,7 @@ COMMON_TOOLS = {
 
 cc_tool_map(
     name = "default_tools",
+    tags = ["manual"],
     tools = COMMON_TOOLS | {
         "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
     },
@@ -48,6 +50,7 @@ cc_tool_map(
 
 cc_tool_map(
     name = "macos_tools",
+    tags = ["manual"],
     tools = COMMON_TOOLS | {
         "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-libtool-darwin",
     },
@@ -59,11 +62,14 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/clang",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/clang",
     }),
     data = [
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -71,11 +77,14 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang++",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang++",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/clang++",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/clang++",
     }),
     data = [
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -83,11 +92,14 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang++",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang++",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/clang++",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/clang++",
     }),
     data = [
         ":exec_platform_linker_builtins",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -95,8 +107,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-ar",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-ar",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-ar",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-ar",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -104,8 +119,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-libtool-darwin",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-libtool-darwin",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-libtool-darwin",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-libtool-darwin",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -113,8 +131,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-objcopy",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-objcopy",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-objcopy",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-objcopy",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -122,8 +143,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-objdump",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-objdump",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-objdump",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-objdump",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -131,8 +155,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-cov",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-cov",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-cov",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-cov",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -140,8 +167,11 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/llvm-strip",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/llvm-strip",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/llvm-strip",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/llvm-strip",
     }),
     data = [":exec_platform_multicall_support_files"],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -149,11 +179,14 @@ cc_tool(
     src = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:bin/clang-tidy",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:bin/clang-tidy",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:bin/clang-tidy",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:bin/clang-tidy",
     }),
     data = [
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 #################################
@@ -169,7 +202,10 @@ alias(
     actual = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:builtin_headers",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:builtin_headers",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:builtin_headers",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:builtin_headers",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 
@@ -178,7 +214,10 @@ alias(
     actual = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:multicall_support_files",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:multicall_support_files",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:multicall_support_files",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:multicall_support_files",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 
@@ -187,6 +226,9 @@ alias(
     actual = select({
         "//constraint:linux_aarch64": "@clang-linux-aarch64//:linker_builtins",
         "//constraint:linux_x86_64": "@clang-linux-x86_64//:linker_builtins",
+        "//constraint:macos_aarch64": "@clang-macos-aarch64//:linker_builtins",
+        "//constraint:macos_x86_64": "@clang-macos-x86_64//:linker_builtins",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )

--- a/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
@@ -33,11 +33,15 @@ cc_toolchain(
     enabled_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     known_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     make_variables = [":example_variable"],
+    tags = ["manual"],
     tool_map = "//toolchains/gcc/tools:all_tools",
 )
 
 toolchain(
     name = "host_gcc_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+    ],
     toolchain = ":host_gcc",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
     visibility = ["//visibility:public"],

--- a/examples/rule_based_toolchain/toolchains/gcc/tools/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/tools/BUILD.bazel
@@ -19,6 +19,7 @@ licenses(["notice"])
 
 cc_tool_map(
     name = "all_tools",
+    tags = ["manual"],
     tools = {
         "@rules_cc//cc/toolchains/actions:ar_actions": ":ar",
         "@rules_cc//cc/toolchains/actions:assembly_actions": ":gcc",
@@ -42,6 +43,7 @@ cc_tool(
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -53,6 +55,7 @@ cc_tool(
         ":exec_platform_builtin_headers",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -64,6 +67,7 @@ cc_tool(
         ":exec_platform_linker_builtins",
         ":exec_platform_multicall_support_files",
     ],
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -71,6 +75,7 @@ cc_tool(
     src = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:bin/x86_64-linux-ar",
     }),
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -78,6 +83,7 @@ cc_tool(
     src = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:bin/x86_64-linux-objcopy",
     }),
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -85,6 +91,7 @@ cc_tool(
     src = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:bin/x86_64-linux-objdump",
     }),
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -92,6 +99,7 @@ cc_tool(
     src = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:bin/x86_64-linux-gcov",
     }),
+    tags = ["manual"],
 )
 
 cc_tool(
@@ -99,6 +107,7 @@ cc_tool(
     src = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:bin/x86_64-linux-strip",
     }),
+    tags = ["manual"],
 )
 
 #################################
@@ -114,6 +123,7 @@ alias(
     actual = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:builtin_headers",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 
@@ -122,6 +132,7 @@ alias(
     actual = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:multicall_support_files",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )
 
@@ -130,5 +141,6 @@ alias(
     actual = select({
         "//constraint:linux_x86_64": "@gcc-linux-x86_64//:linker_builtins",
     }),
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
This makes it easier to do basic testing of rules based toolchain changes on macOS. There are a few changes here:

- Add `tags = ["manual"]` to avoid unnecessary downloads
- Add `--target` to support cross compilation
- Download clang for macOS
- Cross compile to linux to avoid the need for a macOS sysroot download