### PR TITLE
use absolute shebang for macos cc_wrapper

### DIFF
--- a/cc/private/toolchain/osx_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/osx_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
This change resolves the following issue which impacts `rules_rust` (https://github.com/bazelbuild/rules_rust/pull/3535#issuecomment-3134550603):
```
(02:58:02) ERROR: /Users/buildkite/builds/bk-macos-arm64-pz85/bazel/rules-rust-rustlang/util/process_wrapper/BUILD.bazel:31:36: Compiling Rust (without process_wrapper) bin process_wrapper (6 files) failed: (Exit 1): bootstrap_process_wrapper.sh failed: error executing Rustc command (from target //util/process_wrapper:process_wrapper)
  (cd /private/var/tmp/_bazel_buildkite/a86460401be5422e0ecc75a08e74f9e3/sandbox/darwin-sandbox/75/execroot/_main && \
  exec env - \
    CARGO_CFG_TARGET_ARCH=aarch64 \
    CARGO_CFG_TARGET_OS=macos \
    CARGO_CRATE_NAME=process_wrapper \
    CARGO_MANIFEST_DIR='${pwd}/util/process_wrapper' \
    CARGO_PKG_AUTHORS='' \
    CARGO_PKG_DESCRIPTION='' \
    CARGO_PKG_HOMEPAGE='' \
    CARGO_PKG_NAME=process_wrapper \
    CARGO_PKG_VERSION=0.0.0 \
    CARGO_PKG_VERSION_MAJOR=0 \
    CARGO_PKG_VERSION_MINOR=0 \
    CARGO_PKG_VERSION_PATCH=0 \
    CARGO_PKG_VERSION_PRE='' \
    REPOSITORY_NAME='' \
    ZERO_AR_DATE=1 \
  bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/util/process_wrapper/bootstrap_process_wrapper.sh -- bazel-out/darwin_arm64-fastbuild/bin/external/+rust+rust_macos_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain/bin/rustc util/process_wrapper/main.rs '--crate-name=process_wrapper' '--crate-type=bin' '--error-format=human' '--out-dir=bazel-out/darwin_arm64-fastbuild/bin/util/process_wrapper' '--codegen=opt-level=0' '--codegen=debuginfo=0' '--codegen=strip=none' '--remap-path-prefix=${pwd}=.' '--emit=link=bazel-out/darwin_arm64-fastbuild/bin/util/process_wrapper/process_wrapper' '--emit=dep-info' '--color=always' '--target=aarch64-apple-darwin' -L bazel-out/darwin_arm64-fastbuild/bin/external/+rust+rust_macos_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain/lib/rustlib/aarch64-apple-darwin/lib '--edition=2018' '-Cembed-bitcode=no' '--codegen=linker=external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh' '--codegen=link-arg=-mmacosx-version-min=15.2' '--codegen=link-arg=-no-canonical-prefixes' '--codegen=link-arg=-fobjc-link-runtime' '--codegen=link-arg=-headerpad_max_install_names' '--codegen=link-arg=-lc++' '--codegen=link-arg=-lm' '--extern=tinyjson=bazel-out/darwin_arm64-fastbuild/bin/external/+i+rules_rust_tinyjson/libtinyjson-2730294943.rlib' '-Ldependency=bazel-out/darwin_arm64-fastbuild/bin/external/+i+rules_rust_tinyjson' '--sysroot=bazel-out/darwin_arm64-fastbuild/bin/external/+rust+rust_macos_aarch64__aarch64-apple-darwin__stable_tools/rust_toolchain')
# Configuration: 44d823af471c00a0f331560f31c47d7492ea88dc35aa83e5331e5aab8731d666
# Execution platform: @@platforms//host:host
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error: linking with `external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh` failed: exit status: 127
  |
  = note:  "external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh" "/tmp/rustcYxWIZ7/symbols.o" "<17 object files omitted>" "/private/var/tmp/_bazel_buildkite/a86460401be5422e0ecc75a08e74f9e3/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/external/+i+rules_rust_tinyjson/{libtinyjson-2730294943.rlib}.rlib" "/private/var/tmp/_bazel_buildkite/a86460401be5422e0ecc75a08e74f9e3/external/+rust+rust_macos_aarch64__aarch64-apple-darwin__stable_tools/lib/rustlib/aarch64-apple-darwin/lib/{libstd-b14eaf39f161baba.rlib,libpanic_unwind-e9afca0624de13f2.rlib,libobject-f4f25c763c07e1da.rlib,libmemchr-f5821a4757eb4967.rlib,libaddr2line-e2075fd42f8fdfe6.rlib,libgimli-08932eb7054dd262.rlib,librustc_demangle-ed8c67e97825d1a5.rlib,libstd_detect-1047965a55c74dd5.rlib,libhashbrown-a128e33792b49d56.rlib,librustc_std_workspace_alloc-9d142a7fc6a557ed.rlib,libminiz_oxide-b5c8cae15aefe652.rlib,libadler2-458be00c7580c8fb.rlib,libunwind-ebf825f8faf836bb.rlib,libcfg_if-c920e7cfad4eac40.rlib,liblibc-b046c3bdd2263ebf.rlib,liballoc-4320d4958ec5f4d4.rlib,librustc_std_workspace_core-8e246dbdcfd33251.rlib,libcore-c8c2fe5a80a1416e.rlib,libcompiler_builtins-78f29445e315e03f.rlib}.rlib" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.0.0" "-L" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib" "-o" "bazel-out/darwin_arm64-fastbuild/bin/util/process_wrapper/process_wrapper" "-Wl,-dead_strip" "-nodefaultlibs" "-mmacosx-version-min=15.2" "-no-canonical-prefixes" "-fobjc-link-runtime" "-headerpad_max_install_names" "-lc++" "-lm"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: env: bash: No such file or directory
error: aborting due to 1 previous error
```

This change is related to https://github.com/bazelbuild/rules_cc/commit/d74915024017250e46d95e91a3defc34174effe0 where shebangs were updated but on Posix systems `/bin/sh` is expected to be consistently available so `PATH` reliance can be avoided.