### PR TITLE
cc_toolchain's tool_map should be cfg-exec-configured

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -176,7 +176,10 @@ tasks:
       - "--enable_bzlmod"
       - "--ignore_dev_dependency"
 
-  ubuntu_rule_based_toolchains:
+# Rules-based toolchains
+  ubuntu_rule_based_toolchains_bazel_7:
+    name: Ubuntu rule-based toolchains (Bazel 7)
+    bazel: 7.2.1
     name: Ubuntu rule-based toolchains
     platform: ubuntu1804
     working_directory: examples/rule_based_toolchain
@@ -187,8 +190,53 @@ tasks:
     test_targets:
       - "//..."
 
-  macos_rule_based_toolchains:
-    name: macOS rule-based toolchains
+  ubuntu_rule_based_toolchains_bazel_8:
+    name: Ubuntu rule-based toolchains (Bazel 8)
+    bazel: 8.5.0
+    platform: ubuntu1804
+    working_directory: examples/rule_based_toolchain
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+
+  ubuntu_rule_based_toolchains_bazel_9:
+    name: Ubuntu rule-based toolchains (Bazel 9)
+    bazel: 9.0.0rc3
+    platform: ubuntu1804
+    working_directory: examples/rule_based_toolchain
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+
+  macos_rule_based_toolchains_bazel_7:
+    name: macOS rule-based toolchains (Bazel 7)
+    bazel: 7.2.1
+    platform: macos
+    working_directory: examples/rule_based_toolchain
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//..."
+
+  macos_rule_based_toolchains_bazel_8:
+    name: macOS rule-based toolchains (Bazel 8)
+    bazel: 8.5.0
+    platform: macos
+    working_directory: examples/rule_based_toolchain
+    build_flags:
+      - "--enable_bzlmod"
+    build_targets:
+      - "//..."
+
+  macos_rule_based_toolchains_bazel_9:
+    name: macOS rule-based toolchains (Bazel 9)
+    bazel: 9.0.0rc3
     platform: macos
     working_directory: examples/rule_based_toolchain
     build_flags:

--- a/cc/private/rules_impl/cc_toolchain.bzl
+++ b/cc/private/rules_impl/cc_toolchain.bzl
@@ -29,7 +29,9 @@ ToolchainInfo = platform_common.ToolchainInfo
 TemplateVariableInfo = platform_common.TemplateVariableInfo
 
 LEGACY_ACTION_SET_DEPS = [
-    action for actions in LEGACY_FILE_GROUPS.values() for action in actions
+    action
+    for actions in LEGACY_FILE_GROUPS.values()
+    for action in actions
 ]
 
 def _files(ctx, attr_name):
