### PR TITLE
Fix gcc rule-based toolchain example

### DIFF
--- a/examples/rule_based_toolchain/toolchains/gcc/args/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/args/BUILD.bazel
@@ -16,6 +16,11 @@ load("@rules_cc//cc/toolchains/args:sysroot.bzl", "cc_sysroot")
 
 cc_sysroot(
     name = "linux_sysroot",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:assembly_actions",
+        "@rules_cc//cc/toolchains/actions:c_compile",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
     data = [
         "@gcc-linux-x86_64//:include-x86_64-buildroot-linux-gnu",
         "@gcc-linux-x86_64//:lib-gcc-include",


### PR DESCRIPTION
Passing the `--sysroot` argument on linking causes the following linker error

```
<PATH>/external/_main~_repo_rules~gcc-linux-x86_64/bin/../lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: cannot find /lib64/libm.so.6: No such file or directory
<PATH>external/_main~_repo_rules~gcc-linux-x86_64/bin/../lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: cannot find /lib64/libmvec.so.1: No such file or directory
collect2: error: ld returned 1 exit status
```

The cause could be tracked to the `sysroot/usr/lib` directory, where `libm.a` and `libmvec.a` reside but is not fully understood.  In any case, it seems that using copies of the files in that directory instead of symlinks does not produce the errors reported above during linking and with the `--sysroot` argument.

Passing the sysroot during the compilation but not linking succeeds. The assumption being that the paths to the sysroot are then resolved relatively to the compiler.

See also:

  https://github.com/agoessling/bazel_bootlin/blob/master/toolchains/toolchains.bzl#L204

Close issue #395