### PR TITLE
Retain module map names as `Label`s

### DIFF
--- a/cc/private/cc_info.bzl
+++ b/cc/private/cc_info.bzl
@@ -148,22 +148,22 @@ _ModuleMapInfo = provider(
     "ModuleMapInfo",
     fields = {
         "file": "The module map file.",
-        "name": "The name of the module.",
+        "identifier": "The identifier of the module, either a label or a string.",
     },
 )
 
-def create_module_map(*, file, name):
+def create_module_map(*, file, identifier):
     """
     Creates a module map struct.
 
     Args:
         file: The module map file.
-        name: The name of the module.
+        identifier: The identifier of the module.
     Returns:
         A module map struct.
     """
     check_private_api()
-    return _ModuleMapInfo(file = file, name = name)
+    return _ModuleMapInfo(file = file, identifier = identifier)
 
 def create_separate_module_map(module_map):
     """
@@ -174,7 +174,11 @@ def create_separate_module_map(module_map):
     Returns:
         A module map struct.
     """
-    return _ModuleMapInfo(file = module_map.file, name = module_map.name + ".sep")
+    if type(module_map.identifier) == type(""):
+        identifier = module_map.identifier + ".sep"
+    else:
+        identifier = module_map.identifier.same_package_label(module_map.identifier.name + ".sep")
+    return _ModuleMapInfo(file = module_map.file, identifier = identifier)
 
 def create_linking_context(
         *,

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -213,10 +213,17 @@ _ModuleMapInfo = provider(
     ],
 )
 
+def _stringify_module_map_identifier(label_or_string):
+    unambiguous_canonical_label_string = str(label_or_string)
+    # buildifier: disable=canonical-repository
+    if unambiguous_canonical_label_string.startswith("@@"):
+        return unambiguous_canonical_label_string[2:]
+    return unambiguous_canonical_label_string
+
 def _module_map_struct_to_module_map_content(parameters, tree_expander):
     lines = []
     module_map = parameters.module_map
-    lines.append("module \"%s\" {" % module_map.name)
+    lines.append("module \"%s\" {" % _stringify_module_map_identifier(module_map.identifier))
     lines.append("  export *")
 
     def expanded(artifacts):
@@ -288,10 +295,10 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
 
     dependency_module_maps = parameters.dependency_module_maps.to_list()
     for dep in dependency_module_maps:
-        lines.append("  use \"" + dep.name + "\"")
+        lines.append("  use \"" + _stringify_module_map_identifier(dep.identifier) + "\"")
 
     if parameters.separate_module_headers:
-        separate_name = module_map.name + ".sep"
+        separate_name = _stringify_module_map_identifier(module_map.identifier) + ".sep"
         lines.append("  use \"" + separate_name + "\"")
         lines.append("}")
         lines.append("module \"" + separate_name + "\" {")
@@ -305,14 +312,14 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
             added_paths.add(header.path)
 
         for dep in dependency_module_maps:
-            lines.append("  use \"" + dep.name + "\"")
+            lines.append("  use \"" + _stringify_module_map_identifier(dep.identifier) + "\"")
 
     lines.append("}")
 
     if parameters.extern_dependencies:
         for dep in dependency_module_maps:
             lines.append(
-                "extern module \"" + dep.name + "\" \"" +
+                "extern module \"" + _stringify_module_map_identifier(dep.identifier) + "\" \"" +
                 parameters.leading_periods + dep.file.path + "\"",
             )
 
@@ -518,7 +525,7 @@ def _init_cc_compilation_context(
         if not module_map:
             module_map = create_module_map(
                 file = actions.declare_file(label.name + ".cppmap"),
-                name = label.workspace_name + "//" + label.package + ":" + label.name,
+                identifier = label,
             )
 
         # There are different modes for module compilation:

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -213,7 +213,7 @@ _ModuleMapInfo = provider(
     ],
 )
 
-def _stringify_module_map_identifier(label_or_string):
+def stringify_module_map_identifier(label_or_string):
     unambiguous_canonical_label_string = str(label_or_string)
     # buildifier: disable=canonical-repository
     if unambiguous_canonical_label_string.startswith("@@"):
@@ -223,7 +223,7 @@ def _stringify_module_map_identifier(label_or_string):
 def _module_map_struct_to_module_map_content(parameters, tree_expander):
     lines = []
     module_map = parameters.module_map
-    lines.append("module \"%s\" {" % _stringify_module_map_identifier(module_map.identifier))
+    lines.append("module \"%s\" {" % stringify_module_map_identifier(module_map.identifier))
     lines.append("  export *")
 
     def expanded(artifacts):
@@ -295,10 +295,10 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
 
     dependency_module_maps = parameters.dependency_module_maps.to_list()
     for dep in dependency_module_maps:
-        lines.append("  use \"" + _stringify_module_map_identifier(dep.identifier) + "\"")
+        lines.append("  use \"" + stringify_module_map_identifier(dep.identifier) + "\"")
 
     if parameters.separate_module_headers:
