### PR TITLE
Silence warning with parse_headers

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -522,7 +522,6 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.cpp_module_codegen,
                     ACTION_NAMES.cpp_module_deps_scanning,
@@ -535,6 +534,17 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = ["-c", "%{source_file}"],
+                        expand_if_available = "source_file",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_header_parsing,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{source_file}"],
                         expand_if_available = "source_file",
                     ),
                 ],


### PR DESCRIPTION
```
clang -xc++-header -fsyntax-only -c foo.h
clang: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
```

This just no longer passes the `-c` to the header parsing action
