### PR TITLE
Add instructions for compatibility proxy repo to release notes

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -40,5 +40,9 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_cc/releases/download/${TAG}/${ARCHIVE}",
 )
 
+load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
+
+compatibility_proxy_repo()
+
 \`\`\`
 EOF


### PR DESCRIPTION
This is loaded via `cc_binary.bzl`.