### PR TITLE
Only enable archiver flags if output_execpath set

### DIFF
--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -45,6 +45,7 @@ cc_args(
         ],
         "//conditions:default": ["rcsD"],
     }),
+    requires_not_none = "//cc/toolchains/variables:output_execpath",
 )
 
 cc_args(

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
@@ -2,6 +2,7 @@ enabled: false
 flag_sets {
   actions: "c++-link-static-library"
   flag_groups {
+    expand_if_available: "output_execpath"
     flags: "-D"
     flags: "-no_warning_for_no_symbols"
     flags: "-static"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
@@ -2,6 +2,7 @@ enabled: false
 flag_sets {
   actions: "c++-link-static-library"
   flag_groups {
+    expand_if_available: "output_execpath"
     flags: "rcsD"
   }
 }


### PR DESCRIPTION
Updates the rule-based toolchain arguments to only expand `rcsD` and the `libtool` equivalent flags if the `output_execpath` cc compile variable is set. This matches the behavior in `unix_cc_toolchain_config.bzl`.