### PR TITLE
Add additional required files by rules_apple to cc/common bzl_library

### DIFF
--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -19,10 +19,14 @@ bzl_library(
     name = "common",
     srcs = [
         "cc_common.bzl",
+        "cc_helper.bzl",
+        "cc_helper_internal.bzl",
         "cc_info.bzl",
         "cc_shared_library_hint_info.bzl",
         "debug_package_info.bzl",
         "objc_info.bzl",
+        "semantics.bzl",
+        "visibility.bzl",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -96,7 +96,7 @@ bzl_library(
         "objc_intermediate_artifacts.bzl",
         "objc_semantics.bzl",
     ],
-    visibility = ["//cc:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "//cc/common",
         "@bazel_skylib//lib:paths",


### PR DESCRIPTION
Similar to #568. Required as rules_apple depends on .bzl using these, without this change `stardoc` extract fails