### PR TITLE
Add missing DEPS_SCANNER_OUTPUT_FILE env entry for msvc toolchain

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -1178,6 +1178,20 @@ def _impl(ctx):
                     ],
                 ),
             ],
+            env_sets = [
+                env_set(
+                    actions = [
+                        ACTION_NAMES.cpp_module_deps_scanning,
+                    ],
+                    env_entries = [
+                        env_entry(
+                            key = "DEPS_SCANNER_OUTPUT_FILE",
+                            value = "%{output_file}",
+                            expand_if_available = "output_file",
+                        ),
+                    ],
+                ),
+            ],
         )
 
         nologo_feature = feature(


### PR DESCRIPTION
Looks to have been missed in #428 for msvc