### PR TITLE
fix: use depset instead of None

### DIFF
--- a/cc/private/link/create_linking_context_from_compilation_outputs.bzl
+++ b/cc/private/link/create_linking_context_from_compilation_outputs.bzl
@@ -124,7 +124,7 @@ def create_linking_context_from_compilation_outputs(
     linker_input = create_linker_input(
         # TODO(b/331164666): remove cheat, we always produce a file, file.owner gives us a label
         owner = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name),
-        libraries = depset([cc_linking_outputs.library_to_link]) if cc_linking_outputs.library_to_link else None,
+        libraries = depset([cc_linking_outputs.library_to_link] if cc_linking_outputs.library_to_link else []),
         user_link_flags = user_link_flags,
         additional_inputs = additional_inputs,
     )


### PR DESCRIPTION
Under create_linker_input.bzl call to:
```
libraries = _cc_internal.freeze(libraries.to_list())
```
is causing following error:
`Error: 'NoneType' value has no field of method 'to_list()'`