### PR TITLE
Remove dead code for generation of module map used for Swift compilation

### DIFF
--- a/cc/private/rules_impl/objc_common.bzl
+++ b/cc/private/rules_impl/objc_common.bzl
@@ -58,7 +58,6 @@ def _create_context_and_provider(
         compilation_attributes,
         compilation_artifacts,
         intermediate_artifacts,
-        has_module_map,
         deps,
         implementation_deps,
         attr_linkopts,
@@ -150,10 +149,6 @@ def _create_context_and_provider(
         objc_compilation_context_kwargs["private_hdrs"].extend(
             _filter_by_extension(compilation_artifacts.srcs, HEADERS),
         )
-
-    if has_module_map:
-        module_map = intermediate_artifacts.swift_module_map()
-        objc_provider_kwargs["module_map"].append(module_map.file if type(module_map.file) == "File" else module_map.file())
 
     objc_provider_kwargs_built = {}
     for k, v in objc_provider_kwargs.items():

--- a/cc/private/rules_impl/objc_intermediate_artifacts.bzl
+++ b/cc/private/rules_impl/objc_intermediate_artifacts.bzl
@@ -34,29 +34,6 @@ def _create_archive(ctx, enforce_always_link, archive_file_name_suffix):
         extension,
     )
 
-def _get_module_name(ctx):
-    if hasattr(ctx.attr, "module_name") and ctx.attr.module_name != "":
-        return ctx.attr.module_name
-    return (
-        str(ctx.label)
-            .replace("//", "")
-            .replace("@", "")
-            .replace("-", "_")
-            .replace("/", "_")
-            .replace(":", "_")
-    )
-
-def _swift_module_map(ctx):
-    module_name = _get_module_name(ctx)
-    custom_module_map = getattr(ctx.attr, "module_map", None)
-    return cc_common.create_module_map(
-        file = custom_module_map if custom_module_map else _declare_file_with_extension(
-            ctx,
-            ".modulemaps/module.modulemap",
-        ),
-        name = module_name,
-    )
-
 def _internal_module_map(ctx):
     return cc_common.create_module_map(
         file = _declare_file_with_extension(ctx, ".internal.cppmap"),
@@ -69,7 +46,6 @@ def _create_closure_struct(ctx, archive_file_name_suffix, enforce_always_link):
         # TODO(b/331163027): Consider renaming publicly to "create_combined_architecture_archive".
         # Alteratively, consider deleting this method as it is not used anywhere in the repo.
         combined_architecture_archive = lambda: _create_combined_architecture_archive(ctx),
-        swift_module_map = lambda: _swift_module_map(ctx),
         internal_module_map = lambda: _internal_module_map(ctx),
         # TODO(b/331163027): Consider renaming publicly to "create_archive".
         archive = lambda: _create_archive(ctx, enforce_always_link, archive_file_name_suffix),


### PR DESCRIPTION
`objc_library` used to generate a clang module map for Swift consumers, but that has been moved into `rules_swift`'s [swift_clang_module_aspect](https://github.com/bazelbuild/rules_swift/blob/main/swift/swift_clang_module_aspect.bzl).

No callers of `compilation_support.register_compile_and_archive_actions` were passing `generate_module_map_for_swift = True`, and I believe this is private API, so it should be safe to remove.