### PR TITLE
Mark `objc_compilation_support` as publicly visible

### DIFF
--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -106,12 +106,7 @@ bzl_library(
 bzl_library(
     name = "objc_compilation_support_bzl",
     srcs = ["objc_compilation_support.bzl"],
-    visibility = [
-        "//cc:__subpackages__",
-        "//third_party/bazel_rules/rules_apple/apple:__subpackages__",
-        "@build_bazel_rules_apple//apple:__subpackages__",
-        "@rules_apple//apple:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":objc_common",
         "//cc/common:cc_helper_bzl",


### PR DESCRIPTION
We need this to support Bazel 9+ (see: https://github.com/bazelbuild/rules_apple/pull/2862)