### PR TITLE
Register DUMPBIN on Windows when using clang-cl

### DIFF
--- a/cc/private/toolchain/windows_cc_configure.bzl
+++ b/cc/private/toolchain/windows_cc_configure.bzl
@@ -718,6 +718,7 @@ def _get_msvc_vars(repository_ctx, paths, target_arch = "x64", msvc_vars_x64 = N
         build_tools["LIB"] = find_llvm_tool(repository_ctx, llvm_path, "llvm-lib.exe")
         if not build_tools["LIB"]:
             build_tools["LIB"] = find_msvc_tool(repository_ctx, vc_path, "lib.exe", "x64")
+        build_tools["DUMPBIN"] = find_msvc_tool(repository_ctx, vc_path, "dumpbin.exe", "x64")
     else:
         build_tools = _find_msvc_tools(repository_ctx, vc_path, target_arch)
 


### PR DESCRIPTION
This is an updated version of #363.

Without this change, it is not possible to build with clang-cl on Windows.

This is the error this PR fixes:

```
ERROR: C:/users/.../g2xpdmbf/external/rules_cc+/cc/private/toolchain/windows_cc_configure.bzl:756:64: An error occurred during the fetch of repository 'rules_cc++cc_configure_extension+local_config_cc':
   Traceback (most recent call last):
        File "C:/users/.../g2xpdmbf/external/rules_cc+/cc/private/toolchain/cc_configure.bzl", line 94, column 36, in cc_autoconf_impl
                configure_windows_toolchain(repository_ctx)
        File "C:/users/.../g2xpdmbf/external/rules_cc+/cc/private/toolchain/windows_cc_configure.bzl", line 922, column 35, in configure_windows_toolchain
                msvc_vars_x64 = _get_msvc_vars(repository_ctx, paths, "x64")
        File "C:/users/.../g2xpdmbf/external/rules_cc+/cc/private/toolchain/windows_cc_configure.bzl", line 756, column 64, in _get_msvc_vars
                "%{msvc_dumpbin_path_" + target_arch + "}": build_tools["DUMPBIN"],
Error: key "DUMPBIN" not found in dictionary
ERROR: no such package '@@rules_cc++cc_configure_extension+local_config_cc//': key "DUMPBIN" not found in dictionary
```