### PR TITLE
Added GCC toolchain patch to fix the linker scripts for libc.so and libm.so.

### DIFF
--- a/examples/rule_based_toolchain/MODULE.bazel
+++ b/examples/rule_based_toolchain/MODULE.bazel
@@ -57,6 +57,10 @@ http_archive(
 http_archive(
     name = "gcc-linux-x86_64",
     build_file = "//toolchains/gcc:gcc.BUILD",
+    patches = [
+        "//toolchains/gcc:patchs/libc.so.patch",
+        "//toolchains/gcc:patchs/libm.so.patch",
+    ],
     integrity = "sha256-kygjypo+Bn5+KimBCmZtIMnMW7VQ3pR/aHnjis4aqVU=",
     strip_prefix = "x86-64--glibc--stable-2024.05-1",
     urls = ["https://toolchains.bootlin.com/downloads/releases/toolchains/x86-64/tarballs/x86-64--glibc--stable-2024.05-1.tar.xz"],

--- a/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
+++ b/examples/rule_based_toolchain/toolchains/gcc/BUILD.bazel
@@ -16,7 +16,7 @@ load("@rules_cc//cc/toolchains:make_variable.bzl", "cc_make_variable")
 load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 
 licenses(["notice"])
-
+exports_files(glob(["patchs/*.patch"]))
 cc_make_variable(
     name = "example_variable",
     value = "-DEXAMPLE=1",

--- a/examples/rule_based_toolchain/toolchains/gcc/patchs/libc.so.patch
+++ b/examples/rule_based_toolchain/toolchains/gcc/patchs/libc.so.patch
@@ -1,0 +1,8 @@
+--- x86_64-buildroot-linux-gnu/sysroot/usr/lib/libc.so	2025-12-20 10:56:49.263016218 +0000
++++ x86_64-buildroot-linux-gnu/sysroot/usr/lib/libc.so	2025-12-20 10:57:10.713016082 +0000
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf64-x86-64)
+-GROUP ( /lib64/libc.so.6 /usr/lib64/libc_nonshared.a  AS_NEEDED ( /lib64/ld-linux-x86-64.so.2 ) )
++GROUP ( libc.so.6 libc_nonshared.a  AS_NEEDED ( ld-linux-x86-64.so.2 ) )

--- a/examples/rule_based_toolchain/toolchains/gcc/patchs/libm.so.patch
+++ b/examples/rule_based_toolchain/toolchains/gcc/patchs/libm.so.patch
@@ -1,0 +1,8 @@
+--- x86_64-buildroot-linux-gnu/sysroot/usr/lib/libm.so	2025-12-20 10:23:21.186653789 +0000
++++ x86_64-buildroot-linux-gnu/sysroot/usr/lib/libm.so	2025-12-20 10:23:38.186652581 +0000
+@@ -1,4 +1,4 @@
+ /* GNU ld script
+ */
+ OUTPUT_FORMAT(elf64-x86-64)
+-GROUP ( /lib64/libm.so.6  AS_NEEDED ( /lib64/libmvec.so.1 ) )
++GROUP ( libm.so.6  AS_NEEDED ( libmvec.so.1 ) )


### PR DESCRIPTION
```
➜ /workspaces/rules_cc/examples/rule_based_toolchain (main) $ bazel build --config=gcc :quick_test
INFO: Analyzed target //:quick_test (2 packages loaded, 5541 targets configured).
INFO: From Linking quick_test:
/home/codespace/.cache/bazel/_bazel_codespace/3580036953c5d36d0e83906c15f52e80/external/+_repo_rules+gcc-linux-x86_64/bin/../lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: warning: asm_answer.o: missing .note.GNU-stack section implies executable stack
/home/codespace/.cache/bazel/_bazel_codespace/3580036953c5d36d0e83906c15f52e80/external/+_repo_rules+gcc-linux-x86_64/bin/../lib/gcc/x86_64-buildroot-linux-gnu/13.3.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
INFO: Found 1 target...
Target //:quick_test up-to-date:
  bazel-bin/quick_test
INFO: Elapsed time: 38.822s, Critical Path: 6.98s
INFO: 25 processes: 8 action cache hit, 3 internal, 22 linux-sandbox.
INFO: Build completed successfully, 25 total actions
```