### PR TITLE
Prefix cxx_builtin_include_directories with %workspace%

### DIFF
--- a/cc/toolchains/impl/legacy_converter.bzl
+++ b/cc/toolchains/impl/legacy_converter.bzl
@@ -204,7 +204,7 @@ def convert_toolchain(toolchain):
     ))
 
     cxx_builtin_include_directories = [
-        d.path
+        "%workspace%/" + d.path
         for d in toolchain.allowlist_include_directories.to_list()
     ]
     cxx_builtin_include_directories += toolchain.allowlist_absolute_include_directories.to_list()


### PR DESCRIPTION
When passing a directory as a sysroot, the files in the sysroot must be
added here. Previously just the raw relative path such as
`external/sysroot/` was set, which bazel still errored on with
undeclared inclusions. By prefixing this with `%workspace%` bazel is
happy.

Since we're always passing some bazel target here, this seems safe.
