### PR TITLE
Fix absolute file paths checking for Windows

### DIFF
--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for C++ rules."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE")
 load("//cc/private/rules_impl:objc_common.bzl", "objc_common")
 load(":cc_common.bzl", "cc_common")
@@ -789,7 +790,7 @@ def _include_dirs(ctx, additional_make_variable_substitutions):
     package_source_root = _package_source_root(ctx.label.workspace_name, package, sibling_repository_layout)
     for include in ctx.attr.includes:
         includes_attr = _expand(ctx, include, additional_make_variable_substitutions)
-        if includes_attr.startswith("/"):
+        if paths.is_absolute(includes_attr):
             continue
         includes_path = get_relative_path(package_exec_path, includes_attr)
         if not sibling_repository_layout and path_contains_up_level_references(includes_path):

--- a/cc/toolchains/args.bzl
+++ b/cc/toolchains/args.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """All providers for rule-based bazel toolchain config."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 load("//cc/toolchains/impl:args_utils.bzl", "validate_nested_args")
 load(
@@ -48,7 +49,7 @@ def _cc_args_impl(ctx):
     )
 
     for path in ctx.attr.allowlist_absolute_include_directories:
-        if not path.startswith("/"):
+        if not paths.is_absolute(path):
             fail("`{}` is not an absolute paths".format(path))
 
     nested = None


### PR DESCRIPTION
This is a fix for #476 and uses `bazel_skylib`'s `is_absolute` function. I looked for other places that would need a similar fix but found only one more, so I may have missed some.