### PR TITLE
Add dwp cc_action_type

### DIFF
--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -144,6 +144,11 @@ cc_action_type(
 )
 
 cc_action_type(
+    name = "dwp",
+    action_name = ACTION_NAMES.dwp,
+)
+
+cc_action_type(
     name = "validate_static_library",
     action_name = ACTION_NAMES.validate_static_library,
 )


### PR DESCRIPTION
This corresponds to
https://github.com/bazelbuild/bazel/commit/999e50f6b2be72046c7a7797f767ef7656ef5254
so you can use fission with a rules based toolchain by adding dwp to
your tools.
