### PR TITLE
[rule base toolchains] Set missing none_of field of FeatureConstraint

### DIFF
--- a/cc/toolchains/tool_capability.bzl
+++ b/cc/toolchains/tool_capability.bzl
@@ -48,7 +48,7 @@ def _cc_tool_capability_impl(ctx):
         ToolCapabilityInfo(label = ctx.label, feature = ft),
         # Only give it a feature constraint info and not a feature info.
         # This way you can't imply it - you can only require it.
-        FeatureConstraintInfo(label = ctx.label, all_of = depset([ft])),
+        FeatureConstraintInfo(label = ctx.label, all_of = depset([ft]), none_of = depset([])),
     ]
 
 cc_tool_capability = rule(


### PR DESCRIPTION
Not setting this field crashes in `convert_args` if the feature constraint was provided by a `cc_tool_capability`.