### PR TITLE
Fix `invalid linker name in argument '-fuse-ld=ld64.lld'` on macOS

### DIFF
--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -197,6 +197,8 @@ def _find_linker_path(repository_ctx, cc, linker, is_clang):
     # Extract linker path from:
     # /usr/bin/clang ...
     #  "/usr/bin/ld.lld" -pie -z ...
+    # We use the leading space and quoted path to find invocations.
+    # https://github.com/llvm/llvm-project/blob/85c78274358717e4d5d019a801decba5c1add484/clang/lib/Driver/Job.cpp#L207-L209
     invocations = [line for line in result.stderr.splitlines() if line.startswith(" \"")]
     if not invocations:
         return linker


### PR DESCRIPTION
This is caused by this extra warning being printed by the clang invocation used to detect the linker path:

```
ld64.lld: warning: directory not found for option -L/usr/local/lib
```

Fix this by making the match for the path more specific.