### PR TITLE
external_include_paths feature: pass /external:W0 to VC++

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -1028,6 +1028,9 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
+                            flags = ["/external:W0"],
+                        ),
+                        flag_group(
                             flags = ["/external:I%{external_include_paths}"],
                             iterate_over = "external_include_paths",
                             expand_if_available = "external_include_paths",


### PR DESCRIPTION
If /external:I but not /external:W… is passed, VC++ emits diagnostic D9007 and ignores the /external:I option,
cf. https://learn.microsoft.com/en-us/cpp/build/reference/external-external-headers-diagnostics?view=msvc-170#arguments.