### PR TITLE
Allow passing env to cc_tool

### DIFF
--- a/cc/toolchains/cc_toolchain_info.bzl
+++ b/cc/toolchains/cc_toolchain_info.bzl
@@ -199,6 +199,7 @@ ToolInfo = provider(
         "exe": "(File) The file corresponding to the tool",
         "runfiles": "(runfiles) The files required to run the tool",
         "execution_requirements": "(Sequence[str]) A set of execution requirements of the tool",
+        "env": "(dict[str, str]) Environment variables applied when using this tool",
         "allowlist_include_directories": "(depset[DirectoryInfo]) Built-in include directories implied by this tool that should be allowlisted in Bazel's include checker",
         "capabilities": "(Sequence[ToolCapabilityInfo]) Capabilities supported by the tool.",
     },

--- a/cc/toolchains/impl/collect.bzl
+++ b/cc/toolchains/impl/collect.bzl
@@ -107,6 +107,7 @@ def collect_tools(ctx, targets, fail = fail):
                 exe = info.files_to_run.executable,
                 runfiles = collect_data(ctx, [target]),
                 execution_requirements = tuple(),
+                env = {},
                 allowlist_include_directories = depset(),
                 capabilities = tuple(),
             ))

--- a/cc/toolchains/impl/label_utils.bzl
+++ b/cc/toolchains/impl/label_utils.bzl
@@ -1,0 +1,38 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for passing possibly duplicated labels through rule attributes."""
+
+def deduplicate_label_list(name, labels):
+    """Deduplicates a label list while preserving the original indexes.
+
+    Args:
+        name: Name of the macro target using this helper.
+        labels: Labels to normalize and deduplicate.
+
+    Returns:
+        A struct with deduplicated labels and original-to-deduplicated indexes.
+    """
+    deduplicated_labels = {}
+    index_for_label = []
+
+    for label in labels:
+        package_relative_label = native.package_relative_label(label)
+        if package_relative_label not in deduplicated_labels:
+            deduplicated_labels[package_relative_label] = len(deduplicated_labels)
+        index_for_label.append(deduplicated_labels[package_relative_label])
+
+    return struct(
+        labels = deduplicated_labels.keys(),
+        indexes = index_for_label,
+    )

--- a/cc/toolchains/tool.bzl
+++ b/cc/toolchains/tool.bzl
@@ -15,6 +15,8 @@
 
 load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
 load("//cc/toolchains/impl:collect.bzl", "collect_data", "collect_provider")
+load("//cc/toolchains/impl:label_utils.bzl", "deduplicate_label_list")
+load("//cc/toolchains/impl:nested_args.bzl", "format_dict_values")
 load(
     ":cc_toolchain_info.bzl",
     "ToolCapabilityInfo",
@@ -30,12 +32,22 @@ def _cc_tool_impl(ctx):
     else:
         fail("Expected cc_tool's src attribute to be either an executable or a single file")
 
+    format_targets = {}
+    for i in range(len(ctx.attr.format_keys)):
+        format_targets[ctx.attr.format_keys[i]] = ctx.attr.format_values[ctx.attr.format_value_indexes[i]]
+    env, _ = format_dict_values(
+        env = ctx.attr.env,
+        format = format_targets,
+        must_use = format_targets.keys(),
+    )
+
     runfiles = collect_data(ctx, ctx.attr.data + [ctx.attr.src])
     tool = ToolInfo(
         label = ctx.label,
         exe = exe,
         runfiles = runfiles,
         execution_requirements = tuple(ctx.attr.tags),
+        env = env,
         allowlist_include_directories = depset(
             direct = [d[DirectoryInfo] for d in ctx.attr.allowlist_include_directories],
         ),
@@ -59,7 +71,7 @@ def _cc_tool_impl(ctx):
         ),
     ]
 
-cc_tool = rule(
+_cc_tool = rule(
     implementation = _cc_tool_impl,
     # @unsorted-dict-items
     attrs = {
@@ -100,6 +112,31 @@ This can help work around errors like:
 (if these are builtin files, make sure these paths are in your toolchain)`.
 """,
         ),
