### PR TITLE
Remove libopts toolchain variable

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -482,16 +482,6 @@ def _impl(ctx):
                     ],
                 ),
                 flag_set(
-                    actions = all_link_actions,
-                    flag_groups = [
-                        flag_group(
-                            flags = ["%{libopts}"],
-                            iterate_over = "libopts",
-                            expand_if_available = "libopts",
-                        ),
-                    ],
-                ),
-                flag_set(
                     actions = all_link_actions +
                               [ACTION_NAMES.cpp_link_static_library],
                     flag_groups = [


### PR DESCRIPTION
This appears to have been removed 9 years ago https://github.com/bazelbuild/bazel/commit/a8fc49b3ce772d98e6038a619cccdba81e76ac6d
