### PR TITLE
Add feature for external_include_paths

### DIFF
--- a/cc/toolchains/args/external_include_paths/BUILD
+++ b/cc/toolchains/args/external_include_paths/BUILD
@@ -1,5 +1,13 @@
 load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
+
+cc_feature(
+    name = "feature",
+    args = [":external_include_paths"],
+    feature_name = "external_include_paths",
+    visibility = ["//visibility:public"],
+)
 
 cc_args(
     name = "external_include_paths",


### PR DESCRIPTION
This is not enabled by default but allows users to unconditionally
enable this functionality by adding it to their enabled features.
Alternatively they can still add the cc_args to their args and manually
add a feature for use with `--features=external_include_paths` if they
need the legacy behavior
