### PR TITLE
Add missing requires_not_none expansion in strip_flags

### DIFF
--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -54,4 +54,5 @@ cc_args(
     actions = ["//cc/toolchains/actions:strip"],
     args = ["{input_file}"],
     format = {"input_file": "//cc/toolchains/variables:input_file"},
+    requires_not_none = "//cc/toolchains/variables:input_file",
 )


### PR DESCRIPTION
Fixes the strip_flags expansion that broke when the input_file variable was changed to be optional.