### PR TITLE
Expose compiler constraint values in public API

### DIFF
--- a/cc/compiler/BUILD
+++ b/cc/compiler/BUILD
@@ -45,6 +45,54 @@ load("//cc/toolchains:compiler_flag.bzl", "compiler_flag")
 
 package(default_visibility = ["//visibility:public"])
 
+# Constraint setting and values for platform-based toolchain selection.
+# Use these in your platform() definitions to constrain by compiler type.
+#
+# Example:
+#   platform(
+#       name = "windows_clang_cl",
+#       constraint_values = [
+#           "@platforms//os:windows",
+#           "@rules_cc//cc/compiler:clang-cl",
+#       ],
+#   )
+
+constraint_setting(
+    name = "cc_compiler",
+    # This is the canonical location for compiler constraint values.
+    # The values in cc/private/toolchain are aliases to these for backward compatibility.
+)
+
+constraint_value(
+    name = "clang_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
+    name = "gcc_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
+    name = "msvc_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
+    name = "clang-cl_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
+    name = "mingw_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
+constraint_value(
+    name = "msys_constraint",
+    constraint_setting = ":cc_compiler",
+)
+
 licenses(["notice"])
 
 compiler_flag(name = "compiler")

--- a/cc/private/toolchain/BUILD
+++ b/cc/private/toolchain/BUILD
@@ -21,37 +21,51 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-# It is frequently necessary to constrain platforms based on the cc compiler type.
-constraint_setting(name = "cc_compiler")
+# DEPRECATED: Use //cc/compiler:cc_compiler and //cc/compiler:<compiler>_constraint instead.
+# These aliases are kept for backward compatibility.
+#
+# Prefer using the public API in //cc/compiler:
+#   @rules_cc//cc/compiler:cc_compiler (constraint_setting)
+#   @rules_cc//cc/compiler:clang_constraint
+#   @rules_cc//cc/compiler:gcc_constraint
+#   @rules_cc//cc/compiler:msvc_constraint
+#   @rules_cc//cc/compiler:clang-cl_constraint
+#   @rules_cc//cc/compiler:mingw_constraint
+#   @rules_cc//cc/compiler:msys_constraint
 
-constraint_value(
+alias(
+    name = "cc_compiler",
+    actual = "//cc/compiler:cc_compiler",
+)
+
+alias(
     name = "clang",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:clang_constraint",
 )
 
-constraint_value(
+alias(
     name = "gcc",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:gcc_constraint",
 )
 
-constraint_value(
+alias(
     name = "msvc",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:msvc_constraint",
 )
 
-constraint_value(
+alias(
     name = "clang-cl",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:clang-cl_constraint",
 )
 
-constraint_value(
+alias(
     name = "mingw",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:mingw_constraint",
 )
 
-constraint_value(
+alias(
     name = "msys",
-    constraint_setting = ":cc_compiler",
+    actual = "//cc/compiler:msys_constraint",
 )
 
 cc_library(

--- a/cc/private/toolchain/BUILD.windows.tpl
+++ b/cc/private/toolchain/BUILD.windows.tpl
@@ -660,7 +660,7 @@ toolchain(
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:windows",
-        "@rules_cc//cc/private/toolchain:clang-cl",
+        "@rules_cc//cc/compiler:clang-cl_constraint",
     ],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
@@ -732,7 +732,7 @@ toolchain(
     name = "cc-toolchain-arm64_windows-clang-cl",
     exec_compatible_with = [
         "@platforms//os:windows",
-        "@rules_cc//cc/private/toolchain:clang-cl",
+        "@rules_cc//cc/compiler:clang-cl_constraint",
     ],
     target_compatible_with = [
         "@platforms//cpu:arm64",


### PR DESCRIPTION
## Summary
- Adds public `constraint_setting` and `constraint_value` targets to `//cc/compiler`
- Converts `cc/private/toolchain` constraints to aliases for backward compatibility
- Updates `BUILD.windows.tpl` to use new public paths

## Problem
Users who need to define platforms constrained by compiler type currently have to reference `@rules_cc//cc/private/toolchain:clang-cl` (and similar), which:
1. Exposes private implementation details
2. Behaves inconsistently between Bazel 7 and 8 with bzlmod
3. Is not documented as the canonical location

## Solution
Users can now use the public API:
```python
platform(
    name = "windows_clang_cl",
    constraint_values = [
        "@platforms//os:windows",
        "@rules_cc//cc/compiler:clang-cl_constraint",
    ],
)
```

## Test plan
- [x] `bazel build //cc/compiler:all //cc/private/toolchain:all` succeeds
- [x] Backward compatibility maintained via aliases

Fixes #330