### PR TITLE
Fix CcSharedLibraryInfo loads

### DIFF
--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -130,7 +130,6 @@ bzl_library(
         rctx.file(
             "proxy.bzl",
             """
-load("@rules_cc//cc/private/rules_impl:native.bzl", "NativeCcSharedLibraryInfo")
 cc_binary = native.cc_binary
 cc_import = native.cc_import
 cc_library = native.cc_library
@@ -145,8 +144,6 @@ memprof_profile = getattr(native, "memprof_profile", None) # only in Bazel 7+
 propeller_optimize = native.propeller_optimize
 cc_toolchain = native.cc_toolchain
 cc_toolchain_alias = native.cc_toolchain_alias
-
-CcSharedLibraryInfo = NativeCcSharedLibraryInfo
             """,
         )
         rctx.file(
@@ -164,6 +161,7 @@ DebugPackageInfo = NativeDebugPackageInfo
 CcToolchainConfigInfo = NativeCcToolchainConfigInfo
 ObjcInfo = apple_common.Objc
 new_objc_provider = apple_common.new_objc_provider
+CcSharedLibraryInfo = NativeCcSharedLibraryInfo
             """,
         )
 


### PR DESCRIPTION
Based on `cc/common/cc_shared_library_info.bzl:load("@cc_compatibility_proxy//:symbols.bzl", _CcSharedLibraryInfo = "CcSharedLibraryInfo")` this symbol was in the wrong file. Now it's aligned with the bazel9 case.

Fixes #550