### PR TITLE
Pass -fobjc-link-runtime only when building with Clang

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1724,10 +1724,10 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = all_link_actions,
-                flag_groups = [flag_group(flags = [
-                    "-no-canonical-prefixes",
-                    "-fobjc-link-runtime",
-                ])],
+                flag_groups = [flag_group(
+                    flags = ["-no-canonical-prefixes"] +
+                            (["-fobjc-link-runtime"] if ctx.attr.compiler == "clang" else []),
+                )],
             ),
         ],
     )


### PR DESCRIPTION
GCC doesn’t support that flag.