### PR TITLE
Fix repo mapping lookup in runfiles library

### DIFF
--- a/cc/runfiles/runfiles.cc
+++ b/cc/runfiles/runfiles.cc
@@ -214,6 +214,9 @@ string Runfiles::Rlocation(const string& path,
   string target_apparent = path.substr(0, first_slash);
   auto lookup_key = std::make_pair(target_apparent, source_repo);
   auto lower_bound = repo_mapping_.lower_bound(lookup_key);
+  if (lower_bound == repo_mapping_.end()) {
+    return RlocationUnchecked(path, runfiles_map_, directory_);
+  }
   if (lower_bound->first == lookup_key) {
     return RlocationUnchecked(lower_bound->second + path.substr(first_slash),
                               runfiles_map_, directory_);

--- a/cc/runfiles/runfiles.cc
+++ b/cc/runfiles/runfiles.cc
@@ -218,6 +218,9 @@ string Runfiles::Rlocation(const string& path,
   // The largest entry that is less than or equal to lookup_key.
   auto floor = upper_bound == repo_mapping_.begin() ? upper_bound
                                                     : std::prev(upper_bound);
+  if (floor == repo_mapping_.end()) {
+    return RlocationUnchecked(path, runfiles_map_, directory_);
+  }
   if (floor->first == lookup_key) {
     return RlocationUnchecked(floor->second + path.substr(first_slash),
                               runfiles_map_, directory_);


### PR DESCRIPTION
The lookup of a prefix match in the repo mapping has to use "floor" semantics (largest element less or equal) and needs to check for bounds to avoid undefined behavior.