### PR TITLE
Add provides CcInfo to objc_library

### DIFF
--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -136,4 +136,5 @@ in binary targets that depend on this library."""),
     fragments = ["objc", "apple", "cpp"],
     cfg = semantics.apple_crosstool_transition,
     toolchains = use_cc_toolchain() + cc_semantics.get_runtimes_toolchain(),
+    provides = [CcInfo],
 )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel/issues/21893
