### PR TITLE
Do not pass -p flag to strip on windows

### DIFF
--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -43,6 +43,7 @@ cc_args(
     actions = ["//cc/toolchains/actions:strip"],
     args = select({
         "@platforms//os:macos": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-p"],
     }),
 )


### PR DESCRIPTION
I suspect this was ported from unix_toolchain but this flag does not work on windows