### PR TITLE
Fix visibility for `//cc/common:cc_shared_library_info_bzl`

### DIFF
--- a/cc/common/BUILD
+++ b/cc/common/BUILD
@@ -55,7 +55,7 @@ bzl_library(
 bzl_library(
     name = "cc_shared_library_info_bzl",
     srcs = ["cc_shared_library_info.bzl"],
-    visibility = ["//cc:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "@cc_compatibility_proxy//:symbols_bzl",
     ],


### PR DESCRIPTION
It is expected that users will need the provider.