@@ -122,7 +124,8 @@ def _attributes(ctx):
         legacy_file_groups = {}
         for group, actions in LEGACY_FILE_GROUPS.items():
             action_targets = [
-                legacy_action_set_lookup[action] for action in actions
+                legacy_action_set_lookup[action]
+                for action in actions
             ]
             legacy_file_groups[group] = depset(transitive = [
                 toolchain_config_info.files[action]
@@ -384,7 +387,7 @@ The label of the rule providing <code>cc_toolchain_config_info</code>.""",
             providers = [ActionTypeSetInfo],
         ),
     } | CC_TOOLCHAIN_CONFIG_PUBLIC_ATTRS | {
-        # Override tool_map to make it optional.
+        # Override tool_map to make it optional and exec-configured.
         "tool_map": attr.label(
             cfg = "exec",
             providers = [ToolConfigInfo],

--- a/cc/toolchains/BUILD
+++ b/cc/toolchains/BUILD
@@ -28,6 +28,7 @@ bzl_library(
         "//cc/private/rules_impl:toolchain_rules",
         "//cc/private/rules_impl/fdo:fdo_rules",
         "//cc/toolchains/impl:toolchain_impl_rules",
+        "@bazel_features//:features",
         "@bazel_skylib//rules/directory:glob",
         "@cc_compatibility_proxy//:proxy_bzl",
     ],

--- a/cc/toolchains/cc_toolchain_info.bzl
+++ b/cc/toolchains/cc_toolchain_info.bzl
@@ -18,6 +18,7 @@
 # Once it's stabilized, we *may* consider opening up parts of the API, or we may
 # decide to just require users to use the public user-facing rules.
 visibility([
+    "//cc/private/rules_impl/...",
     "//cc/toolchains/...",
     "//tests/rule_based_toolchain/...",
 ])

--- a/cc/toolchains/impl/collect.bzl
+++ b/cc/toolchains/impl/collect.bzl
@@ -22,6 +22,7 @@ load(
 )
 
 visibility([
+    "//cc/private/rules_impl/...",
     "//cc/toolchains/...",
     "//tests/rule_based_toolchain/...",
 ])

--- a/cc/toolchains/impl/utils.bzl
+++ b/cc/toolchains/impl/utils.bzl
@@ -1,0 +1,21 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""All providers for rule-based bazel toolchain config."""
+
+load("@bazel_features//private:util.bzl", _bazel_version_ge = "ge")
+
+visibility("public")
+
+def bazel_supports_starlarkified_cc_toolchains():
+    return _bazel_version_ge("9.0.0-pre.20250911")

--- a/cc/toolchains/legacy_file_group.bzl
+++ b/cc/toolchains/legacy_file_group.bzl
@@ -1,4 +1,4 @@
-# Copyright 2018 The Bazel Authors. All rights reserved.
+# Copyright 2026 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cc/toolchains/legacy_file_group.bzl
+++ b/cc/toolchains/legacy_file_group.bzl
@@ -1,0 +1,46 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""""Mapping of legacy file groups"""
+
+# Taken from https://bazel.build/docs/cc-toolchain-config-reference#actions
+# TODO: This is best-effort. Update this with the correct file groups once we
+#  work out what actions correspond to what file groups.
+LEGACY_FILE_GROUPS = {
+    "ar_files": [
+        Label("//cc/toolchains/actions:ar_actions"),
+    ],
+    "as_files": [
+        Label("//cc/toolchains/actions:assembly_actions"),
+    ],
+    "compiler_files": [
+        Label("//cc/toolchains/actions:cc_flags_make_variable"),
+        Label("//cc/toolchains/actions:c_compile"),
+        Label("//cc/toolchains/actions:cpp_compile"),
+        Label("//cc/toolchains/actions:cpp_header_parsing"),
+    ],
+    # There are no actions listed for coverage and objcopy in action_names.bzl.
+    "coverage_files": [],
+    "dwp_files": [
+        Label("//cc/toolchains/actions:dwp"),
+    ],
+    "linker_files": [
+        Label("//cc/toolchains/actions:cpp_link_dynamic_library"),
+        Label("//cc/toolchains/actions:cpp_link_nodeps_dynamic_library"),
+        Label("//cc/toolchains/actions:cpp_link_executable"),
+    ],
+    "objcopy_files": [],
+    "strip_files": [
+        Label("//cc/toolchains/actions:strip"),
+    ],
+}

--- a/cc/toolchains/tool_map.bzl
+++ b/cc/toolchains/tool_map.bzl
@@ -18,6 +18,7 @@ load(
     "collect_provider",
     "collect_tools",
 )
+load("//cc/toolchains/impl:utils.bzl", "bazel_supports_starlarkified_cc_toolchains")
 load(
     ":cc_toolchain_info.bzl",
     "ActionTypeSetInfo",
@@ -56,7 +57,7 @@ See //cc/toolchains/actions:BUILD for valid options.
         ),
         "tools": attr.label_list(
             mandatory = True,
-            cfg = "exec",
+            cfg = "target" if bazel_supports_starlarkified_cc_toolchains() else "exec",
             allow_files = True,
             doc = """The tool to use for the specified actions.
 

--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Implementation of the cc_toolchain rule."""
 
-load("@bazel_features//private:util.bzl", _bazel_version_ge = "ge")
 load("//cc/toolchains:cc_toolchain.bzl", _cc_toolchain = "cc_toolchain")
 load("//cc/toolchains:legacy_file_group.bzl", "LEGACY_FILE_GROUPS")
 load(
@@ -21,8 +20,19 @@ load(
     "cc_legacy_file_group",
     "cc_toolchain_config",
 )
+load("//cc/toolchains/impl:utils.bzl", "bazel_supports_starlarkified_cc_toolchains")
 
 visibility("public")
+
+_CPU = select({
+    Label("//cc/toolchains/impl:darwin_aarch64"): "darwin_arm64",
+    Label("//cc/toolchains/impl:darwin_x86_64"): "darwin_x86_64",
+    Label("//cc/toolchains/impl:linux_aarch64"): "aarch64",
+    Label("//cc/toolchains/impl:linux_x86_64"): "k8",
+    Label("//cc/toolchains/impl:windows_x86_32"): "win32",
+    Label("//cc/toolchains/impl:windows_x86_64"): "win64",
+    "//conditions:default": "",
+})
 
 def cc_toolchain(
         *,
@@ -134,7 +144,7 @@ def cc_toolchain(
 
     cc_toolchain_visibility = kwargs.pop("visibility", default = None)
 
-    if _bazel_version_ge("9.0.0-pre.20250911"):
+    if bazel_supports_starlarkified_cc_toolchains():
         _cc_toolchain(
             name = name,
             tool_map = tool_map,
@@ -144,15 +154,7 @@ def cc_toolchain(
             known_features = known_features,
             enabled_features = enabled_features,
             compiler = compiler,
-            cpu = select({
-                Label("//cc/toolchains/impl:darwin_aarch64"): "darwin_arm64",
-                Label("//cc/toolchains/impl:darwin_x86_64"): "darwin_x86_64",
-                Label("//cc/toolchains/impl:linux_aarch64"): "aarch64",
-                Label("//cc/toolchains/impl:linux_x86_64"): "k8",
-                Label("//cc/toolchains/impl:windows_x86_32"): "win32",
-                Label("//cc/toolchains/impl:windows_x86_64"): "win64",
-                "//conditions:default": "",
-            }),
+            cpu = _CPU,
             dynamic_runtime_lib = dynamic_runtime_lib,
             libc_top = libc_top,
             module_map = module_map,
@@ -178,15 +180,7 @@ def cc_toolchain(
         known_features = known_features,
         enabled_features = enabled_features,
         compiler = compiler,
-        cpu = select({
-            Label("//cc/toolchains/impl:darwin_aarch64"): "darwin_arm64",
-            Label("//cc/toolchains/impl:darwin_x86_64"): "darwin_x86_64",
-            Label("//cc/toolchains/impl:linux_aarch64"): "aarch64",
-            Label("//cc/toolchains/impl:linux_x86_64"): "k8",
-            Label("//cc/toolchains/impl:windows_x86_32"): "win32",
-            Label("//cc/toolchains/impl:windows_x86_64"): "win64",
-            "//conditions:default": "",
-        }),
+        cpu = _CPU,
         visibility = ["//visibility:private"],
         **kwargs
     )

--- a/examples/rule_based_toolchain/MODULE.bazel
+++ b/examples/rule_based_toolchain/MODULE.bazel
@@ -4,7 +4,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_cc")
 local_path_override(

--- a/examples/rule_based_toolchain/quick_test.cc
+++ b/examples/rule_based_toolchain/quick_test.cc
@@ -27,5 +27,6 @@ TEST(Dynamic, ProperlyLinked) {
 }
 
 TEST(Asm, ProperlyLinked) {
-  EXPECT_EQ(asm_answer, 0xFE4B67C4);
+  constexpr int kExpectedAsmAnswer = static_cast<int>(0xFE4B67C4u);
+  EXPECT_EQ(asm_answer, kExpectedAsmAnswer);
 }

--- a/examples/rule_based_toolchain/toolchains/clang/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/clang/BUILD.bazel
@@ -35,10 +35,17 @@ cc_toolchain(
         "//toolchains/args:warnings",
         "//toolchains/args:target",
     ],
+    compiler = "clang",
     enabled_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     known_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     make_variables = [":example_variable"],
-    tool_map = "//toolchains/clang/tools:all_tools",
+    # This `select` happens under the target configuration. For macOS,
+    # llvm-libtool-darwin should be used when creating static libraries even if the
+    # exec platform is linux.
+    tool_map = select({
+        "@platforms//os:macos": "//toolchains/clang/tools:macos_tools",
+        "//conditions:default": "//toolchains/clang/tools:default_tools",
+    }),
 )
 
 toolchain(

--- a/examples/rule_based_toolchain/toolchains/clang/tools/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/clang/tools/BUILD.bazel
@@ -17,19 +17,6 @@ load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 
 licenses(["notice"])
 
-# This `select` happens under the target configuration. For macOS,
-# llvm-libtool-darwin should be used when creating static libraries even if the
-# exec platform is linux.
-alias(
-    name = "all_tools",
-    actual = select({
-        "@platforms//os:macos": ":macos_tools",
-        "//conditions:default": ":default_tools",
-    }),
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
 COMMON_TOOLS = {
     "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
     "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
@@ -45,7 +32,7 @@ cc_tool_map(
     tools = COMMON_TOOLS | {
         "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
     },
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 cc_tool_map(
@@ -54,7 +41,7 @@ cc_tool_map(
     tools = COMMON_TOOLS | {
         "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-libtool-darwin",
     },
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 cc_tool(

--- a/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
@@ -30,6 +30,7 @@ cc_toolchain(
         "//toolchains/args:no_absolute_paths_for_builtins",
         "//toolchains/args:warnings",
     ],
+    compiler = "gcc",
     enabled_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     known_features = ["@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features"],
     make_variables = [":example_variable"],

--- a/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
+++ b/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
@@ -178,13 +178,6 @@ def _toolchain_collects_files_test(env, targets):
     tc.files().get(targets.c_compile[ActionTypeInfo]).contains_exactly(_COLLECTED_C_COMPILE_FILES)
     tc.files().get(targets.cpp_compile[ActionTypeInfo]).contains_exactly(_COLLECTED_CPP_COMPILE_FILES)
 
-    env.expect.that_target(
-        targets.collects_files_c_compile,
-    ).default_outputs().contains_exactly(_COLLECTED_C_COMPILE_FILES)
-    env.expect.that_target(
-        targets.collects_files_cpp_compile,
-    ).default_outputs().contains_exactly(_COLLECTED_CPP_COMPILE_FILES)
-
     legacy = convert_toolchain(tc.actual)
     env.expect.that_collection(legacy.features).contains_exactly([
         legacy_feature(
@@ -263,8 +256,6 @@ TARGETS = [
     "//tests/rule_based_toolchain/actions:cpp_compile",
     ":builtin_feature",
     ":compile_tool_map",
-    ":collects_files_c_compile",
-    ":collects_files_cpp_compile",
     ":collects_files_toolchain_config",
     ":compile_feature",
     ":c_compile_args",


### PR DESCRIPTION
However, it's not enough for `tool_map` to be on `cc_toolchain_config` - it must be on the toolchain itself to properly share the same exec platform as the action requesting the toolchain. Therefore we rearrange the implementation of the `cc_toolchain` macro to pass it to the rule, and teach the rule to accept it from either the attribute or the `cc_toolchain_config.` Eventually, `cc_toolchain_config` can be retired, though it will be a long journey.