### PR TITLE
Make main_output public API

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -84,7 +84,7 @@ def _link(
         whole_archive = _UNBOUND,
         additional_linkstamp_defines = _UNBOUND,
         always_link = _UNBOUND,
-        main_output = _UNBOUND,
+        main_output = None,
         use_shareable_artifact_factory = _UNBOUND,
         build_config = _UNBOUND,
         emit_interface_shared_library = _UNBOUND):
@@ -98,7 +98,6 @@ def _link(
        whole_archive != _UNBOUND or \
        additional_linkstamp_defines != _UNBOUND or \
        always_link != _UNBOUND or \
-       main_output != _UNBOUND or \
        use_shareable_artifact_factory != _UNBOUND or \
        build_config != _UNBOUND or \
        emit_interface_shared_library != _UNBOUND:
@@ -118,8 +117,6 @@ def _link(
         additional_linkstamp_defines = []
     if always_link == _UNBOUND:
         always_link = False
-    if main_output == _UNBOUND:
-        main_output = None
     if use_shareable_artifact_factory == _UNBOUND:
         use_shareable_artifact_factory = False
     if build_config == _UNBOUND:


### PR DESCRIPTION
This API allows creating shared libraries with custom filenames, not
just the default pattern. This is required to write a rule that produces
python native extensions which have entirely different output naming
formats than standard shared libraries.

This API has been around for years now so I assume it's well understood
enough and there isn't a clear alternative.
