### PR TITLE
Add more missing variables for objc_executable action

### DIFF
--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -361,6 +361,41 @@ cc_variable(
     type = types.option(types.list(types.file)),
 )
 
+# TODO: Remove when we drop bazel 8.x support
+cc_variable(
+    name = "filelist",
+    actions = ["//cc/toolchains/actions:objc_executable"],
+    type = types.option(types.file),
+)
+
+# TODO: Remove when we drop bazel 8.x support
+cc_variable(
+    name = "linked_binary",
+    actions = ["//cc/toolchains/actions:objc_executable"],
+    type = types.option(types.file),
+)
+
+# TODO: Remove when we drop bazel 8.x support
+cc_variable(
+    name = "force_load_exec_paths",
+    actions = ["//cc/toolchains/actions:objc_executable"],
+    type = types.option(types.list(types.file)),
+)
+
+# TODO: Remove when we drop bazel 8.x support
+cc_variable(
+    name = "dep_linkopts",
+    actions = ["//cc/toolchains/actions:objc_executable"],
+    type = types.option(types.list(types.string)),
+)
+
+# TODO: Remove when we drop bazel 8.x support
+cc_variable(
+    name = "attr_linkopts",
+    actions = ["//cc/toolchains/actions:objc_executable"],
+    type = types.option(types.list(types.string)),
+)
+
 cc_variable(
     name = "linkmap_exec_path",
     actions = ["//cc/toolchains/actions:link_actions"],
@@ -532,9 +567,11 @@ cc_variable(
 cc_builtin_variables(
     name = "variables",
     srcs = [
+        ":attr_linkopts",
         ":cc_library_exec_paths",
         ":cs_fdo_instrument_path",
         ":def_file_path",
+        ":dep_linkopts",
         ":dependency_file",
         ":dependent_module_map_files",
         ":dsym_path",
@@ -542,6 +579,8 @@ cc_builtin_variables(
         ":fdo_instrument_path",
         ":fdo_prefetch_hints_path",
         ":fdo_profile_path",
+        ":filelist",
+        ":force_load_exec_paths",
         ":force_pic",
         ":framework_include_paths",
         ":fully_linked_archive_path",
@@ -561,6 +600,7 @@ cc_builtin_variables(
         ":legacy_link_flags",
         ":libraries_to_link",
         ":library_search_directories",
+        ":linked_binary",
         ":linker_param_file",
         ":linkmap_exec_path",
         ":linkstamp_paths",


### PR DESCRIPTION
Before bazel 9.x there were a lot of one off variables for
objc_executable. These are required in order to link Apple specific
binaries from rules_apple
