### PR TITLE
Remove the false impresion that some bzl files are not public

### DIFF
--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -41,7 +41,6 @@ bzl_library(
     deps = [
         ":cc_helper_internal_bzl",
         ":common",
-        ":visibility_bzl",
         "//cc:find_cc_toolchain_bzl",
         "//cc/private:paths_bzl",
         "//cc/private/rules_impl:objc_common",
@@ -80,15 +79,8 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         ":cc_helper_bzl",
-        ":visibility_bzl",
         "//cc:find_cc_toolchain_bzl",
     ],
-)
-
-bzl_library(
-    name = "visibility_bzl",
-    srcs = ["visibility.bzl"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(

--- a/cc/common/cc_debug_helper.bzl
+++ b/cc/common/cc_debug_helper.bzl
@@ -17,9 +17,8 @@ load("//cc:action_names.bzl", "ACTION_NAMES")
 load("//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE")
 load(":cc_common.bzl", "cc_common")
 load(":cc_helper.bzl", "linker_mode")
-load(":visibility.bzl", "INTERNAL_VISIBILITY")
 
-visibility(INTERNAL_VISIBILITY)
+visibility("public")
 
 def create_debug_packager_actions(
         ctx,

--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -30,9 +30,8 @@ load(
     _repository_exec_path = "repository_exec_path",
 )
 load(":cc_info.bzl", "CcInfo")
-load(":visibility.bzl", "INTERNAL_VISIBILITY")
 
-visibility(INTERNAL_VISIBILITY)
+visibility("public")
 
 # LINT.IfChange(linker_mode)
 linker_mode = struct(

--- a/cc/common/visibility.bzl
+++ b/cc/common/visibility.bzl
@@ -1,3 +1,0 @@
-"""Bzl load visibility package specs"""
-
-INTERNAL_VISIBILITY = ["public"]


### PR DESCRIPTION
The value of INTERNAL_VISIBILIY variable was changed to public. However, the name of the variable seems to imply that it is not public. Removing it makes that clear.