### PR TITLE
[0.1.x] Remove dependency on protobuf

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,6 @@ module(
 bazel_dep(name = "bazel_features", version = "1.28.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 
 cc_configure = use_extension("//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,13 +45,6 @@ http_archive(
 )
 
 http_archive(
-    name = "com_google_protobuf",
-    sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
-    strip_prefix = "protobuf-27.0",
-    url = "https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz",
-)
-
-http_archive(
     name = "googletest",
     integrity = "sha256-e0K01u1IgQxTYsJloX+uvpDcI3PIheUhZDnTeSfwKSY=",
     strip_prefix = "googletest-1.15.2",

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Starlark rules for building C++ projects."""
 
-load("@com_google_protobuf//bazel:cc_proto_library.bzl", _cc_proto_library = "cc_proto_library")
 load("//cc:cc_binary.bzl", _cc_binary = "cc_binary")
 load("//cc:cc_import.bzl", _cc_import = "cc_import")
 load("//cc:cc_library.bzl", _cc_library = "cc_library")
@@ -24,6 +23,7 @@ load("//cc:objc_library.bzl", _objc_library = "objc_library")
 load("//cc/common:cc_common.bzl", _cc_common = "cc_common")
 load("//cc/common:cc_info.bzl", _CcInfo = "CcInfo")
 load("//cc/common:debug_package_info.bzl", _DebugPackageInfo = "DebugPackageInfo")
+load("//cc/private/rules_impl:failing_cc_proto_library.bzl", "CC_PROTO_LIBRARY_DEPRECATION", _cc_proto_library = "cc_proto_library")
 load("//cc/toolchains:cc_flags_supplier.bzl", _cc_flags_supplier = "cc_flags_supplier")
 load("//cc/toolchains:cc_toolchain.bzl", _cc_toolchain = "cc_toolchain")
 load("//cc/toolchains:cc_toolchain_config_info.bzl", _CcToolchainConfigInfo = "CcToolchainConfigInfo")
@@ -45,10 +45,22 @@ objc_import = _objc_import
 
 # DEPRECATED: use rule from com_google_protobuf repository
 def cc_proto_library(**kwargs):
+    """Deprecated redirection macro for cc_proto_library.
+
+    Use cc_proto_library from com_google_protobuf.
+
+    On Bazel <8, redirects to native.cc_proto_library.
+    On Bazel >=8, redirects to a mock rule, that fails when analyzed.
+    This allows for a gradual migration away from this macro.
+
+    Args:
+      **kwargs: passed directly into cc_proto_library
+    """
+    __cc_proto_library = getattr(native, "cc_proto_library", _cc_proto_library)
     if "deprecation" not in kwargs:
-        _cc_proto_library(deprecation = "Use cc_proto_library from com_google_protobuf", **kwargs)
+        __cc_proto_library(deprecation = CC_PROTO_LIBRARY_DEPRECATION, **kwargs)
     else:
-        _cc_proto_library(**kwargs)
+        __cc_proto_library(**kwargs)
 
 # Toolchain rules
 

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -35,10 +35,12 @@ bzl_library(
         "cc_shared_library.bzl",
         "cc_static_library.bzl",
         "cc_test.bzl",
+        "failing_cc_proto_library.bzl",
         "objc_import.bzl",
         "objc_library.bzl",
     ],
     visibility = ["//cc:__subpackages__"],
+    deps = ["//cc/common"],
 )
 
 bzl_library(

--- a/cc/private/rules_impl/failing_cc_proto_library.bzl
+++ b/cc/private/rules_impl/failing_cc_proto_library.bzl
@@ -1,0 +1,35 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A failing cc_proto_library rule."""
+
+load("//cc/common:cc_info.bzl", "CcInfo")
+
+CC_PROTO_LIBRARY_DEPRECATION = (
+    "cc_proto_library is removed from @rules_cc//cc:defs.bzl in Bazel 8. " +
+    "Please load the implementation from https://github.com/protocolbuffers/protobuf. " +
+    "After adding the dependency to WORKSPACE or MODULE.bazel use the load statement: " +
+    '`load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")`'
+)
+
+def _impl(_ctx):
+    fail(CC_PROTO_LIBRARY_DEPRECATION)
+
+cc_proto_library = rule(
+    implementation = _impl,
+    provides = [CcInfo],
+    doc = "Do not use. The rule always fails",
+    attrs = {
+        "deps": attr.label_list(),
+    },
+)

--- a/cc/private/rules_impl/native.bzl
+++ b/cc/private/rules_impl/native.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # Redefine native symbols with a new name as a workaround for
-# exporting them in `//third_party/bazel_rules/rules_proto/proto:defs.bzl` with their original name.
+# exporting them in `@rules_cc//cc:defs.bzl` with their original name.
 #
 # While we cannot force users to load these symbol due to the lack of a
 # allowlisting mechanism, we can still export them and tell users to


### PR DESCRIPTION
Cherrypick: 4b1c73e659a95a2eddd90236b636996af0042072

Copybara Import from https://github.com/bazelbuild/rules_cc/pull/449

BEGIN_PUBLIC
Remove dependency on protobuf (#449)

This is a new attempt, which is slightly softer than before. It only fails on Bazel8 and later, because it uses native cc_proto_library, so that it doesn't need to depend on the protobuf repository.

Closes #449
END_PUBLIC

COPYBARA_INTEGRATE_REVIEW=https://github.com/bazelbuild/rules_cc/pull/449 from comius:cc-proto-library-removal-2 655d09580e59802fca299b07f2031b5c960dae65 PiperOrigin-RevId: 791120562
Change-Id: I94e82caf10d08283d4730982b2959058bed4da2d