### PR TITLE
Fix missing deps in some bzl_library targets

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -86,6 +86,7 @@ bzl_library(
     name = "find_cc_toolchain_bzl",
     srcs = ["find_cc_toolchain.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//cc/common"],
 )
 
 bzl_library(
@@ -104,6 +105,10 @@ bzl_library(
     name = "repositories_bzl",
     srcs = ["repositories.bzl"],
     visibility = ["//visibility:private"],
+    deps = [
+        "//cc/common",
+        "//cc/private/toolchain:cc_configure_bzl",
+    ],
 )
 
 bzl_library(

--- a/cc/private/toolchain/BUILD
+++ b/cc/private/toolchain/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//cc:cc_library.bzl", "cc_library")
 load("//cc/toolchains:cc_flags_supplier.bzl", "cc_flags_supplier")
 load("//cc/toolchains:compiler_flag.bzl", "compiler_flag")
@@ -86,6 +87,16 @@ filegroup(
 filegroup(
     name = "link_dynamic_library",
     srcs = ["link_dynamic_library.sh"],
+)
+
+bzl_library(
+    name = "cc_configure_bzl",
+    srcs = [
+        "cc_configure.bzl",
+        "lib_cc_configure.bzl",
+        "unix_cc_configure.bzl",
+        "windows_cc_configure.bzl",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Complete transitive deps of .bzl files are needed for tools like Stardoc.

See https://github.com/bazel-contrib/rules_go/issues/4394