### PR TITLE
Pass -D to libtool on macos

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1371,6 +1371,7 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
+                            "-D",
                             "-no_warning_for_no_symbols",
                             "-static",
                             "-o",

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -39,6 +39,7 @@ cc_args(
     actions = ["//cc/toolchains/actions:ar_actions"],
     args = select({
         ":use_libtool_on_macos_setting": [
+            "-D",
             "-no_warning_for_no_symbols",
             "-static",
         ],

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
@@ -2,6 +2,7 @@ enabled: false
 flag_sets {
   actions: "c++-link-static-library"
   flag_groups {
+    flags: "-D"
     flags: "-no_warning_for_no_symbols"
     flags: "-static"
   }


### PR DESCRIPTION
This was the default in Bazel before Starlarkification.

```
-D     When building a static library, set archive contents' user ids, group ids, dates, and file modes to reasonable defaults. This allows libraries created with identical input to be identical to
       each other, regardless of time of day, user, group, umask, and other aspects of the environment.
```