### PR TITLE
Add bool_flag for ar flags for macOS

### DIFF
--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -1,9 +1,21 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
 load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
 
 package(default_visibility = ["//visibility:private"])
+
+bool_flag(
+    name = "use_libtool_on_macos",
+    build_setting_default = True,
+)
+
+config_setting(
+    name = "use_libtool_on_macos_setting",
+    constraint_values = ["@platforms//os:macos"],
+    flag_values = {":use_libtool_on_macos": "true"},
+)
 
 cc_feature(
     name = "feature",
@@ -26,7 +38,7 @@ cc_args(
     name = "create_static_archive",
     actions = ["//cc/toolchains/actions:ar_actions"],
     args = select({
-        "@platforms//os:macos": ["-static"],
+        ":use_libtool_on_macos_setting": ["-static"],
         "//conditions:default": ["rcsD"],
     }),
 )
@@ -35,7 +47,7 @@ cc_args(
     name = "output_execpath",
     actions = ["//cc/toolchains/actions:ar_actions"],
     args = select({
-        "@platforms//os:macos": ["-o"],
+        ":use_libtool_on_macos_setting": ["-o"],
         "//conditions:default": [],
     }) + ["{output_execpath}"],
     format = {"output_execpath": "//cc/toolchains/variables:output_execpath"},


### PR DESCRIPTION
With this users can pass
`--@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=false`
to always use ar, even when targeting macOS. This works well for
llvm-ar.

Fixes https://github.com/bazelbuild/rules_cc/issues/331
