### PR TITLE
[feat] add support for dwo_files in DebugPackageInfo on bazel 9

### DIFF
--- a/cc/common/cc_debug_helper.bzl
+++ b/cc/common/cc_debug_helper.bzl
@@ -44,6 +44,8 @@ def create_debug_packager_actions(
         linking_mode: (str) See cc_helper.bzl%linker_mode
         use_pic: (bool)
         lto_artifacts: ([CcLtoBackendArtifacts])
+    Returns:
+        dwo_files: (depset) The dwo_files used to generate the dwp_output
     """
     dwo_files = _collect_transitive_dwo_artifacts(
         cc_compilation_outputs,
@@ -62,7 +64,7 @@ def create_debug_packager_actions(
     dwo_files_list = dwo_files.to_list()
     if len(dwo_files_list) == 0:
         ctx.actions.write(dwp_output, "", False)
-        return
+        return dwo_files
 
     # We apply a hierarchical action structure to limit the maximum number of inputs to any
     # single action.
@@ -98,6 +100,7 @@ def create_debug_packager_actions(
         inputs = packager["inputs"],
         outputs = packager["outputs"],
     )
+    return dwo_files
 
 def _collect_transitive_dwo_artifacts(cc_compilation_outputs, cc_debug_context, linking_mode, use_pic, lto_backend_artifacts):
     dwo_files = []

--- a/cc/private/debug_package_info.bzl
+++ b/cc/private/debug_package_info.bzl
@@ -22,5 +22,6 @@ DebugPackageInfo = provider(
         "stripped_file": "The stripped file (the explicit '.stripped' target).",
         "unstripped_file": "The unstripped file (the default executable target).",
         "dwp_file": "The .dwp file (for fission builds) or null if --fission=no.",
+        "dwo_files": "The depset of .dwo files (for fission builds) or null if --fission=no",
     },
 )

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -706,7 +706,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     stripped_file = ctx.outputs.stripped_binary
     cc_helper.create_strip_action(ctx, cc_toolchain, cpp_config, binary, stripped_file, feature_configuration)
     dwp_file = ctx.outputs.dwp_file
-    create_debug_packager_actions(
+    dwo_files = create_debug_packager_actions(
         ctx,
         cc_toolchain,
         dwp_file,
@@ -810,6 +810,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         stripped_file = stripped_file,
         unstripped_file = binary,
         dwp_file = explicit_dwp_file,
+        dwo_files = dwo_files,
     )
     binary_info = struct(
         files = files_to_build,

--- a/tests/debug_files/BUILD
+++ b/tests/debug_files/BUILD
@@ -1,0 +1,5 @@
+load("//tests/debug_files:dwo_files_test.bzl", "dwo_files_test_suite")
+
+# Call a macro that defines targets that perform the tests at analysis time,
+# and that can be executed with "bazel test" to return the result.
+dwo_files_test_suite(name = "dwo_files_test")

--- a/tests/debug_files/dwo_files_test.bzl
+++ b/tests/debug_files/dwo_files_test.bzl
@@ -1,0 +1,89 @@
+""" This module tests the DebugInfoProvider dwo_files functionality
+
+"""
+
+load("@bazel_features//private:util.bzl", _bazel_version_ge = "ge")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc/common:debug_package_info.bzl", "DebugPackageInfo")
+
+def _test_n_dwo_files(ctx, n):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+
+    # We check if the dwp_file exists as a way to test
+    # if we should expect dwo files to be present
+    if target_under_test[DebugPackageInfo].dwp_file != None:
+        asserts.equals(env, n, len(target_under_test[DebugPackageInfo].dwo_files.to_list()))
+
+    return analysistest.end(env)
+
+def _dwo_files_contents(ctx):
+    # We expect the DebugInfoProvider
+    # to contain one dwo file per "source" file
+    # and it must include dwo files from implementation deps
+    return _test_n_dwo_files(ctx, 3)
+
+def _dwo_files_no_contents(ctx):
+    # without fission the list should be empty
+    return _test_n_dwo_files(ctx, 0)
+
+dwo_files_contents_test = analysistest.make(
+    _dwo_files_contents,
+    config_settings = {
+        "//command_line_option:fission": "yes",
+        "//command_line_option:features": ["per_object_debug_info"],
+    },
+)
+
+dwo_files_no_contents_test = analysistest.make(
+    _dwo_files_no_contents,
+    config_settings = {
+        "//command_line_option:fission": "no",
+    },
+)
+
+def _test_provider_contents():
+    cc_library(
+        name = "impl_lib",
+        hdrs = ["impl_lib.h"],
+        srcs = ["impl_lib.cc"],
+    )
+
+    cc_library(
+        name = "lib",
+        hdrs = ["lib.h"],
+        srcs = ["lib.cc"],
+        implementation_deps = [":impl_lib"],
+    )
+
+    cc_binary(
+        name = "main",
+        srcs = ["main.cc"],
+        deps = ["lib"],
+    )
+
+    dwo_files_contents_test(
+        name = "dwo_files_content_test",
+        target_under_test = ":main",
+    )
+    dwo_files_no_contents_test(
+        name = "dwo_files_no_content_test",
+        target_under_test = ":main",
+    )
+
+def dwo_files_test_suite(name):
+    if _bazel_version_ge("9.0.0-pre.20250911"):
+        # we only test this if we are on a version where
+        # the DebugPackageInfo provider is defined by rules_cc
+        # and not bazel.
+        _test_provider_contents()
+
+        native.test_suite(
+            name = name,
+            tests = [
+                ":dwo_files_content_test",
+                ":dwo_files_no_content_test",
+            ],
+        )

--- a/tests/debug_files/dwo_files_test.bzl
+++ b/tests/debug_files/dwo_files_test.bzl
@@ -49,6 +49,7 @@ def _test_provider_contents():
         name = "impl_lib",
         hdrs = ["impl_lib.h"],
         srcs = ["impl_lib.cc"],
+        target_compatible_with = ["@platforms//os:linux"],
     )
 
     cc_library(
@@ -56,12 +57,14 @@ def _test_provider_contents():
         hdrs = ["lib.h"],
         srcs = ["lib.cc"],
         implementation_deps = [":impl_lib"],
+        target_compatible_with = ["@platforms//os:linux"],
     )
 
     cc_binary(
         name = "main",
         srcs = ["main.cc"],
         deps = ["lib"],
+        target_compatible_with = ["@platforms//os:linux"],
     )
 
     dwo_files_contents_test(

--- a/tests/debug_files/impl_lib.cc
+++ b/tests/debug_files/impl_lib.cc
@@ -1,0 +1,9 @@
+#include "impl_lib.h"
+#include <iostream>
+
+namespace impl{
+    void impl_func(){
+        std::cout << "impl_func";
+    }
+
+}

--- a/tests/debug_files/impl_lib.h
+++ b/tests/debug_files/impl_lib.h
@@ -1,0 +1,8 @@
+#ifndef TESTS_DEBUG_FILES_IMPL_LIB_H_
+#define TESTS_DEBUG_FILES_IMPL_LIB_H_
+
+namespace impl{
+    void impl_func();
+}
+
+#endif

--- a/tests/debug_files/lib.cc
+++ b/tests/debug_files/lib.cc
@@ -1,0 +1,8 @@
+#include "lib.h"
+#include <iostream>
+
+namespace lib{
+    void Lib::do_lib(){
+        std::cout << "doing lib\n";
+    }
+}

--- a/tests/debug_files/lib.h
+++ b/tests/debug_files/lib.h
@@ -1,0 +1,11 @@
+#ifndef TESTS_DEBUG_FILES_LIB_HH_
+#define TESTS_DEBUG_FILES_LIB_HH_
+
+namespace lib{
+   class Lib{
+       public:
+       void do_lib();
+   };
+}
+
+#endif

--- a/tests/debug_files/main.cc
+++ b/tests/debug_files/main.cc
@@ -1,0 +1,7 @@
+#include "lib.h"
+
+int main(int argc, char** argv){
+    lib::Lib library;
+    library.do_lib();
+    return 0;
+}


### PR DESCRIPTION
Expose the generated .dwo files in DebugPackageInfo but only for bazel 9 and up

* Allows for collecting debug info for many targets with de-duplication 
* See original bazel issue  https://github.com/bazelbuild/bazel/issues/19149  for a good description of use cases

Existing PR against bazel https://github.com/bazelbuild/bazel/pull/24779 

