### PR TITLE
Enable `/std:c++17` by default for the Windows cc toolchain

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -751,6 +751,7 @@ def _impl(ctx):
                     flag_groups = [
                         flag_group(
                             flags = [
+                                "/std:c++17",
                                 "/DNOMINMAX",
                                 "/D_WIN32_WINNT=0x0601",
                                 "/D_CRT_SECURE_NO_DEPRECATE",


### PR DESCRIPTION
Context: https://github.com/bazelbuild/bazel/issues/26523#issuecomment-3062496169