-        separate_name = _stringify_module_map_identifier(module_map.identifier) + ".sep"
+        separate_name = stringify_module_map_identifier(module_map.identifier) + ".sep"
         lines.append("  use \"" + separate_name + "\"")
         lines.append("}")
         lines.append("module \"" + separate_name + "\" {")
@@ -312,14 +312,14 @@ def _module_map_struct_to_module_map_content(parameters, tree_expander):
             added_paths.add(header.path)
 
         for dep in dependency_module_maps:
-            lines.append("  use \"" + _stringify_module_map_identifier(dep.identifier) + "\"")
+            lines.append("  use \"" + stringify_module_map_identifier(dep.identifier) + "\"")
 
     lines.append("}")
 
     if parameters.extern_dependencies:
         for dep in dependency_module_maps:
             lines.append(
-                "extern module \"" + _stringify_module_map_identifier(dep.identifier) + "\" \"" +
+                "extern module \"" + stringify_module_map_identifier(dep.identifier) + "\" \"" +
                 parameters.leading_periods + dep.file.path + "\"",
             )
 

--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -1148,7 +1148,7 @@ def _create_cc_compile_actions(
 
     if _should_provide_header_modules(feature_configuration, private_headers, public_headers):
         cpp_module_map = cc_compilation_context._module_map
-        module_map_label = Label(cpp_module_map.name)
+        module_map_label = Label(cpp_module_map.identifier)
         modules = _create_module_action(
             action_construction_context = action_construction_context,
             cc_compilation_context = cc_compilation_context,
@@ -2105,7 +2105,7 @@ def _create_module_action(
         additional_compilation_inputs,
         additional_include_scanning_roots,
         outputs):
-    module_map_label = Label(cpp_module_map.name)
+    module_map_label = Label(cpp_module_map.identifier)
     return _create_pic_nopic_compile_source_actions(
         action_construction_context = action_construction_context,
         cc_compilation_context = cc_compilation_context,

--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -18,6 +18,7 @@ All build variables we create for various `CppCompileAction`s
 load("//cc/common:cc_helper_internal.bzl", "extensions", "get_fdo_build_stamp", "get_linkstamp_stamps", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
 load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
+load(":cc_compilation_helper.bzl", "stringify_module_map_identifier")
 
 # deliberately short name for less clutter while using in this file, we can have
 # a different symbol with a more descriptive name if we ever export this
@@ -310,7 +311,7 @@ def get_specific_compile_build_variables(
     result = {}
 
     if feature_configuration.is_enabled("module_maps") and cpp_module_map:
-        result[_VARS.MODULE_NAME] = str(cpp_module_map.identifier)
+        result[_VARS.MODULE_NAME] = stringify_module_map_identifier(cpp_module_map.identifier)
         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
 

--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -310,7 +310,7 @@ def get_specific_compile_build_variables(
     result = {}
 
     if feature_configuration.is_enabled("module_maps") and cpp_module_map:
-        result[_VARS.MODULE_NAME] = cpp_module_map.name
+        result[_VARS.MODULE_NAME] = str(cpp_module_map.identifier)
         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
 

--- a/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
+++ b/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
@@ -230,7 +230,7 @@ def get_cc_toolchain_provider(ctx, attributes):
 
     module_map = None
     if attributes.module_map != None and attributes.module_map_artifact != None:
-        module_map = cc_common.create_module_map(file = attributes.module_map_artifact, name = "crosstool")
+        module_map = cc_common.create_module_map(file = attributes.module_map_artifact, identifier = "crosstool")
 
     cc_compilation_context = cc_common.create_compilation_context(module_map = module_map)
 

--- a/cc/private/rules_impl/objc_intermediate_artifacts.bzl
+++ b/cc/private/rules_impl/objc_intermediate_artifacts.bzl
@@ -55,13 +55,13 @@ def _swift_module_map(ctx):
             ctx,
             ".modulemaps/module.modulemap",
         ),
-        name = module_name,
+        identifier = module_name,
     )
 
 def _internal_module_map(ctx):
     return cc_common.create_module_map(
         file = _declare_file_with_extension(ctx, ".internal.cppmap"),
-        name = str(ctx.label),
+        identifier = ctx.label,
     )
 
 def _create_closure_struct(ctx, archive_file_name_suffix, enforce_always_link):


### PR DESCRIPTION
With the exception of special module map names, all of them are effectively labels. This commit ensures that they are retained as `Label`s, not label string and thus:
* memory usage is reduced for module maps from external repos, whose module map name previously resulted in a newly retained string;
* module map names now use properly formatted external repo labels as names, which makes it more obvious what they are;
* the roundtrip in header module compilation flows is avoided. This actually fixes a bug where the missing `@@` prefix for label strings resulted in incorrect or even failing `Label` calls due to main repo labels being resolved relative to the rules_cc repo and external repo labels failing the validation of the `Label` constructor.