### PR TITLE
Embed absolute path to bash in cc_wrapper template

### DIFF
--- a/cc/private/toolchain/linux_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/linux_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!%{bash}
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/osx_cc_wrapper.sh.tpl
+++ b/cc/private/toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!%{bash}
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -436,6 +436,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
         "cc_wrapper.sh",
         paths[cc_wrapper_src],
         {
+            "%{bash}": escape_string(repository_ctx.which("bash")),
             "%{cc}": escape_string(str(cc)),
             "%{env}": escape_string(get_env(repository_ctx)),
         },


### PR DESCRIPTION
Alternate to #448 that allows still using bash, with the absolute path resolved at templating time, see https://github.com/bazelbuild/rules_rust/pull/3535. Opened as draft for visibility but there may be other scripts that need similar patch and there should also be an error check for `repository_ctx.which("bash")` returning `None` if somehow bash is unavailable.