### PR TITLE
Fix exec transition handling in cc tool_map for multiplatform builds

### DIFF
--- a/cc/toolchains/tool.bzl
+++ b/cc/toolchains/tool.bzl
@@ -65,7 +65,6 @@ cc_tool = rule(
     attrs = {
         "src": attr.label(
             allow_files = True,
-            cfg = "exec",
             doc = """The underlying binary that this tool represents.
 
 Usually just a single prebuilt (eg. @toolchain//:bin/clang), but may be any
@@ -124,11 +123,10 @@ Example:
 load("//cc/toolchains:tool.bzl", "cc_tool")
 
 cc_tool(
-    name = "clang_tool",
+    name = "clang",
     src = "@llvm_toolchain//:bin/clang",
     # Suppose clang needs libc to run.
     data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
-    tags = ["requires-network"],
     capabilities = ["//cc/toolchains/capabilities:supports_pic"],
 )
 ```


### PR DESCRIPTION
These extra exec transitions are harmful because they allow Bazel to select a _different_ exec platform than the one the toolchain is being used on. This means when host != exec (say Windows host, Linux remote), the wrong compiler can be picked and the build fails.

Without this patch, users who want to support multiplatform builds need to hack it by forcing the tools to transition to the correct exec platform, since the toolchain "forgets". See [example workaround being reverted](https://github.com/dzbarsky/toolchains_llvm_bootstrapped/pull/2/commits/ea3f261d933d702bdec98ddd8ecf081ae306568b) and CI works when [patch is applied](https://github.com/dzbarsky/toolchains_llvm_bootstrapped/pull/2/commits/970164f03f5802e30b2d9c3c9af2efc5bece2a54)

While I was here I cleaned up the example a bit to be more like the canonical usage of `cc_tool`.