### PR TITLE
Added regression testing for bzl_library trees

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -31,6 +31,14 @@ exports_files([
     "defs.bzl",
     "action_names.bzl",
     "system_library.bzl",
+    "cc_binary.bzl",
+    "cc_import.bzl",
+    "cc_library.bzl",
+    "cc_shared_library.bzl",
+    "cc_static_library.bzl",
+    "cc_test.bzl",
+    "objc_import.bzl",
+    "objc_library.bzl",
 ])
 
 # The toolchain type used to distinguish cc toolchains.

--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -14,6 +14,14 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+exports_files(
+    [
+        "cc_common.bzl",
+        "cc_info.bzl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 bzl_library(
     name = "common",
     srcs = glob(["*.bzl"]),

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -37,6 +37,76 @@ stardoc(
     deps = ["//cc/toolchains:toolchain_rules"],
 )
 
+stardoc(
+    name = "cc_binary",
+    out = "cc_binary.md",
+    input = "//cc:cc_binary.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_library",
+    out = "cc_library.md",
+    input = "//cc:cc_library.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_import",
+    out = "cc_import.md",
+    input = "//cc:cc_import.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_shared_library",
+    out = "cc_shared_library.md",
+    input = "//cc:cc_shared_library.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_static_library",
+    out = "cc_static_library.md",
+    input = "//cc:cc_static_library.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_test",
+    out = "cc_test.md",
+    input = "//cc:cc_test.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "cc_common",
+    out = "cc_common.md",
+    input = "//cc/common:cc_common.bzl",
+    deps = ["//cc/common"],
+)
+
+stardoc(
+    name = "cc_info",
+    out = "cc_info.md",
+    input = "//cc/common:cc_info.bzl",
+    deps = ["//cc/common"],
+)
+
+stardoc(
+    name = "objc_import",
+    out = "objc_import.md",
+    input = "//cc:objc_import.bzl",
+    deps = ["//cc:core_rules"],
+)
+
+stardoc(
+    name = "objc_library",
+    out = "objc_library.md",
+    input = "//cc:objc_library.bzl",
+    deps = ["//cc:core_rules"],
+)
+
 expand_template(
     name = "toolchain_api_md",
     out = "generated_toolchain_api.md",


### PR DESCRIPTION
Recent changes to `rules_cc` have lead to breakages of the `bzl_library` targets where they no longer include the full dependency graph. This change fixes the missing dependencies and adds `stardoc` targets to serve a regression test going forward.

closes https://github.com/bazelbuild/rules_cc/issues/279