### PR TITLE
Align action configs with legacy ones to allow LtoBackend actions to succeed

### DIFF
--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -221,21 +221,6 @@ cc_action_type_set(
     ],
 )
 
-# TODO(zbarsky): Feels like this is wrong but it matches legacy config
-# and avoids crashes due to inaccessible variables
-cc_action_type_set(
-    name = "non_lto_backend_compile_actions",
-    actions = [
-        ":c_compile",
-        ":cpp_compile",
-        ":cpp_header_parsing",
-        ":cpp_module_compile",
-        ":clif_match",
-        ":linkstamp_compile",
-        ":preprocess_assemble",
-    ],
-)
-
 cc_action_type_set(
     name = "cpp_compile_actions",
     actions = [
@@ -250,6 +235,25 @@ cc_action_type_set(
     ],
 )
 
+# This should match `compile_actions` with `lto_backend` omitted, because `lto_backend` actions
+# do not instantiate the full set of build variables.
+cc_action_type_set(
+    name = "source_compile_actions",
+    actions = [
+        ":linkstamp_compile",
+        ":cpp_compile",
+        ":cpp_header_parsing",
+        ":cpp_module_compile",
+        ":cpp_module_codegen",
+        ":clif_match",
+        ":objcpp_compile",
+        ":preprocess_assemble",
+        ":c_compile_actions",
+        ":assembly_actions",
+        ":objc_compile",
+    ],
+)
+
 cc_action_type_set(
     name = "compile_actions",
     actions = [
@@ -257,7 +261,6 @@ cc_action_type_set(
         ":c_compile_actions",
         ":assembly_actions",
         ":objc_compile",
-        ":objcpp_compile",
     ],
 )
 

--- a/cc/toolchains/args/include_flags/BUILD
+++ b/cc/toolchains/args/include_flags/BUILD
@@ -19,7 +19,7 @@ cc_feature(
 
 cc_args(
     name = "includes_flags",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = [
         "-include",
         "{includes}",
@@ -42,7 +42,7 @@ cc_feature(
 
 cc_args(
     name = "quote_include_paths_flags",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = [
         "-iquote",
         "{quote_include_paths}",
@@ -53,7 +53,7 @@ cc_args(
 
 cc_args(
     name = "include_paths_flags",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = [
         "-I{include_paths}",
     ],
@@ -63,7 +63,7 @@ cc_args(
 
 cc_args(
     name = "system_include_paths_flags",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = [
         "-isystem",
         "{system_include_paths}",
@@ -74,7 +74,7 @@ cc_args(
 
 cc_args(
     name = "framework_include_paths_flags",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = [
         "-F{framework_include_paths}",
     ],

--- a/cc/toolchains/args/preprocessor_defines/BUILD
+++ b/cc/toolchains/args/preprocessor_defines/BUILD
@@ -11,7 +11,7 @@ cc_feature(
 
 cc_args(
     name = "preprocessor_defines",
-    actions = ["//cc/toolchains/actions:non_lto_backend_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     args = ["-D{preprocessor_defines}"],
     format = {"preprocessor_defines": "//cc/toolchains/variables:preprocessor_defines"},
     iterate_over = "//cc/toolchains/variables:preprocessor_defines",

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -65,7 +65,7 @@ cc_variable(
 
 cc_variable(
     name = "framework_include_paths",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.list(types.directory),
 )
 
@@ -90,13 +90,13 @@ cc_variable(
 
 cc_variable(
     name = "include_paths",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.list(types.directory),
 )
 
 cc_variable(
     name = "includes",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.option(types.list(types.file)),
 )
 
@@ -366,7 +366,7 @@ cc_variable(
 
 cc_variable(
     name = "preprocessor_defines",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.list(types.string),
 )
 
@@ -378,7 +378,7 @@ cc_variable(
 
 cc_variable(
     name = "quote_include_paths",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.list(types.directory),
 )
 
@@ -423,7 +423,7 @@ cc_variable(
 
 cc_variable(
     name = "system_include_paths",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     type = types.list(types.directory),
 )
 

--- a/tests/rule_based_toolchain/args/BUILD
+++ b/tests/rule_based_toolchain/args/BUILD
@@ -83,7 +83,7 @@ util.helper_target(
 util.helper_target(
     cc_args,
     name = "bad_env_format_list",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions"],
     env = {"FOO": "{preprocessor_defines}"},
     format = {"preprocessor_defines": "//cc/toolchains/variables:preprocessor_defines"},
     tags = ["manual"],


### PR DESCRIPTION
This matches how it was previously setup: https://github.com/bazelbuild/rules_cc/blob/933844609a1c1f0ea0ddb64c28d463e901f36f57/cc/private/toolchain_config/legacy_features.bzl#L169-L187

Without this, we get:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.AssertionError: LtoBackendAction command line expansion cannot fail
	at com.google.devtools.build.lib.rules.cpp.LtoBackendAction.computeKey(LtoBackendAction.java:288)
	at com.google.devtools.build.lib.actions.ActionKeyComputer.getKey(ActionKeyComputer.java:43)
	at com.google.devtools.build.lib.actions.ActionCacheChecker.mustExecute(ActionCacheChecker.java:575)
	at com.google.devtools.build.lib.actions.ActionCacheChecker.getTokenIfNeedToExecute(ActionCacheChecker.java:507)
	at com.google.devtools.build.lib.skyframe.SkyframeActionExecutor.checkActionCache(SkyframeActionExecutor.java:764)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.checkCacheAndExecuteIfNeeded(ActionExecutionFunction.java:706)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.computeInternal(ActionExecutionFunction.java:345)
	at com.google.devtools.build.lib.skyframe.ActionExecutionFunction.compute(ActionExecutionFunction.java:202)
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:471)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:435)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.compute(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask$InterruptibleTask.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: com.google.devtools.build.lib.actions.CommandLineExpansionException: Invalid toolchain configuration: Cannot find variable named 'preprocessor_defines'.
	at com.google.devtools.build.lib.rules.cpp.LtoBackendArtifacts$1.arguments(LtoBackendArtifacts.java:129)
	at com.google.devtools.build.lib.rules.cpp.LtoBackendArtifacts$1.arguments(LtoBackendArtifacts.java:109)
	at com.google.devtools.build.lib.actions.CommandLines.allArguments(CommandLines.java:171)
	at com.google.devtools.build.lib.analysis.actions.SpawnAction.getArguments(SpawnAction.java:208)
	at com.google.devtools.build.lib.rules.cpp.LtoBackendAction.computeKey(LtoBackendAction.java:286)
```

I now have this fully working e2e at https://github.com/cerisier/toolchains_llvm_bootstrapped/pull/56/files#diff-cce4f0083471dff12279a3b4e3b3206404e4932a3d60f3443c0f60900706093e so happy to contribute those feature targets as well if someone tells me where to put them :)