+        "env": attr.string_dict(
+            doc = """Environment variables to apply when running this tool.
+
+Format expansion is performed on values using the format attribute.
+""",
+        ),
+        "format_keys": attr.string_list(
+            doc = """Format strings used in substitutions for env values.
+
+Use the cc_tool macro's format attribute instead.
+""",
+        ),
+        "format_values": attr.label_list(
+            allow_files = True,
+            doc = """Targets used in substitutions for env values.
+
+Use the cc_tool macro's format attribute instead.
+""",
+        ),
+        "format_value_indexes": attr.int_list(
+            doc = """Index of the target in format_values for each format key.
+
+Use the cc_tool macro's format attribute instead.
+""",
+        ),
         "capabilities": attr.label_list(
             providers = [ToolCapabilityInfo],
             doc = """Declares that a tool is capable of doing something.
@@ -136,3 +173,91 @@ cc_tool(
 """,
     executable = True,
 )
+
+def cc_tool(
+        *,
+        name,
+        src = None,
+        data = None,
+        allowlist_include_directories = None,
+        env = None,
+        format = {},
+        capabilities = None,
+        **kwargs):
+    """Declares a tool for use by toolchain actions.
+
+    `cc_tool` rules are used in a `cc_tool_map` rule to ensure all files and
+    metadata required to run a tool are available when constructing a `cc_toolchain`.
+
+    In general, include all files that are always required to run a tool (e.g. libexec/** and
+    cross-referenced tools in bin/*) in the [data](#cc_tool-data) attribute. If some files are only
+    required when certain flags are passed to the tool, consider using a `cc_args` rule to
+    bind the files to the flags that require them. This reduces the overhead required to properly
+    enumerate a sandbox with all the files required to run a tool, and ensures that there isn't
+    unintentional leakage across configurations and actions.
+
+    Example:
+    ```
+    load("//cc/toolchains:tool.bzl", "cc_tool")
+
+    cc_tool(
+        name = "clang",
+        src = "@llvm_toolchain//:bin/clang",
+        # Suppose clang needs libc to run.
+        data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
+        capabilities = ["//cc/toolchains/capabilities:supports_pic"],
+    )
+    ```
+
+    Args:
+        name: (str) The name of the target.
+        src: (Label) The underlying binary that this tool represents.
+            Usually just a single prebuilt (e.g. @toolchain//:bin/clang), but may be any
+            executable label.
+        data: (List[Label]) Additional files that are required for this tool to run.
+            Frequently, clang and gcc require additional files to execute as they often shell out to
+            other binaries (e.g. `cc1`).
+        allowlist_include_directories: (List[Label]) Include paths implied by using this tool.
+            Compilers may include a set of built-in headers that are implicitly available
+            unless flags like `-nostdinc` are provided. Bazel checks that all included
+            headers are properly provided by a dependency or allowlisted through this
+            mechanism.
+
+            As a rule of thumb, only use this if Bazel is complaining about absolute paths in your
+            toolchain and you've ensured that the toolchain is compiling with the
+            `-no-canonical-prefixes` and/or `-fno-canonical-system-headers` arguments.
+
+            These files are not automatically passed to each action. If they need to be,
+            add them to 'data' as well.
+
+            This can help work around errors like:
+            `the source file 'main.c' includes the following non-builtin files with absolute paths
+            (if these are builtin files, make sure these paths are in your toolchain)`.
+        env: (Dict[str, str]) Environment variables to apply when running this tool.
+            Format expansion is performed on values using `format`.
+        format: (Dict[str, Label]) A mapping of format strings to the label of a corresponding
+            target. This target can be a `directory`, `subdirectory`, or a single file that the
+            value should be pulled from. All instances of `{variable_name}` in the `env` dictionary
+            values will be replaced with the expanded value in this dictionary.
+        capabilities: (List[Label]) Declares that a tool is capable of doing something.
+            For example, `@rules_cc//cc/toolchains/capabilities:supports_pic`.
+        **kwargs: [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes)
+            that should be applied to this rule.
+    """
+    format_keys = format.keys()
+    format_values = deduplicate_label_list(
+        name = name,
+        labels = [format[key] for key in format_keys],
+    )
+    return _cc_tool(
+        name = name,
+        src = src,
+        data = data,
+        allowlist_include_directories = allowlist_include_directories,
+        env = env,
+        format_keys = format_keys,
+        format_values = format_values.labels,
+        format_value_indexes = format_values.indexes,
+        capabilities = capabilities,
+        **kwargs
+    )

