### PR TITLE
Allow 'includes = ["."]' in the root of the repo

### DIFF
--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -818,10 +818,6 @@ def _include_dirs(ctx, additional_make_variable_substitutions):
         if not sibling_repository_layout and path_contains_up_level_references(includes_path):
             fail("Path references a path above the execution root.", attr = "includes")
 
-        if includes_path == ".":
-            fail("'" + includes_attr + "' resolves to the workspace root, which would allow this rule and all of its " +
-                 "transitive dependents to include any file in your workspace. Please include only" +
-                 " what you need", attr = "includes")
         result.append(includes_path)
 
         # We don't need to perform the above checks against out_includes_path again since any errors


### PR DESCRIPTION
This isn't really something you want to do in a large project, but this
is a very common requirement of open source libraries that are part of
the BCR. Today they are buildable when pulled in through bzlmod, but not
when you're testing changes to them directly.

Bazel already adds an `-iquote .` to the root of the repo for all
builds, so if something is in your dependency tree, you can include it
relatively with the path from the root. If you want to guard against
that you can use layering_check to make sure deps are explicitly
defined.

Fixes https://github.com/bazelbuild/rules_cc/issues/453
