### PR TITLE
Only pass profile-correction flag on GCC

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -98,7 +98,13 @@ lto_index_actions = [
 def _use_msvc_toolchain(ctx):
     return ctx.attr.cpu in ["x64_windows", "arm64_windows"] and (ctx.attr.compiler == "msvc-cl" or ctx.attr.compiler == "clang-cl")
 
+def _is_gcc_compiler(compiler):
+    return "gcc" in compiler
+
 def _impl(ctx):
+    profile_correction_flags = (
+        ["-fprofile-correction"] if _is_gcc_compiler(ctx.attr.compiler) else []
+    )
     if _use_msvc_toolchain(ctx):
         artifact_name_patterns = [
             artifact_name_pattern(
@@ -1547,8 +1553,7 @@ def _impl(ctx):
                             flag_group(
                                 flags = [
                                     "-fprofile-use=%{fdo_profile_path}",
-                                    "-fprofile-correction",
-                                ],
+                                ] + profile_correction_flags,
                                 expand_if_available = "fdo_profile_path",
                             ),
                         ],

--- a/cc/private/toolchain_config/cc_toolchain_config_info.bzl
+++ b/cc/private/toolchain_config/cc_toolchain_config_info.bzl
@@ -102,7 +102,12 @@ def create_cc_toolchain_config_info(
             default_compile_flags = ([f for f in features if f.name == "default_compile_flags"])[0]
             legacy_features.append(default_compile_flags)
         platform = "mac" if target_libc == "macosx" else "linux"
-        legacy_features.extend(get_legacy_features(platform, feature_names, linker_tool_path))
+        legacy_features.extend(get_legacy_features(
+            platform,
+            feature_names,
+            linker_tool_path,
+            compiler,
+        ))
         legacy_features.extend([f for f in features if f.name not in ["legacy_compile_flags", "default_compile_flags"]])
         legacy_features.extend(get_features_to_appear_last(feature_names))
 

--- a/cc/private/toolchain_config/legacy_features.bzl
+++ b/cc/private/toolchain_config/legacy_features.bzl
@@ -26,7 +26,10 @@ load(
     "with_feature_set",
 )
 
-def get_legacy_features(platform, existing_feature_names, linker_tool_path):
+def _is_gcc_compiler(compiler):
+    return "gcc" in compiler
+
+def get_legacy_features(platform, existing_feature_names, linker_tool_path, compiler):
     """The features added to all legacy toolchains
 
     Note: these features won't be added to the crosstools that defines
@@ -37,10 +40,14 @@ def get_legacy_features(platform, existing_feature_names, linker_tool_path):
         platform: (str) One of 'linux' or 'mac'
         existing_feature_names: ([str])
         linker_tool_path: (str)
+        compiler: (str) The compiler identifier (e.g. 'gcc', 'clang').
 
     Returns:
         ([FeatureInfo])
     """
+    profile_correction_flags = (
+        ["-fprofile-correction"] if _is_gcc_compiler(compiler) else []
+    )
     result = []
     if "legacy_compile_flags" not in existing_feature_names:
         result.append(feature(
@@ -285,8 +292,7 @@ def get_legacy_features(platform, existing_feature_names, linker_tool_path):
                         "-fprofile-use=%{fdo_profile_path}",
                         "-Wno-profile-instr-unprofiled",
                         "-Wno-profile-instr-out-of-date",
-                        "-fprofile-correction",
-                    ],
+                    ] + profile_correction_flags,
                 )],
             )],
         ))
@@ -326,8 +332,7 @@ def get_legacy_features(platform, existing_feature_names, linker_tool_path):
                         "-fprofile-use=%{fdo_profile_path}",
                         "-Wno-profile-instr-unprofiled",
                         "-Wno-profile-instr-out-of-date",
-                        "-fprofile-correction",
-                    ],
+                    ] + profile_correction_flags,
                 )],
             )],
         ))
@@ -364,8 +369,7 @@ def get_legacy_features(platform, existing_feature_names, linker_tool_path):
                     expand_if_available = "fdo_profile_path",
                     flags = [
                         "-fauto-profile=%{fdo_profile_path}",
-                        "-fprofile-correction",
-                    ],
+                    ] + profile_correction_flags,
                 )],
             )],
         ))


### PR DESCRIPTION
This is a GCC flag, Clang emits a warning and ignores it.