--- a/cc/toolchains/tool_map.bzl
+++ b/cc/toolchains/tool_map.bzl
@@ -19,6 +19,7 @@ load(
     "collect_provider",
     "collect_tools",
 )
+load("//cc/toolchains/impl:label_utils.bzl", "deduplicate_label_list")
 load(
     ":cc_toolchain_info.bzl",
     "ActionTypeSetInfo",
@@ -112,20 +113,16 @@ def cc_tool_map(name, tools, **kwargs):
             and the `cc_tool` or executable target that implements that action.
         **kwargs: [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) that should be applied to this rule.
     """
-    actions = []
-    tool_index_for_action = []
-    deduplicated_tools = {}
-    for action, tool in tools.items():
-        actions.append(action)
-        label = native.package_relative_label(tool)
-        if label not in deduplicated_tools:
-            deduplicated_tools[label] = len(deduplicated_tools)
-        tool_index_for_action.append(deduplicated_tools[label])
+    actions = tools.keys()
+    deduplicated_tools = deduplicate_label_list(
+        name = name,
+        labels = [tools[action] for action in actions],
+    )
 
     _cc_tool_map(
         name = name,
         actions = actions,
-        tools = deduplicated_tools.keys(),
-        tool_index_for_action = tool_index_for_action,
+        tools = deduplicated_tools.labels,
+        tool_index_for_action = deduplicated_tools.indexes,
         **kwargs
     )

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -474,53 +474,6 @@ cc_feature(
 | <a id="cc_mutually_exclusive_category-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 
 
-<a id="cc_tool"></a>
-
-## cc_tool
-
-<pre>
-load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_tool")
-
-cc_tool(<a href="#cc_tool-name">name</a>, <a href="#cc_tool-src">src</a>, <a href="#cc_tool-data">data</a>, <a href="#cc_tool-allowlist_include_directories">allowlist_include_directories</a>, <a href="#cc_tool-capabilities">capabilities</a>)
-</pre>
-
-Declares a tool for use by toolchain actions.
-
-[`cc_tool`](#cc_tool) rules are used in a [`cc_tool_map`](#cc_tool_map) rule to ensure all files and
-metadata required to run a tool are available when constructing a [`cc_toolchain`](#cc_toolchain).
-
-In general, include all files that are always required to run a tool (e.g. libexec/** and
-cross-referenced tools in bin/*) in the [data](#cc_tool-data) attribute. If some files are only
-required when certain flags are passed to the tool, consider using a [`cc_args`](#cc_args) rule to
-bind the files to the flags that require them. This reduces the overhead required to properly
-enumerate a sandbox with all the files required to run a tool, and ensures that there isn't
-unintentional leakage across configurations and actions.
-
-Example:
-```
-load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
-
-cc_tool(
-    name = "clang",
-    src = "@llvm_toolchain//:bin/clang",
-    # Suppose clang needs libc to run.
-    data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
-    capabilities = ["@rules_cc//cc/toolchains/capabilities:supports_pic"],
-)
-```
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="cc_tool-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="cc_tool-src"></a>src |  The underlying binary that this tool represents.<br><br>Usually just a single prebuilt (eg. @toolchain//:bin/clang), but may be any executable label.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="cc_tool-data"></a>data |  Additional files that are required for this tool to run.<br><br>Frequently, clang and gcc require additional files to execute as they often shell out to other binaries (e.g. `cc1`).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="cc_tool-allowlist_include_directories"></a>allowlist_include_directories |  Include paths implied by using this tool.<br><br>Compilers may include a set of built-in headers that are implicitly available unless flags like `-nostdinc` are provided. Bazel checks that all included headers are properly provided by a dependency or allowlisted through this mechanism.<br><br>As a rule of thumb, only use this if Bazel is complaining about absolute paths in your toolchain and you've ensured that the toolchain is compiling with the `-no-canonical-prefixes` and/or `-fno-canonical-system-headers` arguments.<br><br>These files are not automatically passed to each action. If they need to be, add them to 'data' as well.<br><br>This can help work around errors like: `the source file 'main.c' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain)`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="cc_tool-capabilities"></a>capabilities |  Declares that a tool is capable of doing something.<br><br>For example, `@rules_cc//cc/toolchains/capabilities:supports_pic`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-
-
 <a id="cc_tool_capability"></a>
 
 ## cc_tool_capability
@@ -723,6 +676,57 @@ use this rule.
 | <a id="cc_nested_args-requires_equal"></a>requires_equal |  (Label) The label of a [`cc_variable`](#cc_variable) that should be checked for equality before expanding this rule. If the variable is not equal to (requires_equal_value)[#cc_nested_args-requires_equal_value], this rule will be ignored.   |  `None` |
 | <a id="cc_nested_args-requires_equal_value"></a>requires_equal_value |  (str) The value to compare (requires_equal)[#cc_nested_args-requires_equal] against.   |  `None` |
 | <a id="cc_nested_args-kwargs"></a>kwargs |  [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) that should be applied to this rule.   |  none |
+
+
+<a id="cc_tool"></a>
+
+## cc_tool
+
+<pre>
+load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_tool")
+
+cc_tool(*, <a href="#cc_tool-name">name</a>, <a href="#cc_tool-src">src</a>, <a href="#cc_tool-data">data</a>, <a href="#cc_tool-allowlist_include_directories">allowlist_include_directories</a>, <a href="#cc_tool-env">env</a>, <a href="#cc_tool-format">format</a>, <a href="#cc_tool-capabilities">capabilities</a>, <a href="#cc_tool-kwargs">**kwargs</a>)
+</pre>
+
+Declares a tool for use by toolchain actions.
+
+[`cc_tool`](#cc_tool) rules are used in a [`cc_tool_map`](#cc_tool_map) rule to ensure all files and
+metadata required to run a tool are available when constructing a [`cc_toolchain`](#cc_toolchain).
+
+In general, include all files that are always required to run a tool (e.g. libexec/** and
+cross-referenced tools in bin/*) in the [data](#cc_tool-data) attribute. If some files are only
+required when certain flags are passed to the tool, consider using a [`cc_args`](#cc_args) rule to
+bind the files to the flags that require them. This reduces the overhead required to properly
+enumerate a sandbox with all the files required to run a tool, and ensures that there isn't
+unintentional leakage across configurations and actions.
+
+Example:
+```
+load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
+
+cc_tool(
+    name = "clang",
+    src = "@llvm_toolchain//:bin/clang",
+    # Suppose clang needs libc to run.
+    data = ["@llvm_toolchain//:lib/x86_64-linux-gnu/libc.so.6"]
+    capabilities = ["@rules_cc//cc/toolchains/capabilities:supports_pic"],
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="cc_tool-name"></a>name |  (str) The name of the target.   |  none |
+| <a id="cc_tool-src"></a>src |  (Label) The underlying binary that this tool represents. Usually just a single prebuilt (e.g. @toolchain//:bin/clang), but may be any executable label.   |  `None` |
+| <a id="cc_tool-data"></a>data |  (List[Label]) Additional files that are required for this tool to run. Frequently, clang and gcc require additional files to execute as they often shell out to other binaries (e.g. `cc1`).   |  `None` |
+| <a id="cc_tool-allowlist_include_directories"></a>allowlist_include_directories |  (List[Label]) Include paths implied by using this tool. Compilers may include a set of built-in headers that are implicitly available unless flags like `-nostdinc` are provided. Bazel checks that all included headers are properly provided by a dependency or allowlisted through this mechanism.<br><br>As a rule of thumb, only use this if Bazel is complaining about absolute paths in your toolchain and you've ensured that the toolchain is compiling with the `-no-canonical-prefixes` and/or `-fno-canonical-system-headers` arguments.<br><br>These files are not automatically passed to each action. If they need to be, add them to 'data' as well.<br><br>This can help work around errors like: `the source file 'main.c' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain)`.   |  `None` |
+| <a id="cc_tool-env"></a>env |  (Dict[str, str]) Environment variables to apply when running this tool. Format expansion is performed on values using `format`.   |  `None` |
+| <a id="cc_tool-format"></a>format |  (Dict[str, Label]) A mapping of format strings to the label of a corresponding target. This target can be a `directory`, `subdirectory`, or a single file that the value should be pulled from. All instances of `{variable_name}` in the `env` dictionary values will be replaced with the expanded value in this dictionary.   |  `{}` |
+| <a id="cc_tool-capabilities"></a>capabilities |  (List[Label]) Declares that a tool is capable of doing something. For example, `@rules_cc//cc/toolchains/capabilities:supports_pic`.   |  `None` |
+| <a id="cc_tool-kwargs"></a>kwargs |  [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) that should be applied to this rule.   |  none |
 
 
 <a id="cc_tool_map"></a>

--- a/tests/rule_based_toolchain/subjects.bzl
+++ b/tests/rule_based_toolchain/subjects.bzl
@@ -210,6 +210,7 @@ _ToolFactory = generate_factory(
         exe = _subjects.file,
         runfiles = runfiles_subject,
         execution_requirements = _subjects.collection,
+        env = _subjects.dict,
         allowlist_include_directories = _FakeDirectoryDepset,
         capabilities = ProviderSequence(_ToolCapabilityFactory),
     ),

--- a/tests/rule_based_toolchain/tool/BUILD
+++ b/tests/rule_based_toolchain/tool/BUILD
@@ -25,6 +25,25 @@ cc_tool(
     visibility = ["//tests/rule_based_toolchain:__subpackages__"],
 )
 
+cc_tool(
+    name = "tool_with_env",
+    src = "//tests/rule_based_toolchain/testdata:bin_wrapper.sh",
+    data = [
+        "//tests/rule_based_toolchain/testdata:bin",
+        "//tests/rule_based_toolchain/testdata:file1",
+    ],
+    env = {
+        "STATIC": "value",
+        "TOOL_ENV": "{tool_env}",
+        "TOOL_ENV_AGAIN": "{tool_env_again}",
+    },
+    format = {
+        "tool_env": "//tests/rule_based_toolchain/testdata:file1",
+        "tool_env_again": "//tests/rule_based_toolchain/testdata:file1",
+    },
+    visibility = ["//tests/rule_based_toolchain:__subpackages__"],
+)
+
 cc_directory_tool(
     name = "directory_tool",
     data = ["bin"],

--- a/tests/rule_based_toolchain/tool/tool_test.bzl
+++ b/tests/rule_based_toolchain/tool/tool_test.bzl
@@ -65,6 +65,14 @@ def _tool_with_allowlist_include_directories_test(env, targets):
         _FILE1,
     ])
 
+def _tool_env_expansion_test(env, targets):
+    tool = env.expect.that_target(targets.tool_with_env).provider(ToolInfo)
+    tool.env().contains_exactly({
+        "STATIC": "value",
+        "TOOL_ENV": "tests/rule_based_toolchain/testdata/file1",
+        "TOOL_ENV_AGAIN": "tests/rule_based_toolchain/testdata/file1",
+    })
+
 def _collect_tools_collects_tools_test(env, targets):
     env.expect.that_value(
         value = collect_tools(env.ctx, [targets.tool, targets.wrapped_tool]),
@@ -108,6 +116,7 @@ TARGETS = [
     "//tests/rule_based_toolchain/tool:wrapped_tool",
     "//tests/rule_based_toolchain/tool:directory_tool",
     "//tests/rule_based_toolchain/tool:tool_with_allowlist_include_directories",
+    "//tests/rule_based_toolchain/tool:tool_with_env",
     "//tests/rule_based_toolchain/testdata:bin_wrapper",
     "//tests/rule_based_toolchain/testdata:multiple",
     "//tests/rule_based_toolchain/testdata:bin_filegroup",
@@ -124,4 +133,5 @@ TESTS = {
     "collect_tools_collects_single_files_test": _collect_tools_collects_single_files_test,
     "collect_tools_fails_on_non_binary_test": _collect_tools_fails_on_non_binary_test,
     "tool_with_allowlist_include_directories_test": _tool_with_allowlist_include_directories_test,
+    "tool_env_expansion_test": _tool_env_expansion_test,
 }

--- a/tests/rule_based_toolchain/toolchain_config/BUILD
+++ b/tests/rule_based_toolchain/toolchain_config/BUILD
@@ -46,6 +46,13 @@ util.helper_target(
     env = {"CPP_COMPILE": "1"},
 )
 
+util.helper_target(
+    cc_args,
+    name = "c_compile_env_args",
+    actions = ["//tests/rule_based_toolchain/actions:c_compile"],
+    env = {"FROM_ARGS": "args-env"},
+)
+
 cc_tool(
     name = "c_compile_tool",
     src = "//tests/rule_based_toolchain/testdata:bin_wrapper",
@@ -110,6 +117,14 @@ util.helper_target(
     tools = {
         "//tests/rule_based_toolchain/actions:c_compile": ":c_compile_tool",
         "//tests/rule_based_toolchain/actions:cpp_compile": "//tests/rule_based_toolchain/tool:wrapped_tool",
+    },
+)
+
+util.helper_target(
+    cc_tool_map,
+    name = "tool_env_tool_map",
+    tools = {
+        "//tests/rule_based_toolchain/actions:c_compile": "//tests/rule_based_toolchain/tool:tool_with_env",
     },
 )
 
@@ -197,6 +212,13 @@ util.helper_target(
     args = [":c_compile_args"],
     feature_name = "simple_feature2",
     visibility = ["//tests/rule_based_toolchain:__subpackages__"],
+)
+
+util.helper_target(
+    cc_toolchain_config,
+    name = "tool_env_toolchain_config",
+    args = [":c_compile_env_args"],
+    tool_map = ":tool_env_tool_map",
 )
 
 analysis_test_suite(

--- a/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
+++ b/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
@@ -16,6 +16,8 @@
 load(
     "//cc:cc_toolchain_config_lib.bzl",
     legacy_action_config = "action_config",
+    legacy_env_entry = "env_entry",
+    legacy_env_set = "env_set",
     legacy_feature = "feature",
     legacy_flag_group = "flag_group",
     legacy_flag_set = "flag_set",
@@ -251,6 +253,33 @@ def _toolchain_collects_files_test(env, targets):
         ),
     ]).in_order()
 
+def _tool_env_wires_into_toolchain_test(env, targets):
+    tc = env.expect.that_target(targets.tool_env_toolchain_config).provider(ToolchainConfigInfo)
+    legacy = convert_toolchain(tc.actual)
+
+    env.expect.that_collection(legacy.features).contains_exactly([
+        legacy_feature(
+            name = "implied_by_always_enabled_env_sets",
+            enabled = True,
+            env_sets = [
+                legacy_env_set(
+                    actions = ["c_compile"],
+                    env_entries = [
+                        legacy_env_entry(key = "STATIC", value = "value"),
+                        legacy_env_entry(key = "TOOL_ENV", value = "tests/rule_based_toolchain/testdata/file1"),
+                        legacy_env_entry(key = "TOOL_ENV_AGAIN", value = "tests/rule_based_toolchain/testdata/file1"),
+                    ],
+                ),
+                legacy_env_set(
+                    actions = ["c_compile"],
+                    env_entries = [
+                        legacy_env_entry(key = "FROM_ARGS", value = "args-env"),
+                    ],
+                ),
+            ],
+        ),
+    ])
+
 TARGETS = [
     "//tests/rule_based_toolchain/actions:c_compile",
     "//tests/rule_based_toolchain/actions:cpp_compile",
@@ -260,6 +289,9 @@ TARGETS = [
     ":compile_feature",
     ":c_compile_args",
     ":c_compile_tool_map",
+    ":tool_env_toolchain_config",
+    ":tool_env_tool_map",
+    ":c_compile_env_args",
     ":empty_tool_map",
     ":implies_simple_feature",
     ":overrides_feature",
@@ -280,4 +312,5 @@ TESTS = {
     "feature_missing_requirements_invalid_test": _feature_missing_requirements_invalid_test,
     "args_missing_requirements_invalid_test": _args_missing_requirements_invalid_test,
     "toolchain_collects_files_test": _toolchain_collects_files_test,
+    "tool_env_wires_into_toolchain_test": _tool_env_wires_into_toolchain_test,
 }


### PR DESCRIPTION
This covers 2 use cases:
1) passing license file env vars to proprietary compilers
2) Exposing the location of helper binaries to cc_tool. The alternative of supplying those as env/data via `cc_args` doesn't work because then the binaries will be cfg=target instead of cfg=exec.