### PR TITLE
Move providers out of native.bzl

### DIFF
--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -28,7 +28,6 @@ bzl_library(
     deps = [
         "//cc/private:cc_internal_bzl",
         "//cc/private:paths_bzl",
-        "//cc/private/rules_impl:native_bzl",
         "@bazel_skylib//lib:paths",
         "@cc_compatibility_proxy//:symbols_bzl",
     ],

--- a/cc/extensions.bzl
+++ b/cc/extensions.bzl
@@ -116,13 +116,15 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
   name = "proxy_bzl",
   srcs = ["proxy.bzl"],
-  deps = ["@rules_cc//cc/private/rules_impl:native_bzl"],
   visibility = ["@rules_cc//cc:__subpackages__"],
 )
 bzl_library(
   name = "symbols_bzl",
   srcs = ["symbols.bzl"],
-  deps = ["@rules_cc//cc/private/rules_impl:native_bzl"],
+  deps = [
+      "@rules_cc//cc/private/rules_impl:native_cc_common_bzl",
+      "@rules_cc//cc/private/rules_impl:native_providers_bzl",
+  ],
   visibility = ["@rules_cc//cc:__subpackages__"],
 )
             """,
@@ -149,12 +151,11 @@ cc_toolchain_alias = native.cc_toolchain_alias
         rctx.file(
             "symbols.bzl",
             """
-load("@rules_cc//cc/private/rules_impl:native.bzl", "native_cc_common")
-load("@rules_cc//cc/private/rules_impl:native.bzl", "NativeCcInfo")
-load("@rules_cc//cc/private/rules_impl:native.bzl", "NativeDebugPackageInfo")
-load("@rules_cc//cc/private/rules_impl:native.bzl", "NativeCcToolchainConfigInfo")
-load("@rules_cc//cc/private/rules_impl:native.bzl", "NativeCcSharedLibraryInfo")
-
+load("@rules_cc//cc/private/rules_impl:native_cc_common.bzl", "native_cc_common")
+load("@rules_cc//cc/private/rules_impl:native_providers.bzl", "NativeCcInfo")
+load("@rules_cc//cc/private/rules_impl:native_providers.bzl", "NativeDebugPackageInfo")
+load("@rules_cc//cc/private/rules_impl:native_providers.bzl", "NativeCcToolchainConfigInfo")
+load("@rules_cc//cc/private/rules_impl:native_providers.bzl", "NativeCcSharedLibraryInfo")
 cc_common = native_cc_common
 CcInfo = NativeCcInfo
 DebugPackageInfo = NativeDebugPackageInfo

--- a/cc/private/BUILD
+++ b/cc/private/BUILD
@@ -66,7 +66,6 @@ bzl_library(
         "//cc/private/compile:compile_bzl",
         "//cc/private/link:link_bzl",
         "//cc/private/rules_impl:cc_toolchain_info_bzl",
-        "//cc/private/rules_impl:native_bzl",
         "//cc/private/toolchain_config:toolchain_config_bzl",
     ],
 )

--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -37,7 +37,7 @@ load("//cc/private/link:link.bzl", "link")
 load("//cc/private/link:link_build_variables.bzl", "create_link_variables")
 load("//cc/private/link:lto_backends.bzl", "create_lto_backend_artifacts", "setup_common_lto_variables")
 load("//cc/private/rules_impl:cc_toolchain_info.bzl", "CcToolchainInfo")
-load("//cc/private/rules_impl:native.bzl", _cc_common_internal = "native_cc_common")
+load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 load("//cc/private/toolchain_config:cc_toolchain_config_info.bzl", "create_cc_toolchain_config_info")
 load("//cc/private/toolchain_config:configure_features.bzl", "configure_features")
 

--- a/cc/private/compile/BUILD
+++ b/cc/private/compile/BUILD
@@ -22,7 +22,7 @@ bzl_library(
         "//cc:action_names_bzl",
         "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
-        "//cc/private/rules_impl:native_bzl",
+        "//cc/private/rules_impl:native_cc_common_bzl",
         "@bazel_skylib//lib:paths",
     ],
 )

--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -18,7 +18,7 @@ All build variables we create for various `CppCompileAction`s
 
 load("//cc/common:cc_helper_internal.bzl", "extensions", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
 load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
-load("//cc/private/rules_impl:native.bzl", _cc_common_internal = "native_cc_common")
+load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 
 # deliberately short name for less clutter while using in this file, we can have
 # a different symbol with a more descriptive name if we ever export this

--- a/cc/private/link/BUILD
+++ b/cc/private/link/BUILD
@@ -23,7 +23,7 @@ bzl_library(
         "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private/compile:compile_bzl",
-        "//cc/private/rules_impl:native_bzl",
+        "//cc/private/rules_impl:native_cc_common_bzl",
         "@bazel_skylib//lib:paths",
     ],
 )

--- a/cc/private/link/cpp_link_action.bzl
+++ b/cc/private/link/cpp_link_action.bzl
@@ -21,7 +21,7 @@ load("//cc/private/link:finalize_link_action.bzl", "finalize_link_action")
 load("//cc/private/link:link_build_variables.bzl", "setup_linking_variables")
 load("//cc/private/link:lto_backends.bzl", "create_shared_non_lto_artifacts")
 load("//cc/private/link:target_types.bzl", "LINK_TARGET_TYPE", "USE_ARCHIVER", "USE_LINKER", "is_dynamic_library")
