### PR TITLE
Fix use_lto_native_object_directory path issue

### DIFF
--- a/cc/private/link/lto_indexing_action.bzl
+++ b/cc/private/link/lto_indexing_action.bzl
@@ -93,7 +93,7 @@ def create_lto_artifacts_and_lto_indexing_action(
     lto_output_root_prefix = root_relative_path(output) + ".lto" if allow_lto_indexing else "shared.nonlto"
     lto_obj_root_prefix = lto_output_root_prefix
     if feature_configuration.is_enabled("use_lto_native_object_directory"):
-        lto_obj_root_prefix = lto_output_root_prefix + "-obj"
+        lto_obj_root_prefix = "shared.nonlto-obj"
     object_file_inputs = compilation_outputs.pic_objects if use_pic else compilation_outputs.objects
 
     all_lto_artifacts = create_lto_backends(


### PR DESCRIPTION
This path changed in the starlarkification commit

Before: https://github.com/bazelbuild/bazel/blob/4dae9ffbe331bd8a7a449e9fe1198a25ca7f0679/src/main/java/com/google/devtools/build/lib/rules/cpp/CppLinkActionBuilder.java#L541-L545

After: https://github.com/bazelbuild/bazel/blob/4dae9ffbe331bd8a7a449e9fe1198a25ca7f0679/src/main/starlark/builtins_bzl/common/cc/link/lto_indexing_action.bzl#L89-L90

I believe this is meant to be the same path across all uses of this
feature, which also use this path: https://github.com/bazelbuild/rules_cc/blob/2a18367fa71b9c0fe0325d65171e9d9e70d59990/cc/private/link/finalize_link_action.bzl#L121-L122
