### PR TITLE
Fix bzl_library deps for `//cc/common`

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -118,6 +118,7 @@ bzl_library(
     deps = [
         ":core_rules",
         "//cc/common",
+        "//cc/common:cc_helper_bzl",
         "//cc/private/rules_impl:failing_cc_proto_library_bzl",
         "//cc/toolchains:toolchain_rules",
     ],

--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -13,15 +13,28 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//cc:starlark_doc_extract_helper.bzl", "starlark_doc_extract_helper")
 
 bzl_library(
     name = "common",
-    srcs = glob(["*.bzl"]),
+    srcs = glob(
+        ["*.bzl"],
+        exclude = [
+            "cc_helper.bzl",
+            "cc_debug_helper.bzl",
+            "visibility.bzl",
+            "semantics.bzl",
+            "cc_helper_internal.bzl",
+            "cc_shared_library_info.bzl",
+        ],
+    ),
     visibility = ["//visibility:public"],
     deps = [
         "//cc/private:cc_internal_bzl",
         "//cc/private:paths_bzl",
         "//cc/private/rules_impl:native_bzl",
+        "@bazel_skylib//lib:paths",
+        "@cc_compatibility_proxy//:symbols_bzl",
     ],
 )
 
@@ -33,6 +46,32 @@ bzl_library(
         ":visibility_bzl",
         "//cc/private:paths_bzl",
         "//cc/private/rules_impl:objc_common",
+    ],
+)
+
+bzl_library(
+    name = "cc_shared_library_info_bzl",
+    srcs = ["cc_shared_library_info.bzl"],
+    visibility = ["//cc:__subpackages__"],
+    deps = [
+        "@cc_compatibility_proxy//:proxy_bzl",
+    ],
+)
+
+bzl_library(
+    name = "semantics_bzl",
+    srcs = ["semantics.bzl"],
+    visibility = ["//cc:__subpackages__"],
+)
+
+bzl_library(
+    name = "cc_helper_internal_bzl",
+    srcs = ["cc_helper_internal.bzl"],
+    visibility = ["//cc:__subpackages__"],
+    deps = [
+        "//cc/private:cc_internal_bzl",
+        "//cc/private:paths_bzl",
+        "@bazel_skylib//lib:paths",
     ],
 )
 
@@ -61,3 +100,23 @@ filegroup(
     ]),
     visibility = ["//visibility:public"],
 )
+
+# unused targets to test that we have the right bzl_library graph
+[starlark_doc_extract_helper(
+    name = f + "_doc_extract",
+    src = f,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":common",
+    ],
+) for f in glob(
+    ["*.bzl"],
+    exclude = [
+        "cc_helper.bzl",
+        "cc_debug_helper.bzl",
+        "visibility.bzl",
+        "semantics.bzl",
+        "cc_helper_internal.bzl",
+        "cc_shared_library_info.bzl",
+    ],
+)]

--- a/cc/common/cc_helper_internal.bzl
+++ b/cc/common/cc_helper_internal.bzl
@@ -285,7 +285,8 @@ def is_stamping_enabled(ctx):
         ctx: The rule context.
 
     Returns:
-    (int): 1: Always stamp the build information into the binary, even in [--nostamp][stamp] builds.
+        (int) Possible values are:
+        1: Always stamp the build information into the binary, even in [--nostamp][stamp] builds.
         This setting should be avoided, since it potentially kills remote caching for the binary and
         any downstream actions that depend on it.
         0: Always replace build information by constant values. This gives good build result caching.
@@ -350,6 +351,7 @@ def root_relative_path(file):
 
     Args:
         file: (File) The file to get the root-relative path for.
