### PR TITLE
Add objc_fully_link to linker_param_file

### DIFF
--- a/cc/toolchains/args/linker_param_file/BUILD
+++ b/cc/toolchains/args/linker_param_file/BUILD
@@ -22,6 +22,7 @@ cc_args(
     actions = [
         "//cc/toolchains/actions:link_actions",
         "//cc/toolchains/actions:ar_actions",
+        "//cc/toolchains/actions:objc_fully_link",
     ],
     args = ["@{param_file}"],
     format = {"param_file": "//cc/toolchains/variables:linker_param_file"},

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -269,6 +269,7 @@ cc_variable(
     name = "linker_param_file",
     actions = [
         "//cc/toolchains/actions:cpp_link_static_library",
+        "//cc/toolchains/actions:objc_fully_link",
         "//cc/toolchains/actions:link_actions",
     ],
     type = types.option(types.file),

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/unix/linker_param_file.textproto
@@ -8,6 +8,7 @@ flag_sets {
   actions: "lto-index-for-executable"
   actions: "lto-index-for-nodeps-dynamic-library"
   actions: "objc-executable"
+  actions: "objc-fully-link"
   flag_groups {
     expand_if_available: "linker_param_file"
     flags: "@%{linker_param_file}"


### PR DESCRIPTION
This action goes through the same linking logic as
c++-link-static-library so it also gets this variable
