### PR TITLE
Add objc_arc_flags

### DIFF
--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -26,6 +26,7 @@ cc_feature_set(
         "//cc/toolchains/args/shared_flag:feature",
         "//cc/toolchains/args/strip_debug_symbols:feature",
         "//cc/toolchains/args/strip_flags:feature",
+        "//cc/toolchains/args/objc_arc_flags:feature",
     ],
 )
 

--- a/cc/toolchains/args/objc_arc_flags/BUILD
+++ b/cc/toolchains/args/objc_arc_flags/BUILD
@@ -1,0 +1,26 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_feature(
+    name = "feature",
+    args = [
+        ":objc_arc",
+        ":no_objc_arc",
+    ],
+    feature_name = "_objc_arc",  # Doesn't override legacy feature, but shouldn't be disabled
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "objc_arc",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = ["-fobjc-arc"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:objc_arc",
+)
+
+cc_args(
+    name = "no_objc_arc",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = ["-fno-objc-arc"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:no_objc_arc",
+)


### PR DESCRIPTION
These have bazel variables that control if they're enabled or not, so on
the toolchain side they can be unconditional
