### PR TITLE
Add support for `-fstack-usage`

### DIFF
--- a/cc/private/compile/cc_compilation_outputs.bzl
+++ b/cc/private/compile/cc_compilation_outputs.bzl
@@ -33,6 +33,8 @@ CcCompilationOutputsInfo = provider(
         "_pic_dwo_files": "(list[File]) All .pic.dwo files built by the target, corresponding to .pic.o outputs.",
         "_gcno_files": "(list[File]) All .gcno files built by the target, corresponding to .o outputs.",
         "_pic_gcno_files": "(list[File]) All .pic.gcno files built by the target, corresponding to .pic.gcno outputs.",
+        "_su_files": "(list[File]) All .su files built by the target, corresponding to .o outputs.",
+        "_pic_su_files": "(list[File]) All .pic.su files built by the target, corresponding to .pic.o outputs.",
         "temps": '(() -> depset[File]) All artifacts that are created if "--save_temps" is true.',
         "_header_tokens": "(list[File]) All token .h.processed files created when preprocessing or parsing headers.",
         "_module_files": "(list[File]) All .pcm files built by the target.",
@@ -52,6 +54,8 @@ def create_compilation_outputs_internal(
         pic_dwo_files = [],
         gcno_files = [],
         pic_gcno_files = [],
+        su_files = [],
+        pic_su_files = [],
         temps = [],
         header_tokens = [],
         module_files = [],
@@ -69,6 +73,8 @@ def create_compilation_outputs_internal(
         pic_dwo_files: A list of PIC dwo files.
         gcno_files: A list of gcno files.
         pic_gcno_files: A list of PIC gcno files.
+        su_files: A list of stack usage files.
+        pic_su_files: A list of PIC stack usage files.
         temps: A depset of temporary files.
         header_tokens: A list of header tokens.
         module_files: A list of module files.
@@ -91,6 +97,8 @@ def create_compilation_outputs_internal(
         _lto_compilation_context = lto_compilation_context,
         _gcno_files = _cc_internal.freeze(gcno_files),
         _pic_gcno_files = _cc_internal.freeze(pic_gcno_files),
+        _su_files = _cc_internal.freeze(su_files),
+        _pic_su_files = _cc_internal.freeze(pic_su_files),
         _dwo_files = _cc_internal.freeze(dwo_files),
         _pic_dwo_files = _cc_internal.freeze(pic_dwo_files),
         cpp_module_files = _cc_internal.freeze(cpp_module_files),
@@ -194,6 +202,8 @@ def merge_compilation_outputs(*, compilation_outputs):
     pic_dwo_files = []
     gcno_files = []
     pic_gcno_files = []
+    su_files = []
+    pic_su_files = []
     lto_compilation_contexts = []
     transitive_temps = []
     header_tokens = []
@@ -206,6 +216,8 @@ def merge_compilation_outputs(*, compilation_outputs):
         pic_dwo_files.extend(co._pic_dwo_files)
         gcno_files.extend(co._gcno_files)
         pic_gcno_files.extend(co._pic_gcno_files)
+        su_files.extend(co._su_files)
+        pic_su_files.extend(co._pic_su_files)
         transitive_temps.append(co.temps())
         header_tokens.extend(co._header_tokens)
         module_files.extend(co._module_files)
@@ -220,6 +232,8 @@ def merge_compilation_outputs(*, compilation_outputs):
         _pic_dwo_files = pic_dwo_files,
         _gcno_files = gcno_files,
         _pic_gcno_files = pic_gcno_files,
+        _su_files = su_files,
+        _pic_su_files = pic_su_files,
         temps = wrap_with_check_private_api(depset(transitive = transitive_temps)),
         _header_tokens = header_tokens,
         _module_files = module_files,

--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -344,6 +344,8 @@ def compile(
         "lto_compilation_context": {},
         "gcno_files": [],
         "pic_gcno_files": [],
+        "su_files": [],
+        "pic_su_files": [],
         "dwo_files": [],
         "pic_dwo_files": [],
         "cpp_module_files": [],
@@ -1600,6 +1602,16 @@ def _create_compile_source_action(
             object_file = object_file,
         )
 
+    su_file = None
+    if feature_configuration.is_enabled("generate_stack_usage"):
+        su_file_name = paths.replace_extension(paths.basename(object_file.path), ".su")
+        su_file = _cc_internal.declare_other_output_file(
+            ctx = action_construction_context,
+            output_name = su_file_name,
+            object_file = object_file,
+        )
+        additional_outputs = list(additional_outputs) + [su_file]
+
     lto_indexing_file = None
     if bitcode_output and not feature_configuration.is_enabled("no_use_lto_indexing_bitcode_file"):
         lto_indexing_file_name = paths.replace_extension(
@@ -1678,15 +1690,13 @@ def _create_compile_source_action(
         additional_inputs = additional_compilation_inputs + auxiliary_fdo_inputs.to_list()
 
     # Provide these args conditionally as they require a recent version of Bazel.
+    module_args = {}
+    if additional_outputs:
+        module_args["additional_outputs"] = additional_outputs
     if modmap_file:
-        module_args = {
-            "additional_outputs": additional_outputs,
-            "module_files": module_files,
-            "modmap_file": modmap_file,
-            "modmap_input_file": modmap_input_file,
-        }
-    else:
-        module_args = {}
+        module_args["module_files"] = module_files
+        module_args["modmap_file"] = modmap_file
+        module_args["modmap_input_file"] = modmap_input_file
 
     _cc_internal.create_cc_compile_action(
         action_construction_context = action_construction_context,
@@ -1733,6 +1743,11 @@ def _create_compile_source_action(
             outputs["pic_gcno_files"].append(gcno_file)
         else:
             outputs["gcno_files"].append(gcno_file)
+    if su_file:
+        if use_pic:
+            outputs["pic_su_files"].append(su_file)
+        else:
+            outputs["su_files"].append(su_file)
     return object_file
 
 def _create_temps_action(

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -792,6 +792,9 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         output_groups["def_file"] = depset([generated_def_file])
     if linkmap:
         output_groups["linkmap"] = depset([linkmap])
+    su_files = list(cc_compilation_outputs._su_files) + list(cc_compilation_outputs._pic_su_files)
+    if su_files:
+        output_groups["stack_usage"] = depset(su_files)
 
     if cc_linking_outputs_binary_library != None:
         # For consistency and readability.

--- a/cc/private/rules_impl/cc_library_impl.bzl
+++ b/cc/private/rules_impl/cc_library_impl.bzl
@@ -334,6 +334,9 @@ def _cc_library_impl(ctx):
     merged_output_groups = cc_helper.merge_output_groups(
         [current_output_groups, output_group_builder],
     )
+    su_files = list(compilation_outputs._su_files) + list(compilation_outputs._pic_su_files)
+    if su_files:
+        merged_output_groups["stack_usage"] = depset(su_files)
 
     providers.append(cc_info)
     providers.append(OutputGroupInfo(**merged_output_groups))

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1571,6 +1571,20 @@ def _impl(ctx):
         ],
     )
 
+    generate_stack_usage_feature = feature(
+        name = "generate_stack_usage",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fstack-usage"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     output_execpath_flags_feature = feature(
         name = "output_execpath_flags",
         flag_sets = [
@@ -1854,6 +1868,7 @@ def _impl(ctx):
             build_interface_libraries_feature,
             dynamic_library_linker_tool_feature,
             generate_linkmap_feature,
+            generate_stack_usage_feature,
             shared_flag_feature,
             linkstamps_feature,
             output_execpath_flags_feature,
@@ -1948,6 +1963,7 @@ def _impl(ctx):
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
             generate_linkmap_feature,
+            generate_stack_usage_feature,
             no_dotd_file_feature,
         ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = True)
 


### PR DESCRIPTION
This PR adds support for `-fstack-usage` by adding a `generate_stack_usage` feature. I roughly tried to follow the `generate_linkmap` feature as a template.

I left Windows support out because it seems like MSVC doesn't support this and I have no Windows machine to test on, but I can look into this if desired.

If this PR is roughly acceptable I would also like to contribute a similar PR for GCC's `-fcallgraph-info`. The motivation is for an embedded target I could compute necessary stack usage at build time and give each processor on my target exactly the amount of stack it needs to not waste any IRAM space which I only have tens of kilobytes of.

I'm not sure if this is the correct approach, or if something that solves this problem in a more general way (like a fix for https://github.com/bazelbuild/rules_cc/issues/594) is preferred. Apologies if this is naive in some way, this is at (or past!) the limits of my bazel knowledge 😃 

Example usage:
```
david@Davids-Mac-mini stack_usage_test % cat BUILD *.cc
# BUILD
load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
load("@rules_cc//cc:cc_library.bzl", "cc_library")

cc_library(
    name = "math",
    srcs = ["math.cc"],
    hdrs = ["math.h"],
    features = ["generate_stack_usage"],
)

cc_binary(
    name = "main",
    srcs = ["main.cc"],
    deps = [":math"],
    features = ["generate_stack_usage"],
)
// main.cc
#include <cstdio>
#include "math.h"

int main() {
    int x = add(3, 4);
    int y = multiply(x, 5);
    printf("%d\n", y);
    return 0;
}
// math.cc
#include "math.h"

int add(int a, int b) {
    int result = a + b;
    return result;
}

int multiply(int a, int b) {
    int result = a * b;
    return result;
}
david@Davids-Mac-mini stack_usage_test % bazelisk build //...
Starting local Bazel server (9.0.0) and connecting to it...
INFO: Analyzed 2 targets (86 packages loaded, 475 targets configured).
INFO: Found 2 targets...
INFO: Elapsed time: 3.237s, Critical Path: 0.30s
INFO: 9 processes: 5 action cache hit, 5 internal, 4 darwin-sandbox.
INFO: Build completed successfully, 9 total actions
david@Davids-Mac-mini stack_usage_test % cat bazel-bin/_objs/main/main.su bazel-bin/_objs/math/math.su
main.cc:5:main  48      static
math.cc:4:_Z3addii      16      static
math.cc:9:_Z8multiplyii 16      static
```