### PR TITLE
Add BAZEL_COPTS to mirror --copts

### DIFF
--- a/cc/private/toolchain/BUILD.tpl
+++ b/cc/private/toolchain/BUILD.tpl
@@ -115,6 +115,7 @@ cc_toolchain_config(
     opt_compile_flags = [%{opt_compile_flags}],
     dbg_compile_flags = [%{dbg_compile_flags}],
     conly_flags = [%{conly_flags}],
+    c_flags = [%{c_flags}],
     cxx_flags = [%{cxx_flags}],
     link_flags = [%{link_flags}],
     link_libs = [%{link_libs}],

--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -113,6 +113,7 @@ cc_autoconf = repository_rule(
         "BAZEL_COMPILER",
         "BAZEL_HOST_SYSTEM",
         "BAZEL_CONLYOPTS",
+        "BAZEL_COPTS",
         "BAZEL_CXXOPTS",
         "BAZEL_LINKOPTS",
         "BAZEL_LINKLIBS",

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -459,6 +459,12 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
         },
     )
 
+    c_opts = split_escaped(get_env_var(
+        repository_ctx,
+        "BAZEL_COPTS",
+        "",
+        False,
+    ), ":")
     conly_opts = split_escaped(get_env_var(
         repository_ctx,
         "BAZEL_CONLYOPTS",
@@ -662,6 +668,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
                 False,
             )),
             "%{conly_flags}": get_starlark_list(conly_opts),
+            "%{c_flags}": get_starlark_list(c_opts),
             "%{coverage_compile_flags}": coverage_compile_flags,
             "%{coverage_link_flags}": coverage_link_flags,
             "%{cxx_builtin_include_directories}": get_starlark_list(builtin_include_directories),

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -408,6 +408,14 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["opt"])],
             ),
             flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.c_flags,
+                    ),
+                ] if ctx.attr.c_flags else []),
+            ),
+            flag_set(
                 actions = [ACTION_NAMES.c_compile],
                 flag_groups = ([
                     flag_group(
@@ -1920,6 +1928,7 @@ cc_toolchain_config = rule(
         "compile_flags": attr.string_list(),
         "compiler": attr.string(mandatory = True),
         "conly_flags": attr.string_list(),
+        "c_flags": attr.string_list(),
         "coverage_compile_flags": attr.string_list(),
         "coverage_link_flags": attr.string_list(),
         "cpu": attr.string(mandatory = True),


### PR DESCRIPTION
This lets us fully replace --copts, --cxxopts, --conlyopts, and --linkopts with --repo_env.  When triggering transitions to other platforms, these flags apply to all platforms.  This is especially problematic when cross compiling for a different operating system.