### PR TITLE
Specify default C language version for Unix

### DIFF
--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -462,7 +462,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
     conly_opts = split_escaped(get_env_var(
         repository_ctx,
         "BAZEL_CONLYOPTS",
-        "",
+        "-std=c17",
         False,
     ), ":")
 


### PR DESCRIPTION
This is the equivalent of
https://github.com/bazelbuild/rules_cc/blob/0.2.3/cc/private/toolchain/unix_cc_configure.bzl#L472, just for C instead of C++.