### PR TITLE
Fix generate_modmap: use default generate_modmap

### DIFF
--- a/cc/private/rules_impl/cc_toolchain.bzl
+++ b/cc/private/rules_impl/cc_toolchain.bzl
@@ -96,7 +96,7 @@ def _attributes(ctx):
         link_dynamic_library_tool = ctx.file._link_dynamic_library_tool,
         grep_includes = grep_includes,
         aggregate_ddi = _single_file(ctx, "_aggregate_ddi"),
-        generate_modmap = ctx.attr.generate_modmap[DefaultInfo].files_to_run if getattr(ctx.attr, "generate_modmap", None) else None,
+        generate_modmap = _single_file(ctx, "_generate_modmap"),
         module_map = ctx.attr.module_map,
         as_files = _files(ctx, "as_files"),
         ar_files = _files(ctx, "ar_files"),


### PR DESCRIPTION
We previously expose generate_modmap attribute in https://github.com/bazelbuild/bazel/commit/8028655414a189b6897b1b51e3e43b5711e0af98 to support https://github.com/bazelbuild/rules_cc/pull/447 . After migrating to the Starlark implementation, this attribute is no longer needed. Remove the override and rely on the default generate_modmap behavior.