### PR TITLE
Demonstrate cc_helper failure

### DIFF
--- a/tests/simple_binary/BUILD
+++ b/tests/simple_binary/BUILD
@@ -17,12 +17,12 @@ load("//cc:cc_binary.bzl", "cc_binary")
 licenses(["notice"])
 
 cc_binary(
-    name = "foo",
+    name = "bin",
     srcs = ["foo.cc"],
 )
 
 cc_binary(
-    name = "libfoo.so",
+    name = "foo",
     srcs = ["foo.cc"],
     linkshared = 1,
 )


### PR DESCRIPTION
```
Traceback (most recent call last):
        File "/home/ubuntu/dev/bazelbuild/rules_cc/cc/private/rules_impl/cc_binary.bzl", line 800, column 44, in _impl
                binary_info, providers = cc_binary_impl(ctx, [])
        File "/home/ubuntu/dev/bazelbuild/rules_cc/cc/private/rules_impl/cc_binary.bzl", line 466, column 122, in cc_binary_impl
                has_legacy_link_shared_name = _is_link_shared(ctx) and (_matches([".so", ".dylib", ".dll"], target_name) or cc_helper.is_valid_shared_library_name(target_name))
Error: 'struct' value has no field or method 'is_valid_shared_library_name'
Available attributes: build_linking_context_from_libraries, build_output_groups_for_emitting_compile_providers, build_precompiled_files, check_cpp_modules, check_srcs_extensions, collect_native_cc_libraries, copts_filter, create_cc_instrumented_files_info, create_strip_action, defines, dll_hash_suffix, extensions, generate_def_file, get_cc_flags_make_variable, get_compilation_contexts_from_deps, get_copts, get_cpp_module_interfaces, get_dynamic_libraries_for_runtime, get_expanded_env, get_linked_artifact, get_linking_contexts_from_deps, get_local_defines_for_runfiles_lookup, get_private_hdrs, get_providers, get_public_hdrs, get_srcs, get_static_mode_params_for_dynamic_library_libraries, get_toolchain_global_make_variables, get_windows_def_file_for_linking, has_target_constraints, include_dirs, is_code_coverage_enabled, is_compilation_outputs_empty, is_non_empty_list_or_select, is_stamping_enabled, is_test_target, is_valid_shared_library_artifact, linker_scripts, linkopts, local_defines, merge_cc_debug_contexts, merge_output_groups, report_invalid_options, should_create_per_object_debug_info, should_use_pic, stringify_linker_input, system_include_dirs, tokenize
ERROR: /home/ubuntu/dev/bazelbuild/rules_cc/tests/simple_binary/BUILD:24:10: Analysis of target '//tests/simple_binary:foo' (config: 2a478bf) failed
```
