### PR TITLE
Make archiver_flags public

### DIFF
--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -9,12 +9,14 @@ package(default_visibility = ["//visibility:private"])
 bool_flag(
     name = "use_libtool_on_macos",
     build_setting_default = True,
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "use_libtool_on_macos_setting",
     constraint_values = ["@platforms//os:macos"],
     flag_values = {":use_libtool_on_macos": "true"},
+    visibility = ["//visibility:public"],
 )
 
 cc_feature(


### PR DESCRIPTION
Downstream toolchains need to use these to align the AR tool with the flags. 