### PR TITLE
Do not include MacOSX path if we are not in OSX

### DIFF
--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -591,7 +591,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
         ) +
         # Always included in case the user has Xcode + the CLT installed, both
         # paths can be used interchangeably
-        ["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"],
+        (["/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"] if darwin else []),
     )
 
     generate_modulemap = is_clang


### PR DESCRIPTION
This keeps the generated file on Linux free from unnecessary paths