### PR TITLE
Apply default compile flags passed as attrs in Windows MSVC toolchain config

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -814,7 +814,7 @@ def _impl(ctx):
                     ],
                     flag_groups = [
                         flag_group(
-                            flags = default_compile_flags_list,
+                            flags = default_compile_flags_list + ctx.attr.default_compile_flags,
                         ),
                     ],
                 ),


### PR DESCRIPTION
This change allows customization of Windows toolchain.

In our project, we are building a custom toolchain based on LLVM. For simplicity, we reuse the creation of toolchain config for Windows. However, we noticed that the compile flags passed by attributes are not passed to the compiler.

Since the same logic is present in creating GNU config, I assumed that somebody previously just missed it.