### PR TITLE
Add missing bzl_library dependencies to //cc/common

### DIFF
--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -19,6 +19,8 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
+        "@bazel_skylib//lib:paths",
+        "@cc_compatibility_proxy//:proxy_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private:paths_bzl",
         "//cc/private/rules_impl:native_bzl",


### PR DESCRIPTION
`//cc/common` is missing some dependencies in its `*.bzl` files. For whatever reason, this builds fine in the repo, but depending on the `.bzl` files with missing dependencies in downstream `bzl_library` targets causes a build failure.

This change adds some dependencies to fix it.