-load("//cc/private/rules_impl:native.bzl", _cc_common_internal = "native_cc_common")
+load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 
 def link_action(
         *,

--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -21,7 +21,7 @@ load("//cc/private/link:collect_solib_dirs.bzl", "collect_solib_dirs")
 load("//cc/private/link:create_libraries_to_link_values.bzl", "add_libraries_to_link", "add_object_files_to_link", "process_objects_for_lto")
 load("//cc/private/link:link_build_variables.bzl", "setup_common_linking_variables")
 load("//cc/private/link:target_types.bzl", "LINKING_MODE", "LINK_TARGET_TYPE", "USE_ARCHIVER", "USE_LINKER", "is_dynamic_library")
-load("//cc/private/rules_impl:native.bzl", _cc_common_internal = "native_cc_common")
+load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 
 def finalize_link_action(
         actions,

--- a/cc/private/link/lto_backends.bzl
+++ b/cc/private/link/lto_backends.bzl
@@ -34,7 +34,7 @@ step process:
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//cc/common:cc_helper_internal.bzl", "should_create_per_object_debug_info")
 load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
-load("//cc/private/rules_impl:native.bzl", _cc_common_internal = "native_cc_common")
+load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 
 LtoBackendArtifactsInfo = provider(
     doc = "LtoBackendArtifacts represents a set of artifacts for a single ThinLTO backend compile.",

--- a/cc/private/rules_impl/BUILD
+++ b/cc/private/rules_impl/BUILD
@@ -119,8 +119,17 @@ bzl_library(
 )
 
 bzl_library(
-    name = "native_bzl",
-    srcs = ["native.bzl"],
+    name = "native_cc_common_bzl",
+    srcs = ["native_cc_common.bzl"],
+    visibility = [
+        "//cc:__subpackages__",
+        "@cc_compatibility_proxy//:__pkg__",
+    ],
+)
+
+bzl_library(
+    name = "native_providers_bzl",
+    srcs = ["native_providers.bzl"],
     visibility = [
         "//cc:__subpackages__",
         "@cc_compatibility_proxy//:__pkg__",

--- a/cc/private/rules_impl/native_cc_common.bzl
+++ b/cc/private/rules_impl/native_cc_common.bzl
@@ -1,0 +1,18 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Native implementation of cc_common."""
+
+# buildifier: disable=native-cc-common
+native_cc_common = cc_common

--- a/cc/private/rules_impl/native_providers.bzl
+++ b/cc/private/rules_impl/native_providers.bzl
@@ -14,10 +14,6 @@
 #
 # Redefine native symbols with a new name as a workaround for
 # exporting them in `@rules_cc//cc:defs.bzl` with their original name.
-#
-# While we cannot force users to load these symbol due to the lack of a
-# allowlisting mechanism, we can still export them and tell users to
-# load it to make a future migration to pure Starlark easier.
 """Lovely workaround to be able to expose native constants pretending to be Starlark."""
 
 # buildifier: disable=native-cc-info
@@ -28,9 +24,6 @@ NativeDebugPackageInfo = DebugPackageInfo
 
 # buildifier: disable=native-cc-toolchain-config-info
 NativeCcToolchainConfigInfo = CcToolchainConfigInfo
-
-# buildifier: disable=native-cc-common
-native_cc_common = cc_common
 
 # buildifier: disable=native-cc-shared-library-info
 NativeCcSharedLibraryInfo = CcSharedLibraryInfo

--- a/cc/private/toolchain_config/BUILD
+++ b/cc/private/toolchain_config/BUILD
@@ -23,7 +23,6 @@ bzl_library(
         "//cc:cc_toolchain_config_lib_bzl",
         "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
-        "//cc/private/rules_impl:native_bzl",
         "@bazel_skylib//lib:paths",
     ],
 )

--- a/cc/toolchains/BUILD
+++ b/cc/toolchains/BUILD
@@ -24,7 +24,6 @@ bzl_library(
         "//cc:find_cc_toolchain_bzl",
         "//cc/private:paths_bzl",
         "//cc/private/rules_impl:cc_flags_supplier_lib_bzl",
-        "//cc/private/rules_impl:native_bzl",
         "//cc/private/rules_impl:toolchain_rules",
         "//cc/private/rules_impl/fdo:fdo_rules",
         "//cc/toolchains/impl:toolchain_impl_rules",
@@ -38,7 +37,7 @@ bzl_library(
     srcs = ["cc_toolchain_config_info.bzl"],
     visibility = ["//cc:__subpackages__"],
     deps = [
-        "//cc/private/rules_impl:native_bzl",
+        "@cc_compatibility_proxy//:symbols_bzl",
     ],
 )
 


### PR DESCRIPTION
This is necessary to make referencing these symbols a descriptive error in Bazel with autoload disabled. Native `cc_common` is still used by rules_cc and must not fail in the same way.

Work towards https://github.com/bazelbuild/bazel/issues/27684
Related to https://github.com/bazelbuild/bazel/pull/28360