### PR TITLE
Make external_include_paths work automatically

### DIFF
--- a/cc/toolchains/args/external_include_paths/BUILD
+++ b/cc/toolchains/args/external_include_paths/BUILD
@@ -1,22 +1,32 @@
+#
+# To use this feature pass `--features=external_include_paths --host_features=external_include_paths`
+#
+# To enable this by default, add it to your `enabled_features`:
+#
+# enabled_features = [
+#     "@rules_cc//cc/toolchains/args/external_include_paths:feature",
+# ],
+#
+
 load("//cc/toolchains:args.bzl", "cc_args")
-load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_feature(
+    name = "feature",
+    args = [":external_include_paths"],
+    feature_name = "external_include_paths",
+    visibility = ["//visibility:public"],
+)
 
 cc_args(
     name = "external_include_paths",
     actions = ["//cc/toolchains/actions:compile_actions"],
-    nested = [":search_dir_args"],
-    requires_not_none = "//cc/toolchains/variables:external_include_paths",
-    visibility = ["//visibility:public"],
-)
-
-cc_nested_args(
-    name = "search_dir_args",
     args = [
         "-isystem",
         "{search_dir}",
     ],
-    format = {
-        "search_dir": "//cc/toolchains/variables:external_include_paths",
-    },
+    format = {"search_dir": "//cc/toolchains/variables:external_include_paths"},
     iterate_over = "//cc/toolchains/variables:external_include_paths",
+    requires_not_none = "//cc/toolchains/variables:external_include_paths",
+    visibility = ["//visibility:public"],
 )

--- a/cc/toolchains/features/BUILD
+++ b/cc/toolchains/features/BUILD
@@ -50,6 +50,7 @@ cc_feature_set(
         ":static_linking_mode",
         ":dynamic_linking_mode",
         ":static_link_cpp_runtimes",
+        "//cc/toolchains/args/external_include_paths:feature",
     ],
     visibility = ["//visibility:private"],
 )

--- a/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
+++ b/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
@@ -208,6 +208,33 @@ def _toolchain_collects_files_test(env, targets):
             )],
         ),
         legacy_feature(
+            name = "external_include_paths",
+            enabled = False,
+            flag_sets = [legacy_flag_set(
+                actions = [
+                    "assemble",
+                    "c++-compile",
+                    "c++-header-parsing",
+                    "c++-module-codegen",
+                    "c++-module-compile",
+                    "c-compile",
+                    "clif-match",
+                    "linkstamp-compile",
+                    "lto-backend",
+                    "objc++-compile",
+                    "objc-compile",
+                    "preprocess-assemble",
+                ],
+                flag_groups = [
+                    legacy_flag_group(
+                        expand_if_available = "external_include_paths",
+                        flags = ["-isystem", "%{external_include_paths}"],
+                        iterate_over = "external_include_paths",
+                    ),
+                ],
+            )],
+        ),
+        legacy_feature(
             name = "supports_pic",
             enabled = False,
         ),


### PR DESCRIPTION
This mirrors today's setup since this feature is special and must be
passed with `--features` in order to flip on behavior in bazel.
