### PR TITLE
Make libtool archives hermetic on macOS

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1377,6 +1377,7 @@ def _impl(ctx):
                         flags = [
                             "-no_warning_for_no_symbols",
                             "-static",
+                            "-D",
                             "-o",
                             "%{output_execpath}",
                         ],

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -41,6 +41,7 @@ cc_args(
         ":use_libtool_on_macos_setting": [
             "-no_warning_for_no_symbols",
             "-static",
+            "-D",
         ],
         "//conditions:default": ["rcsD"],
     }),

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
@@ -4,6 +4,7 @@ flag_sets {
   flag_groups {
     flags: "-no_warning_for_no_symbols"
     flags: "-static"
+    flags: "-D"
   }
 }
 flag_sets {


### PR DESCRIPTION
Without this flag the archives have timestamps, user ids, and group ids.
