### PR TITLE
Fix make variable handling in rule-based toolchain example

### DIFF
--- a/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc/toolchains:make_variable.bzl", "cc_make_variable")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 
 licenses(["notice"])
+
+cc_make_variable(
+    name = "example_variable",
+    value = "-DEXAMPLE=1",
+    variable_name = "EXAMPLE_SUBSTITUTION",
+)
 
 cc_toolchain(
     name = "host_gcc",
@@ -25,6 +32,7 @@ cc_toolchain(
     ],
     enabled_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     known_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
+    make_variables = [":example_variable"],
     tool_map = "//toolchains/gcc/tools:all_tools",
 )
 


### PR DESCRIPTION
This fixes the following error in the gcc-rule-based toolchain example introduced by the recent "Add cc_make_variable" patch.
```
ERROR: /home/mlaurin/src/bazel/rules_cc.git/examples/rule_based_toolchain/static_answer/BUILD.bazel:19:11: in cc_library rule //static_answer:answer:
Traceback (most recent call last):
File "/virtual_builtins_bzl/common/cc/cc_library.bzl", line 58, column 49, in _cc_library_impl
File "/virtual_builtins_bzl/common/cc/cc_helper.bzl", line 926, column 64, in _get_copts
File "/virtual_builtins_bzl/common/cc/cc_helper.bzl", line 911, column 37, in _expand_make_variables_for_copts
File "/virtual_builtins_bzl/common/cc/cc_helper.bzl", line 819, column 46, in _expand
File "/virtual_builtins_bzl/common/cc/cc_helper.bzl", line 765, column 26, in _expand_nested_variable
File "/virtual_builtins_bzl/common/cc/cc_helper.bzl", line 719, column 9, in _lookup_var
Error in fail: @@//static_answer:answer: $(EXAMPLE_SUBSTITUTION) not defined
ERROR: /home/mlaurin/src/bazel/rules_cc.git/examples/rule_based_toolchain/static_answer/BUILD.bazel:19:11: Analysis of target '//static_answer:answer' failed
ERROR: Analysis of target '//static_answer:answer' failed; build aborted
INFO: Elapsed time: 0.239s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
ERROR: No test targets were found, yet testing was requested
```

There was a mention of this defect in issue #395.