### PR TITLE
Avoid `-Wunused-command-line-argument` warnings in header parsing actions

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -128,7 +128,9 @@ def parse_headers_support(parse_headers_tool_path):
                                 # disable parsing.
                                 "-xc++-header",
                                 "-fsyntax-only",
+                                "%{source_file}",
                             ],
+                            expand_if_available = "source_file",
                         ),
                     ],
                 ),
@@ -530,7 +532,6 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                     ACTION_NAMES.cpp_module_codegen,
                     ACTION_NAMES.cpp_module_deps_scanning,


### PR DESCRIPTION
Since clang 20 (https://github.com/llvm/llvm-project/commit/1efcc532bab505db079bd3becffe32f742287c71), clang will report a warning that options like `-c` are unused when using `-fsyntax-only`. This leads to a lot of spam when running the parse headers action:
```
INFO: From Compiling libc/hdr/types/clock_t.h:
clang-21: warning: argument unused during compilation: '-c' [-Wunused-command-line-argument]
```
To avoid using `-c` with `-fsyntax-only`, remove the header parsing action from the compiler_input_flags feature, and having the header parsing action itself expand `%{source_file}` so it can do so w/o the `-c`.