### PR TITLE
Make Windows MSVC builds actually deterministic

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -382,11 +382,8 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                "/wd4117",
-                                "-D__DATE__=\"redacted\"",
-                                "-D__TIMESTAMP__=\"redacted\"",
-                                "-D__TIME__=\"redacted\"",
-                            ] + (["-Wno-builtin-macro-redefined"] if ctx.attr.compiler == "clang-cl" else []),
+                                "/Brepro",
+                            ],
                         ),
                     ],
                 ),


### PR DESCRIPTION
Uses the `/Brepro` switch to freeze the `__DATE__`, `__TIME__`, `__TIMESTAMP__` macros, and make FileDateStamp in the PE header a hash of the resulting binary.

This undocumented switch works on both clang-cl and MSVC.

Closes https://github.com/bazelbuild/bazel/issues/5750