### PR TITLE
Add LSan feature to UNIX toolchain

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1717,6 +1717,17 @@ def _impl(ctx):
         ],
     )
 
+    lsan_feature = _sanitizer_feature(
+        name = "lsan",
+        specific_compile_flags = [
+            "-fsanitize=leak",
+            "-fno-common",
+        ],
+        specific_link_flags = [
+            "-fsanitize=leak",
+        ],
+    )
+
     tsan_feature = _sanitizer_feature(
         name = "tsan",
         specific_compile_flags = [
@@ -1868,6 +1879,7 @@ def _impl(ctx):
             supports_pic_feature,
             prefer_pic_for_opt_binaries_feature,
             asan_feature,
+            lsan_feature,
             tsan_feature,
             ubsan_feature,
             gcc_quoting_for_param_files_feature,
@@ -1920,6 +1932,7 @@ def _impl(ctx):
             libtool_feature,
             archiver_flags_feature,
             asan_feature,
+            lsan_feature,
             tsan_feature,
             ubsan_feature,
             gcc_quoting_for_param_files_feature,


### PR DESCRIPTION
Mirror the existing sanitizer features with the appropriate leak sanitizer flags.