### PR TITLE
Emit apparent labels as clang module names

### DIFF
--- a/cc/private/cc_info.bzl
+++ b/cc/private/cc_info.bzl
@@ -148,22 +148,22 @@ _ModuleMapInfo = provider(
     "ModuleMapInfo",
     fields = {
         "file": "The module map file.",
-        "name": "The name of the module.",
+        "identifier": "The identifier of the module, either a label or a string.",
     },
 )
 
-def create_module_map(*, file, name):
+def create_module_map(*, file, identifier):
     """
     Creates a module map struct.
 
     Args:
         file: The module map file.
-        name: The name of the module.
+        identifier: The identifier of the module.
     Returns:
         A module map struct.
     """
     check_private_api()
-    return _ModuleMapInfo(file = file, name = name)
+    return _ModuleMapInfo(file = file, identifier = identifier)
 
 def create_separate_module_map(module_map):
     """
@@ -174,7 +174,11 @@ def create_separate_module_map(module_map):
     Returns:
         A module map struct.
     """
-    return _ModuleMapInfo(file = module_map.file, name = module_map.name + ".sep")
+    if type(module_map.identifier) == type(""):
+        identifier = module_map.identifier + ".sep"
+    else:
+        identifier = module_map.identifier.same_package_label(module_map.identifier.name + ".sep")
+    return _ModuleMapInfo(file = module_map.file, identifier = identifier)
 
 def create_linking_context(
         *,

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -215,7 +215,6 @@ _ModuleMapInfo = provider(
 def _module_map_struct_to_module_map_content(parameters, tree_expander):
     lines = []
     module_map = parameters.module_map
-    lines.append("module \"%s\" {" % module_map.name)
     lines.append("  export *")
 
     def expanded(artifacts):
@@ -345,6 +344,7 @@ def _create_module_map_action(
         extern_dependencies = extern_dependencies,
         leading_periods = leading_periods,
     )
+    content.add(module_map.identifier, format = "module \"%s\" {")
     content.add_all([data_struct], map_each = _module_map_struct_to_module_map_content)
 
     # We need to add all tree artifacts to the args object directly so we they can be
@@ -508,7 +508,7 @@ def _init_cc_compilation_context(
         if not module_map:
             module_map = create_module_map(
                 file = actions.declare_file(label.name + ".cppmap"),
-                name = label.workspace_name + "//" + label.package + ":" + label.name,
+                identifier = label,
             )
 
         # There are different modes for module compilation:

--- a/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
+++ b/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
@@ -230,7 +230,7 @@ def get_cc_toolchain_provider(ctx, attributes):
 
     module_map = None
     if attributes.module_map != None and attributes.module_map_artifact != None:
-        module_map = cc_common.create_module_map(file = attributes.module_map_artifact, name = "crosstool")
+        module_map = cc_common.create_module_map(file = attributes.module_map_artifact, identifier = "crosstool")
 
     cc_compilation_context = cc_common.create_compilation_context(module_map = module_map)
 

--- a/cc/private/rules_impl/objc_intermediate_artifacts.bzl
+++ b/cc/private/rules_impl/objc_intermediate_artifacts.bzl
@@ -54,13 +54,13 @@ def _swift_module_map(ctx):
             ctx,
             ".modulemaps/module.modulemap",
         ),
-        name = module_name,
+        identifier = module_name,
     )
 
 def _internal_module_map(ctx):
     return cc_common.create_module_map(
         file = _declare_file_with_extension(ctx, ".internal.cppmap"),
-        name = str(ctx.label),
+        identifier = ctx.label,
     )
 
 def _create_closure_struct(ctx, archive_file_name_suffix, enforce_always_link):


### PR DESCRIPTION
By using `Args`' support for apparent label stringification, module names are now of the form `@my_rules_foo_repo_name//bar:baz` rather than `rules_foo+//bar:baz`. The former is the string that should be used as a dep in a `BUILD` file, while the latter lacks an `@` and uses the canonical name of the repo, which shouldn't be hardcoded.