+
     Returns:
         (str) The root-relative path of the file.
     """

--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -35,11 +35,20 @@ def _compatibility_proxy_repo_impl(rctx):
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
   name = "proxy_bzl",
-  srcs = ["proxy.bzl", "symbols.bzl"],
+  srcs = ["proxy.bzl"],
   deps = [
     "@rules_cc//cc/private/rules_impl:core_rules",
     "@rules_cc//cc/private/rules_impl:toolchain_rules",
     "@rules_cc//cc/private:cc_common",
+  ],
+  visibility = ["@rules_cc//cc:__subpackages__"],
+)
+bzl_library(
+  name = "symbols_bzl",
+  srcs = ["symbols.bzl"],
+  deps = [
+    "@rules_cc//cc/private:cc_common",
+    "@rules_cc//cc/private/toolchain_config:toolchain_config_bzl",
   ],
   visibility = ["@rules_cc//cc:__subpackages__"],
 )
@@ -105,7 +114,13 @@ new_objc_provider = _ObjcInfo
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
   name = "proxy_bzl",
-  srcs = ["proxy.bzl", "symbols.bzl"],
+  srcs = ["proxy.bzl"],
+  deps = ["@rules_cc//cc/private/rules_impl:native_bzl"],
+  visibility = ["@rules_cc//cc:__subpackages__"],
+)
+bzl_library(
+  name = "symbols_bzl",
+  srcs = ["symbols.bzl"],
   deps = ["@rules_cc//cc/private/rules_impl:native_bzl"],
   visibility = ["@rules_cc//cc:__subpackages__"],
 )

--- a/cc/private/BUILD
+++ b/cc/private/BUILD
@@ -65,6 +65,7 @@ bzl_library(
         ":objc_info_bzl",
         "//cc/private/compile:compile_bzl",
         "//cc/private/link:link_bzl",
+        "//cc/private/rules_impl:cc_toolchain_info_bzl",
         "//cc/private/rules_impl:native_bzl",
         "//cc/private/toolchain_config:toolchain_config_bzl",
     ],
@@ -98,7 +99,7 @@ bzl_library(
     name = "cc_launcher_info_bzl",
     srcs = ["cc_launcher_info.bzl"],
     visibility = ["//cc:__subpackages__"],
-    deps = ["//cc/common"],
+    deps = ["//cc/common:cc_helper_internal_bzl"],
 )
 
 bzl_library(

--- a/cc/private/compile/BUILD
+++ b/cc/private/compile/BUILD
@@ -20,7 +20,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cc:action_names_bzl",
-        "//cc/common",
+        "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private/rules_impl:native_bzl",
         "@bazel_skylib//lib:paths",

--- a/cc/private/link/BUILD
+++ b/cc/private/link/BUILD
@@ -20,7 +20,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cc:action_names_bzl",
-        "//cc/common",
+        "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private/compile:compile_bzl",
         "//cc/private/rules_impl:native_bzl",

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -56,6 +56,7 @@ bzl_library(
         "//cc:action_names_bzl",
         "//cc:find_cc_toolchain_bzl",
         "//cc/common",
+        "//cc/common:cc_debug_helper_bzl",
         "@bazel_skylib//lib:paths",
         "@com_google_protobuf//bazel/common:proto_info_bzl",
     ],
@@ -106,6 +107,15 @@ bzl_library(
 bzl_library(
     name = "native_bzl",
     srcs = ["native.bzl"],
+    visibility = [
+        "//cc:__subpackages__",
+        "@cc_compatibility_proxy//:__pkg__",
+    ],
+)
+
+bzl_library(
+    name = "cc_toolchain_info_bzl",
+    srcs = ["cc_toolchain_info.bzl"],
     visibility = [
         "//cc:__subpackages__",
         "@cc_compatibility_proxy//:__pkg__",

--- a/cc/private/toolchain_config/BUILD
+++ b/cc/private/toolchain_config/BUILD
@@ -21,7 +21,7 @@ bzl_library(
     deps = [
         "//cc:action_names_bzl",
         "//cc:cc_toolchain_config_lib_bzl",
-        "//cc/common",
+        "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private/rules_impl:native_bzl",
         "@bazel_skylib//lib:paths",

--- a/cc/starlark_doc_extract_helper.bzl
+++ b/cc/starlark_doc_extract_helper.bzl
@@ -1,6 +1,6 @@
 """Indirection to avoid breaking on Bazel 6"""
 
-visibility("private")
+visibility("//cc/...")
 
 def starlark_doc_extract_helper(**kwargs):
     """Creates a starlark_doc_extract target if the native rule is available


### PR DESCRIPTION
Broken by https://github.com/bazelbuild/rules_cc/commit/b81a4f4808d05c1d9d62be90d6188b8acdc9794f

PiperOrigin-RevId: 827420944
Change-Id: I7fe78f7f718e8db281b43ab8a0d6c07f08706539