### PR TITLE
Move `compile_{input,output}_flags` after `compile_flags`

### DIFF
--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -36,8 +36,8 @@ cc_feature_set(
         "//cc/toolchains/args/library_search_directories:feature",
         "//cc/toolchains/args/dependency_file:feature",
         "//cc/toolchains/args/compile_flags:feature",  # NOTE: This should come below default flags so user flags can override them
-        "//cc/toolchains/args/compiler_input_flags:feature",
-        "//cc/toolchains/args/compiler_output_flags:feature",
+        "//cc/toolchains/args/compiler_input_flags:feature",  # NOTE: This should be after `compile_flags` to allow user flags like `-x c++` to apply
+        "//cc/toolchains/args/compiler_output_flags:feature",  # NOTE: This is just grouped nicely with the `input_flags`
     ],
 )
 

--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -30,14 +30,14 @@ cc_feature_set(
         "//cc/toolchains/args/soname_flags:feature",
         "//cc/toolchains/args/static_libgcc:feature",
         "//cc/toolchains/args/include_flags:feature",
-        "//cc/toolchains/args/compiler_input_flags:feature",
-        "//cc/toolchains/args/compiler_output_flags:feature",
         "//cc/toolchains/args/fission_flags:feature",
         "//cc/toolchains/args/link_flags:feature",
         "//cc/toolchains/args/linkstamp_flags:feature",
         "//cc/toolchains/args/library_search_directories:feature",
         "//cc/toolchains/args/dependency_file:feature",
         "//cc/toolchains/args/compile_flags:feature",  # NOTE: This should come below default flags so user flags can override them
+        "//cc/toolchains/args/compiler_input_flags:feature",
+        "//cc/toolchains/args/compiler_output_flags:feature",
     ],
 )
 


### PR DESCRIPTION
While we want to have the default flags before the user flags, this does not apply to the input (-c ...) and output (-o ...) flags, as this prevents the user to mark a `.c` file as `-x c++` via `copts = ..`.

`gcc` expects that flag before the last `-c ...`