### PR TITLE
Add default objc_fully_link config

### DIFF
--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -201,7 +201,10 @@ cc_action_type(
 
 cc_action_type_set(
     name = "ar_actions",
-    actions = [":cpp_link_static_library"],
+    actions = [
+        ":cpp_link_static_library",
+        ":objc_fully_link",
+    ],
 )
 
 cc_action_type_set(

--- a/cc/toolchains/args/archiver_flags/BUILD
+++ b/cc/toolchains/args/archiver_flags/BUILD
@@ -31,7 +31,11 @@ cc_args_list(
     args = [
         ":create_static_archive",
         ":output_execpath",
+        ":objc_fully_link_archive_path",
         ":libraries_to_link",
+        ":objc_fully_link_objc_library_exec_paths",
+        ":objc_fully_link_cc_library_exec_paths",
+        ":objc_fully_link_imported_library_exec_paths",
     ],
     visibility = ["//visibility:public"],
 )
@@ -51,7 +55,7 @@ cc_args(
 
 cc_args(
     name = "output_execpath",
-    actions = ["//cc/toolchains/actions:ar_actions"],
+    actions = ["//cc/toolchains/actions:cpp_link_static_library"],
     args = select({
         ":use_libtool_on_macos_setting": ["-o"],
         "//conditions:default": [],
@@ -62,7 +66,7 @@ cc_args(
 
 cc_args(
     name = "libraries_to_link",
-    actions = ["//cc/toolchains/actions:ar_actions"],
+    actions = ["//cc/toolchains/actions:cpp_link_static_library"],
     nested = ["libraries_to_link_expansion"],
     requires_not_none = "//cc/toolchains/variables:libraries_to_link",
 )
@@ -91,4 +95,42 @@ cc_nested_args(
     iterate_over = "//cc/toolchains/variables:libraries_to_link.object_files",
     requires_equal = "//cc/toolchains/variables:libraries_to_link.type",
     requires_equal_value = "object_file_group",
+)
+
+cc_args(
+    name = "objc_fully_link_archive_path",
+    actions = ["//cc/toolchains/actions:objc_fully_link"],
+    args = select({
+        ":use_libtool_on_macos_setting": ["-o"],
+        "//conditions:default": [],
+    }) + ["{fully_linked_archive_path}"],
+    format = {"fully_linked_archive_path": "//cc/toolchains/variables:fully_linked_archive_path"},
+    requires_not_none = "//cc/toolchains/variables:fully_linked_archive_path",
+)
+
+cc_args(
+    name = "objc_fully_link_objc_library_exec_paths",
+    actions = ["//cc/toolchains/actions:objc_fully_link"],
+    args = ["{objc_library_exec_paths}"],
+    format = {"objc_library_exec_paths": "//cc/toolchains/variables:objc_library_exec_paths"},
+    iterate_over = "//cc/toolchains/variables:objc_library_exec_paths",
+    requires_not_none = "//cc/toolchains/variables:objc_library_exec_paths",
+)
+
+cc_args(
+    name = "objc_fully_link_cc_library_exec_paths",
+    actions = ["//cc/toolchains/actions:objc_fully_link"],
+    args = ["{cc_library_exec_paths}"],
+    format = {"cc_library_exec_paths": "//cc/toolchains/variables:cc_library_exec_paths"},
+    iterate_over = "//cc/toolchains/variables:cc_library_exec_paths",
+    requires_not_none = "//cc/toolchains/variables:cc_library_exec_paths",
+)
+
+cc_args(
+    name = "objc_fully_link_imported_library_exec_paths",
+    actions = ["//cc/toolchains/actions:objc_fully_link"],
+    args = ["{imported_library_exec_paths}"],
+    format = {"imported_library_exec_paths": "//cc/toolchains/variables:imported_library_exec_paths"},
+    iterate_over = "//cc/toolchains/variables:imported_library_exec_paths",
+    requires_not_none = "//cc/toolchains/variables:imported_library_exec_paths",
 )

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -268,7 +268,7 @@ cc_variable(
 cc_variable(
     name = "linker_param_file",
     actions = [
-        "//cc/toolchains/actions:cpp_link_static_library",
+        "//cc/toolchains/actions:ar_actions",
         "//cc/toolchains/actions:link_actions",
     ],
     type = types.option(types.file),

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/archiver_flags.textproto
@@ -1,6 +1,7 @@
 enabled: false
 flag_sets {
   actions: "c++-link-static-library"
+  actions: "objc-fully-link"
   flag_groups {
     flags: "-D"
     flags: "-no_warning_for_no_symbols"
@@ -13,6 +14,14 @@ flag_sets {
     expand_if_available: "output_execpath"
     flags: "-o"
     flags: "%{output_execpath}"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "fully_linked_archive_path"
+    flags: "-o"
+    flags: "%{fully_linked_archive_path}"
   }
 }
 flag_sets {
@@ -37,6 +46,30 @@ flag_sets {
       }
       iterate_over: "libraries_to_link"
     }
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "objc_library_exec_paths"
+    flags: "%{objc_library_exec_paths}"
+    iterate_over: "objc_library_exec_paths"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "cc_library_exec_paths"
+    flags: "%{cc_library_exec_paths}"
+    iterate_over: "cc_library_exec_paths"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "imported_library_exec_paths"
+    flags: "%{imported_library_exec_paths}"
+    iterate_over: "imported_library_exec_paths"
   }
 }
 name: "archiver_flags_test"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/archiver_flags.textproto
@@ -1,6 +1,7 @@
 enabled: false
 flag_sets {
   actions: "c++-link-static-library"
+  actions: "objc-fully-link"
   flag_groups {
     flags: "rcsD"
   }
@@ -10,6 +11,13 @@ flag_sets {
   flag_groups {
     expand_if_available: "output_execpath"
     flags: "%{output_execpath}"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "fully_linked_archive_path"
+    flags: "%{fully_linked_archive_path}"
   }
 }
 flag_sets {
@@ -34,6 +42,30 @@ flag_sets {
       }
       iterate_over: "libraries_to_link"
     }
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "objc_library_exec_paths"
+    flags: "%{objc_library_exec_paths}"
+    iterate_over: "objc_library_exec_paths"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "cc_library_exec_paths"
+    flags: "%{cc_library_exec_paths}"
+    iterate_over: "cc_library_exec_paths"
+  }
+}
+flag_sets {
+  actions: "objc-fully-link"
+  flag_groups {
+    expand_if_available: "imported_library_exec_paths"
+    flags: "%{imported_library_exec_paths}"
+    iterate_over: "imported_library_exec_paths"
   }
 }
 name: "archiver_flags_test"

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
@@ -8,6 +8,7 @@ flag_sets {
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
   actions: "objc-executable"
+  actions: "objc-fully-link"
   flag_groups {
     expand_if_available: "linker_param_file"
     flags: "@%{linker_param_file}"


### PR DESCRIPTION
The objc-fully-link action looks very very similar to
cpp_link_static_library. The only difference is a few variable names.
This adds objc-fully-link to ar_actions, and sets up the default
arguments for it. Users may want to add `-arch_only` but this is better
than nothing.
