### PR TITLE
Remove unnecessary requires for archiver_flags

### DIFF
--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -47,7 +47,6 @@ cc_args(
         ],
         "//conditions:default": ["rcsD"],
     }),
-    requires_not_none = "//cc/toolchains/variables:output_execpath",
 )
 
 cc_args(

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
@@ -2,7 +2,6 @@ enabled: false
 flag_sets {
   actions: "c++-link-static-library"
   flag_groups {
-    expand_if_available: "output_execpath"
     flags: "-D"
     flags: "-no_warning_for_no_symbols"
     flags: "-static"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
@@ -2,7 +2,6 @@ enabled: false
 flag_sets {
   actions: "c++-link-static-library"
   flag_groups {
-    expand_if_available: "output_execpath"
     flags: "rcsD"
   }
 }


### PR DESCRIPTION
These args don't use this variable, so it doesn't need to confuse things
here (realistically if this isn't set this action will fail too)
