### PR TITLE
Fix GCC detection to be robust to symlinks

### DIFF
--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -276,7 +276,13 @@ def _is_gcc(repository_ctx, cc):
     # GCC's version output uses the basename of argv[0] as the program name:
     # https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/gcc.cc;h=158461167951c1b9540322fb19be6a89d6da07fc;hb=HEAD#l8728
     cc_stdout = repository_ctx.execute([cc, "--version"]).stdout
-    return cc_stdout.startswith("gcc ") or cc_stdout.startswith("gcc-")
+    if cc_stdout.startswith("gcc ") or cc_stdout.startswith("gcc-"):
+        return True
+
+    # As a fallback, also check specs output in case argv[0] was a symlink.
+    specs = repository_ctx.execute([cc, "-v"]).stderr
+    last_line = specs.rstrip("\n").split("\n")[-1]
+    return "gcc version " in last_line
 
 def _get_compiler_name(repository_ctx, cc):
     if _is_clang(repository_ctx, cc):


### PR DESCRIPTION
On Ubuntu /usr/bin/cc is a symlink to /usr/bin/gcc. Because GCC uses `argv[0]` to report its `--version`, that means if the user has set `CC=/usr/bin/cc` then `_is_gcc` will return false and the compiler will be mis-detected.

Instead of relying on the binary name, we'll match how Clang detection was already done: run with `-v` and look for the compiler species in the output. Unlike clang, we'll be slightly more careful by looking for a more specific string, and only on the last line. This is safer because `clang -v` prints GCC-adjacent details and we don't want that being detected as GCC itself.

---

On Ubuntu:

```
jwnimmer@call-cps:~$ ls -l /usr/bin/cc
lrwxrwxrwx 1 root root 20 Jan 31  2024 /usr/bin/cc -> /etc/alternatives/cc
jwnimmer@call-cps:~$ ls -l /etc/alternatives/cc
lrwxrwxrwx 1 root root 12 Jan 31  2024 /etc/alternatives/cc -> /usr/bin/gcc

jwnimmer@call-cps:~$ cc --version | head -n1
cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
jwnimmer@call-cps:~$ gcc --version | head -n1
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0

jwnimmer@call-cps:~$ cc -v 2>&1 | tail -n1
gcc version 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04) 
jwnimmer@call-cps:~$ gcc -v 2>&1 | tail -n1
gcc version 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04) 
```