### PR TITLE
Add proto link tests

### DIFF
--- a/tests/protobuf/BUILD
+++ b/tests/protobuf/BUILD
@@ -1,0 +1,68 @@
+load("//cc:cc_library.bzl", "cc_library")
+load("//cc:cc_test.bzl", "cc_test")
+load("//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+
+proto_library(
+    name = "simple_pb",
+    srcs = [
+        "simple.proto",
+    ],
+)
+
+cc_proto_library(
+    name = "cc_simple_pb",
+    deps = [
+        ":simple_pb",
+    ],
+)
+
+# An intermediate library that calls various generated Protobuf functions.
+cc_library(
+    name = "intermediate_proto_lib",
+    srcs = [
+        "intermediate_proto_lib.cc",
+    ],
+    hdrs = [
+        "intermediate_proto_lib.h",
+    ],
+    deps = [
+        ":cc_simple_pb",
+    ],
+)
+
+# A shim that ensures the proto library is linked dynamically.
+cc_shared_library(
+    name = "dynamic_proto_lib",
+    deps = [
+        ":intermediate_proto_lib",
+    ],
+)
+
+# A testable binary that ensures dynamic linking works as intended.
+cc_test(
+    name = "dynamic_proto_library_link_test",
+    srcs = [
+        "proto_library_link_test.cc",
+    ],
+    dynamic_deps = [
+        ":dynamic_proto_lib",
+    ],
+    deps = [
+        ":intermediate_proto_lib",
+        "@googletest//:gtest_main",
+    ],
+)
+
+# A testable binary that ensures the default link mode works as intended.
+cc_test(
+    name = "proto_library_link_test",
+    srcs = [
+        "proto_library_link_test.cc",
+    ],
+    deps = [
+        ":intermediate_proto_lib",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/tests/protobuf/intermediate_proto_lib.cc
+++ b/tests/protobuf/intermediate_proto_lib.cc
@@ -1,0 +1,35 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/protobuf/intermediate_proto_lib.h"
+
+#include <string>
+
+#include "tests/protobuf/simple.pb.h"
+
+namespace tests::protobuf {
+
+int GetTestProtoValue() {
+    SimpleMessage simple_message;
+    simple_message.set_my_num(kExpectedValue);
+
+    // Ensure serialization methods are linked in.
+    std::string buf;
+    simple_message.SerializeToString(&buf);
+    simple_message.ParseFromString(buf);
+
+    return simple_message.my_num();
+}
+
+}  // namespace tests::protobuf

--- a/tests/protobuf/intermediate_proto_lib.h
+++ b/tests/protobuf/intermediate_proto_lib.h
@@ -1,0 +1,21 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace tests::protobuf {
+
+inline constexpr int kExpectedValue = 42;
+
+int GetTestProtoValue();
+
+}  // namespace tests::protobuf

--- a/tests/protobuf/proto_library_link_test.cc
+++ b/tests/protobuf/proto_library_link_test.cc
@@ -1,0 +1,25 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/protobuf/intermediate_proto_lib.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+TEST(SharedLibraryProtoTest, Value) {
+  EXPECT_EQ(tests::protobuf::GetTestProtoValue(), tests::protobuf::kExpectedValue);
+}
+
+}  // namespace

--- a/tests/protobuf/simple.proto
+++ b/tests/protobuf/simple.proto
@@ -1,0 +1,21 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+edition = "2023";
+
+package tests.protobuf;
+
+message SimpleMessage {
+    int32 my_num = 1;
+}


### PR DESCRIPTION
Adds protobuf library link tests that cover bazelbuild/rules_cc#584 and protocolbuffers/protobuf#25577.