### PR TITLE
Add rules_zig to the Starlarkification allowlist

### DIFF
--- a/cc/common/cc_helper_internal.bzl
+++ b/cc/common/cc_helper_internal.bzl
@@ -83,6 +83,8 @@ PRIVATE_STARLARKIFICATION_ALLOWLIST = [
     ("rules_rust", "rust/private"),
     # Python rules
     ("", "third_party/bazel_rules/rules_python"),
+    # Zig rules
+    ("rules_zig", "zig/private"),
     # Various
     ("", "research/colab"),
     ("", "javatests/com/google/devtools/grok/kythe"),


### PR DESCRIPTION
rules_zig needs to invoke `cc_common.link` with the `main_output` parameter when users request linking via the C toolchain. Motivation for this linking mode is provided in https://github.com/aherrmann/rules_zig/issues/519. The need for access to the `main_output` parameter is motivated in https://github.com/aherrmann/rules_zig/issues/519#issuecomment-3302822718.

rules_zig used to work around this issue with the same hack that rules_rust and rules_mojo applied, but this is no longer available as of Bazel 9.0.0, see https://github.com/aherrmann/rules_zig/issues/589. As described in https://github.com/bazelbuild/bazel/pull/23838#issuecomment-3843160100 there does not seem to be any other work around available. So, I would like to request to add rules_zig to the list of rule sets that are allowed to use the private `cc_common.link` API.

Note, this is a blocker for Bazel 9.0.0 support in rules_zig, see https://github.com/aherrmann/rules_zig/pull/592.