### PR TITLE
Change rules based toolchain macOS conditions to Apple

### DIFF
--- a/cc/settings/BUILD
+++ b/cc/settings/BUILD
@@ -1,7 +1,7 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
 selects.config_setting_group(
-    name = "default_apple",
+    name = "default_apple_constraint",
     match_any = [
         "@platforms//os:ios",
         "@platforms//os:macos",
@@ -13,7 +13,7 @@ selects.config_setting_group(
 )
 
 label_flag(
-    name = "apple",
-    build_setting_default = ":default_apple",
+    name = "apple_constraint",
+    build_setting_default = ":default_apple_constraint",
     visibility = ["//visibility:public"],
 )

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -21,7 +21,7 @@ config_setting(
 selects.config_setting_group(
     name = "use_libtool_on_apple_setting",
     match_all = [
-        "//cc/toolchains/platforms:apple",
+        "//cc/settings:apple_constraint",
         ":use_libtool_setting",
     ],
     visibility = ["//visibility:public"],

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:args_list.bzl", "cc_args_list")
@@ -13,9 +14,16 @@ bool_flag(
 )
 
 config_setting(
-    name = "use_libtool_on_macos_setting",
-    constraint_values = ["@platforms//os:macos"],
+    name = "use_libtool_setting",
     flag_values = {":use_libtool_on_macos": "true"},
+)
+
+selects.config_setting_group(
+    name = "use_libtool_on_apple_setting",
+    match_all = [
+        "//cc/toolchains/platforms:apple",
+        ":use_libtool_setting",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -44,7 +52,7 @@ cc_args(
     name = "create_static_archive",
     actions = ["//cc/toolchains/actions:ar_actions"],
     args = select({
-        ":use_libtool_on_macos_setting": [
+        ":use_libtool_on_apple_setting": [
             "-D",
             "-no_warning_for_no_symbols",
             "-static",
@@ -57,7 +65,7 @@ cc_args(
     name = "output_execpath",
     actions = ["//cc/toolchains/actions:cpp_link_static_library"],
     args = select({
-        ":use_libtool_on_macos_setting": ["-o"],
+        ":use_libtool_on_apple_setting": ["-o"],
         "//conditions:default": [],
     }) + ["{output_execpath}"],
     format = {"output_execpath": "//cc/toolchains/variables:output_execpath"},

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -109,7 +109,7 @@ cc_args(
     name = "objc_fully_link_archive_path",
     actions = ["//cc/toolchains/actions:objc_fully_link"],
     args = select({
-        ":use_libtool_on_macos_setting": ["-o"],
+        ":use_libtool_on_apple_setting": ["-o"],
         "//conditions:default": [],
     }) + ["{fully_linked_archive_path}"],
     format = {"fully_linked_archive_path": "//cc/toolchains/variables:fully_linked_archive_path"},

--- a/cc/toolchains/args/generate_linkmap/BUILD
+++ b/cc/toolchains/args/generate_linkmap/BUILD
@@ -13,7 +13,7 @@ cc_args(
     name = "generate_linkmap",
     actions = ["//cc/toolchains/actions:link_actions"],
     args = select({
-        "//cc/toolchains/platforms:apple": ["-Wl,-map,{output_execpath}.map"],
+        "//cc/settings:apple_constraint": ["-Wl,-map,{output_execpath}.map"],
         "//conditions:default": ["-Wl,-Map={output_execpath}.map"],
     }),
     format = {"output_execpath": "//cc/toolchains/variables:output_execpath"},

--- a/cc/toolchains/args/generate_linkmap/BUILD
+++ b/cc/toolchains/args/generate_linkmap/BUILD
@@ -13,7 +13,7 @@ cc_args(
     name = "generate_linkmap",
     actions = ["//cc/toolchains/actions:link_actions"],
     args = select({
-        "@platforms//os:macos": ["-Wl,-map,{output_execpath}.map"],
+        "//cc/toolchains/platforms:apple": ["-Wl,-map,{output_execpath}.map"],
         "//conditions:default": ["-Wl,-Map={output_execpath}.map"],
     }),
     format = {"output_execpath": "//cc/toolchains/variables:output_execpath"},

--- a/cc/toolchains/args/layering_check/BUILD
+++ b/cc/toolchains/args/layering_check/BUILD
@@ -58,7 +58,7 @@ cc_args(
     name = "module_name_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "//cc/toolchains/platforms:apple": ["-Xclang"],
+        "//cc/settings:apple_constraint": ["-Xclang"],
         "//conditions:default": [],
     }) + ["-fmodule-name={module_name}"],
     format = {
@@ -71,7 +71,7 @@ cc_args(
     name = "module_map_file_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "//cc/toolchains/platforms:apple": ["-Xclang"],
+        "//cc/settings:apple_constraint": ["-Xclang"],
         "//conditions:default": [],
     }) + ["-fmodule-map-file={module_map_file}"],
     format = {
@@ -84,7 +84,7 @@ cc_args(
     name = "dependent_module_map_files_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "//cc/toolchains/platforms:apple": ["-Xclang"],
+        "//cc/settings:apple_constraint": ["-Xclang"],
         "//conditions:default": [],
     }) + [
         "-fmodule-map-file={dependent_module_map_files}",

--- a/cc/toolchains/args/layering_check/BUILD
+++ b/cc/toolchains/args/layering_check/BUILD
@@ -58,7 +58,7 @@ cc_args(
     name = "module_name_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "@platforms//os:macos": ["-Xclang"],
+        "//cc/toolchains/platforms:apple": ["-Xclang"],
         "//conditions:default": [],
     }) + ["-fmodule-name={module_name}"],
     format = {
@@ -71,7 +71,7 @@ cc_args(
     name = "module_map_file_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "@platforms//os:macos": ["-Xclang"],
+        "//cc/toolchains/platforms:apple": ["-Xclang"],
         "//conditions:default": [],
     }) + ["-fmodule-map-file={module_map_file}"],
     format = {
@@ -84,7 +84,7 @@ cc_args(
     name = "dependent_module_map_files_args",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
     args = select({
-        "@platforms//os:macos": ["-Xclang"],
+        "//cc/toolchains/platforms:apple": ["-Xclang"],
         "//conditions:default": [],
     }) + [
         "-fmodule-map-file={dependent_module_map_files}",

--- a/cc/toolchains/args/libraries_to_link/BUILD
+++ b/cc/toolchains/args/libraries_to_link/BUILD
@@ -76,7 +76,7 @@ cc_nested_args(
 cc_nested_args(
     name = "single_library_args",
     nested = select({
-        "@platforms//os:macos": [],
+        "//cc/toolchains/platforms:apple": [],
         "//conditions:default": [":optional_whole_archive_start"],
     }) + [
         ":optional_object_file_group",
@@ -85,11 +85,11 @@ cc_nested_args(
         ":optional_static_library",
         ":optional_dynamic_library",
     ] + select({
-        # maOS has a minor nuance where it uses the path to the library instead of `-l:{library_name}`.
-        "@platforms//os:macos": [":macos_optional_versioned_dynamic_library"],
+        # Apple platforms have a minor nuance where they use the path to the library instead of `-l:{library_name}`.
+        "//cc/toolchains/platforms:apple": [":apple_optional_versioned_dynamic_library"],
         "//conditions:default": [":generic_optional_versioned_dynamic_library"],
     }) + select({
-        "@platforms//os:macos": [],
+        "//cc/toolchains/platforms:apple": [],
         "//conditions:default": [":optional_whole_archive_end"],
     }),
 )
@@ -166,7 +166,7 @@ cc_nested_args(
 )
 
 cc_nested_args(
-    name = "macos_optional_versioned_dynamic_library",
+    name = "apple_optional_versioned_dynamic_library",
     args = ["{library_path}"],
     format = {
         "library_path": "//cc/toolchains/variables:libraries_to_link.path",

--- a/cc/toolchains/args/libraries_to_link/BUILD
+++ b/cc/toolchains/args/libraries_to_link/BUILD
@@ -76,7 +76,7 @@ cc_nested_args(
 cc_nested_args(
     name = "single_library_args",
     nested = select({
-        "//cc/toolchains/platforms:apple": [],
+        "//cc/settings:apple_constraint": [],
         "//conditions:default": [":optional_whole_archive_start"],
     }) + [
         ":optional_object_file_group",
@@ -86,10 +86,10 @@ cc_nested_args(
         ":optional_dynamic_library",
     ] + select({
         # Apple platforms have a minor nuance where they use the path to the library instead of `-l:{library_name}`.
-        "//cc/toolchains/platforms:apple": [":apple_optional_versioned_dynamic_library"],
+        "//cc/settings:apple_constraint": [":apple_optional_versioned_dynamic_library"],
         "//conditions:default": [":generic_optional_versioned_dynamic_library"],
     }) + select({
-        "//cc/toolchains/platforms:apple": [],
+        "//cc/settings:apple_constraint": [],
         "//conditions:default": [":optional_whole_archive_end"],
     }),
 )

--- a/cc/toolchains/args/libraries_to_link/private/library_link_args.bzl
+++ b/cc/toolchains/args/libraries_to_link/private/library_link_args.bzl
@@ -15,7 +15,7 @@
 
 load("//cc/toolchains:nested_args.bzl", "cc_nested_args")
 
-def macos_force_load_library_args(name, variable):
+def apple_force_load_library_args(name, variable):
     """A helper for declaring -force_load argument expansion for a library.
 
     This creates an argument expansion that will expand to -Wl,-force_load,<library>
@@ -65,8 +65,8 @@ def library_link_args(name, library_type, from_variable, iterate_over_variable =
             },
         )
 
-    For macos, this expands to a more complex cc_nested_args structure that
-    handles the -force_load flag.
+    For Apple platforms, this expands to a more complex cc_nested_args structure
+    that handles the -force_load flag.
 
     Args:
       name: The name of the rule.
@@ -77,7 +77,7 @@ def library_link_args(name, library_type, from_variable, iterate_over_variable =
     native.alias(
         name = name,
         actual = select({
-            "@platforms//os:macos": ":macos_{}".format(name),
+            "//cc/toolchains/platforms:apple": ":apple_{}".format(name),
             "//conditions:default": ":generic_{}".format(name),
         }),
     )
@@ -92,13 +92,13 @@ def library_link_args(name, library_type, from_variable, iterate_over_variable =
         },
     )
     cc_nested_args(
-        name = "macos_{}".format(name),
+        name = "apple_{}".format(name),
         requires_equal = "//cc/toolchains/variables:libraries_to_link.type",
         requires_equal_value = library_type,
         iterate_over = from_variable if iterate_over_variable else None,
         nested = [":{}_maybe_force_load".format(name)],
     )
-    macos_force_load_library_args(
+    apple_force_load_library_args(
         name = "{}_maybe_force_load".format(name),
         variable = from_variable,
     )

--- a/cc/toolchains/args/libraries_to_link/private/library_link_args.bzl
+++ b/cc/toolchains/args/libraries_to_link/private/library_link_args.bzl
@@ -77,7 +77,7 @@ def library_link_args(name, library_type, from_variable, iterate_over_variable =
     native.alias(
         name = name,
         actual = select({
-            "//cc/toolchains/platforms:apple": ":apple_{}".format(name),
+            "//cc/settings:apple_constraint": ":apple_{}".format(name),
             "//conditions:default": ":generic_{}".format(name),
         }),
     )

--- a/cc/toolchains/args/pic_flags/BUILD
+++ b/cc/toolchains/args/pic_flags/BUILD
@@ -36,7 +36,7 @@ cc_args(
     name = "force_pic_flags",
     actions = ["//cc/toolchains/actions:link_executable_actions"],
     args = select({
-        "//cc/toolchains/platforms:apple": ["-Wl,-pie"],
+        "//cc/settings:apple_constraint": ["-Wl,-pie"],
         "//conditions:default": ["-pie"],
     }),
     requires_not_none = "//cc/toolchains/variables:force_pic",

--- a/cc/toolchains/args/pic_flags/BUILD
+++ b/cc/toolchains/args/pic_flags/BUILD
@@ -36,7 +36,7 @@ cc_args(
     name = "force_pic_flags",
     actions = ["//cc/toolchains/actions:link_executable_actions"],
     args = select({
-        "@platforms//os:macos": ["-Wl,-pie"],
+        "//cc/toolchains/platforms:apple": ["-Wl,-pie"],
         "//conditions:default": ["-pie"],
     }),
     requires_not_none = "//cc/toolchains/variables:force_pic",

--- a/cc/toolchains/args/runtime_library_search_directories/BUILD
+++ b/cc/toolchains/args/runtime_library_search_directories/BUILD
@@ -77,7 +77,7 @@ cc_nested_args(
         "-rpath",
         "-Xlinker",
     ] + select({
-        "//cc/toolchains/platforms:apple": ["@loader_path/{search_path}"],
+        "//cc/settings:apple_constraint": ["@loader_path/{search_path}"],
         "//conditions:default": ["$ORIGIN/{search_path}"],
     }),
     format = {
@@ -106,7 +106,7 @@ cc_nested_args(
         "-rpath",
         "-Xlinker",
     ] + select({
-        "//cc/toolchains/platforms:apple": ["@loader_path/{search_path}"],
+        "//cc/settings:apple_constraint": ["@loader_path/{search_path}"],
         "//conditions:default": ["$ORIGIN/{search_path}"],
     }),
     format = {

--- a/cc/toolchains/args/runtime_library_search_directories/BUILD
+++ b/cc/toolchains/args/runtime_library_search_directories/BUILD
@@ -77,7 +77,7 @@ cc_nested_args(
         "-rpath",
         "-Xlinker",
     ] + select({
-        "@platforms//os:macos": ["@loader_path/{search_path}"],
+        "//cc/toolchains/platforms:apple": ["@loader_path/{search_path}"],
         "//conditions:default": ["$ORIGIN/{search_path}"],
     }),
     format = {
@@ -106,7 +106,7 @@ cc_nested_args(
         "-rpath",
         "-Xlinker",
     ] + select({
-        "@platforms//os:macos": ["@loader_path/{search_path}"],
+        "//cc/toolchains/platforms:apple": ["@loader_path/{search_path}"],
         "//conditions:default": ["$ORIGIN/{search_path}"],
     }),
     format = {

--- a/cc/toolchains/args/sanitize_pwd/BUILD
+++ b/cc/toolchains/args/sanitize_pwd/BUILD
@@ -18,7 +18,7 @@ cc_args(
         "//cc/toolchains/actions:objc_fully_link",
     ],
     env = select({
-        "@platforms//os:macos": {},
+        "//cc/settings:apple_constraint": {},
         "//conditions:default": {"PWD": "/proc/self/cwd"},
     }),
 )

--- a/cc/toolchains/args/soname_flags/BUILD
+++ b/cc/toolchains/args/soname_flags/BUILD
@@ -4,7 +4,7 @@ load("//cc/toolchains:feature.bzl", "cc_feature")
 cc_feature(
     name = "feature",
     args = select({
-        "@platforms//os:macos": [":macos_set_install_name"],
+        "//cc/toolchains/platforms:apple": [":apple_set_install_name"],
         "//conditions:default": [],
     }),
     feature_name = "_soname_flags",  # Doesn't override legacy feature, but shouldn't be disabled
@@ -12,12 +12,12 @@ cc_feature(
 )
 
 cc_args(
-    name = "macos_set_install_name",
+    name = "apple_set_install_name",
     actions = ["//cc/toolchains/actions:link_actions"],
     args = ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
     format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
-    target_compatible_with = ["@platforms//os:macos"],
+    target_compatible_with = ["//cc/toolchains/platforms:apple"],
 )
 
 cc_args(

--- a/cc/toolchains/args/soname_flags/BUILD
+++ b/cc/toolchains/args/soname_flags/BUILD
@@ -4,7 +4,7 @@ load("//cc/toolchains:feature.bzl", "cc_feature")
 cc_feature(
     name = "feature",
     args = select({
-        "//cc/toolchains/platforms:apple": [":apple_set_install_name"],
+        "//cc/settings:apple_constraint": [":apple_set_install_name"],
         "//conditions:default": [],
     }),
     feature_name = "_soname_flags",  # Doesn't override legacy feature, but shouldn't be disabled
@@ -17,7 +17,7 @@ cc_args(
     args = ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
     format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
-    target_compatible_with = ["//cc/toolchains/platforms:apple"],
+    target_compatible_with = ["//cc/settings:apple_constraint"],
 )
 
 cc_args(

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -42,7 +42,7 @@ cc_args(
     name = "preserve_dates",
     actions = ["//cc/toolchains/actions:strip"],
     args = select({
-        "@platforms//os:macos": [],
+        "//cc/toolchains/platforms:apple": [],
         "@platforms//os:windows": [],
         "//conditions:default": ["-p"],
     }),

--- a/cc/toolchains/args/strip_flags/BUILD
+++ b/cc/toolchains/args/strip_flags/BUILD
@@ -42,7 +42,7 @@ cc_args(
     name = "preserve_dates",
     actions = ["//cc/toolchains/actions:strip"],
     args = select({
-        "//cc/toolchains/platforms:apple": [],
+        "//cc/settings:apple_constraint": [],
         "@platforms//os:windows": [],
         "//conditions:default": ["-p"],
     }),

--- a/cc/toolchains/platforms/BUILD
+++ b/cc/toolchains/platforms/BUILD
@@ -1,0 +1,19 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+selects.config_setting_group(
+    name = "default_apple",
+    match_any = [
+        "@platforms//os:ios",
+        "@platforms//os:macos",
+        "@platforms//os:tvos",
+        "@platforms//os:visionos",
+        "@platforms//os:watchos",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+label_flag(
+    name = "apple",
+    build_setting_default = ":default_apple",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This allows you to write a rules based toolchain that targets Apple
platforms that aren't macOS.

I made this overridable since there are other constraints in apple_support
that denote you're building for an apple platform. But those only matter
if you're building a non-standard platform.

Fixes https://github.com/bazelbuild/rules_cc/issues/370
