### PR TITLE
Add cpp module artifact name pattern (.gcm for GCC and .pcm for others)

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1765,7 +1765,13 @@ def _impl(ctx):
     # TODO(#8303): Mac crosstool should also declare every feature.
     if is_linux:
         # Linux artifact name patterns are the default.
-        artifact_name_patterns = []
+        artifact_name_patterns = [
+            artifact_name_pattern(
+                category_name = "cpp_module",
+                prefix = "",
+                extension = ".gcm" if ctx.attr.compiler == "gcc" else ".pcm",
+            ),
+        ]
         features = [
             cpp_modules_feature,
             cpp_module_modmap_file_feature,


### PR DESCRIPTION
see https://github.com/bazelbuild/bazel/pull/22553#discussion_r2169206515