### PR TITLE
Remove deprecations from rules based toolchain for now

### DIFF
--- a/cc/toolchains/features/legacy/BUILD
+++ b/cc/toolchains/features/legacy/BUILD
@@ -97,7 +97,6 @@ cc_external_feature(
 
 cc_external_feature(
     name = "shared_flag",
-    deprecation = "Use //cc/toolchains/args/shared_flag instead",
     feature_name = "shared_flag",
     overridable = True,
 )
@@ -116,7 +115,6 @@ cc_external_feature(
 
 cc_external_feature(
     name = "runtime_library_search_directories",
-    deprecation = "Use //cc/toolchains/args/runtime_library_search_directories instead",
     feature_name = "runtime_library_search_directories",
     overridable = True,
 )
@@ -129,21 +127,18 @@ cc_external_feature(
 
 cc_external_feature(
     name = "archiver_flags",
-    deprecation = "Use //cc/toolchains/args/archiver_flags instead",
     feature_name = "archiver_flags",
     overridable = True,
 )
 
 cc_external_feature(
     name = "libraries_to_link",
-    deprecation = "Use //cc/toolchains/args/libraries_to_link instead",
     feature_name = "libraries_to_link",
     overridable = True,
 )
 
 cc_external_feature(
     name = "force_pic_flags",
-    deprecation = "Use //cc/toolchains/args/force_pic_flags instead",
     feature_name = "force_pic_flags",
     overridable = True,
 )
@@ -219,7 +214,6 @@ cc_external_feature(
 
 cc_external_feature(
     name = "linker_param_file",
-    deprecation = "Use //cc/toolchains/args/linker_param_file instead",
     feature_name = "linker_param_file",
     overridable = True,
 )


### PR DESCRIPTION
Now that the toolchain construction goes through a cc_feature_set you
need to use these features. We can add these back once we recommend
using args instead
