### PR TITLE
Add support for stripopts for strip_flags:feature

### DIFF
--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -16,6 +16,7 @@ cc_args_list(
     name = "strip_flags",
     args = [
         ":strip_debug",
+        ":stripopts",
         ":preserve_dates",
         ":output_file",
         ":input_file",
@@ -27,6 +28,14 @@ cc_args(
     name = "strip_debug",
     actions = ["//cc/toolchains/actions:strip"],
     args = ["-S"],
+)
+
+cc_args(
+    name = "stripopts",
+    actions = ["//cc/toolchains/actions:strip"],
+    args = ["{stripopts}"],
+    format = {"stripopts": "//cc/toolchains/variables:stripopts"},
+    iterate_over = "//cc/toolchains/variables:stripopts",
 )
 
 cc_args(


### PR DESCRIPTION
#324 introduced strip_flags as per https://github.com/bazelbuild/bazel/blob/0a9ebcf4ed0c8b59628f660f8002e6da0b325c2e/src/main/java/com/google/devtools/build/lib/rules/cpp/CppActionConfigs.java#L1358-L1371 but striopts were not implemented.