### PR TITLE
Make rule-based toolchain providers publicly available

### DIFF
--- a/cc/toolchains/cc_toolchain_info.bzl
+++ b/cc/toolchains/cc_toolchain_info.bzl
@@ -13,14 +13,7 @@
 # limitations under the License.
 """All providers for rule-based bazel toolchain config."""
 
-# Until the providers are stabilized, ensure that rules_cc is the only place
-# that can access the providers directly.
-# Once it's stabilized, we *may* consider opening up parts of the API, or we may
-# decide to just require users to use the public user-facing rules.
-visibility([
-    "//cc/toolchains/...",
-    "//tests/rule_based_toolchain/...",
-])
+visibility("public")
 
 # Note that throughout this file, we never use a list. This is because mutable
 # types cannot be stored in depsets. Thus, we type them as a sequence in the


### PR DESCRIPTION
This is required to implement #517

For details see #525