### PR TITLE
Allow using requires_none and requires_not_none at the same time

### DIFF
--- a/cc/toolchains/impl/nested_args.bzl
+++ b/cc/toolchains/impl/nested_args.bzl
@@ -24,7 +24,7 @@ visibility([
     "//tests/rule_based_toolchain/...",
 ])
 
-REQUIRES_MUTUALLY_EXCLUSIVE_ERR = "requires_none, requires_not_none, requires_true, requires_false, and requires_equal are mutually exclusive"
+REQUIRES_MUTUALLY_EXCLUSIVE_ERR = "requires_none and requires_not_none are mututally exclusive with requires_true, requires_false, and requires_equal"
 REQUIRES_NOT_NONE_ERR = "requires_not_none only works on options"
 REQUIRES_NONE_ERR = "requires_none only works on options"
 REQUIRES_TRUE_ERR = "requires_true only works on bools"
@@ -199,17 +199,11 @@ def nested_args_provider(
     transitive_files = [ea.files for ea in nested]
     transitive_files.append(files)
 
-    has_value = [attr for attr in [
-        requires_not_none,
-        requires_none,
-        requires_true,
-        requires_false,
-        requires_equal,
-    ] if attr != None]
-
     # We may want to reconsider this down the line, but it's easier to open up
     # an API than to lock down an API.
-    if len(has_value) > 1:
+    optional_checks = any([requires_not_none, requires_none])
+    boolean_checks = any([requires_true, requires_false, requires_equal])
+    if optional_checks and boolean_checks:
         fail(REQUIRES_MUTUALLY_EXCLUSIVE_ERR)
 
     kwargs = {}

--- a/cc/toolchains/impl/nested_args.bzl
+++ b/cc/toolchains/impl/nested_args.bzl
@@ -24,7 +24,9 @@ visibility([
     "//tests/rule_based_toolchain/...",
 ])
 
-REQUIRES_MUTUALLY_EXCLUSIVE_ERR = "requires_none and requires_not_none are mututally exclusive with requires_true, requires_false, and requires_equal"
+REQUIRES_MUTUALLY_EXCLUSIVE_ERR = "requires_none and requires_not_none are mutually exclusive with requires_true, requires_false, and requires_equal"
+REQUIRES_BOOLEAN_MUTUALLY_EXCLUSIVE_ERR = "requires_true, requires_false, and requires_equal are mutually exclusive"
+REQUIRES_NONE_SAME_VARIABLE_ERR = "requires_none and requires_not_none cannot reference the same variable"
 REQUIRES_NOT_NONE_ERR = "requires_not_none only works on options"
 REQUIRES_NONE_ERR = "requires_none only works on options"
 REQUIRES_TRUE_ERR = "requires_true only works on bools"
@@ -202,9 +204,17 @@ def nested_args_provider(
     # We may want to reconsider this down the line, but it's easier to open up
     # an API than to lock down an API.
     optional_checks = any([requires_not_none, requires_none])
-    boolean_checks = any([requires_true, requires_false, requires_equal])
+    boolean_checks = [attr for attr in [
+        requires_true,
+        requires_false,
+        requires_equal,
+    ] if attr != None]
     if optional_checks and boolean_checks:
         fail(REQUIRES_MUTUALLY_EXCLUSIVE_ERR)
+    if len(boolean_checks) > 1:
+        fail(REQUIRES_BOOLEAN_MUTUALLY_EXCLUSIVE_ERR)
+    if requires_not_none and requires_none and requires_not_none == requires_none:
+        fail(REQUIRES_NONE_SAME_VARIABLE_ERR)
 
     kwargs = {}
 
@@ -228,14 +238,14 @@ def nested_args_provider(
             after_option_unwrap = False,
         ))
         unwrap_options.append(requires_not_none)
-    elif requires_none:
+    if requires_none:
         kwargs["expand_if_not_available"] = requires_none
         requires_types.setdefault(requires_none, []).append(struct(
             msg = REQUIRES_NONE_ERR,
             valid_types = ["option"],
             after_option_unwrap = False,
         ))
-    elif requires_true:
+    if requires_true:
         kwargs["expand_if_true"] = requires_true
         requires_types.setdefault(requires_true, []).append(struct(
             msg = REQUIRES_TRUE_ERR,
@@ -243,7 +253,7 @@ def nested_args_provider(
             after_option_unwrap = True,
         ))
         unwrap_options.append(requires_true)
-    elif requires_false:
+    if requires_false:
         kwargs["expand_if_false"] = requires_false
         requires_types.setdefault(requires_false, []).append(struct(
             msg = REQUIRES_FALSE_ERR,
@@ -251,7 +261,7 @@ def nested_args_provider(
             after_option_unwrap = True,
         ))
         unwrap_options.append(requires_false)
-    elif requires_equal:
+    if requires_equal:
         if not requires_equal_value:
             fail(REQUIRES_EQUAL_VALUE_ERR)
         kwargs["expand_if_equal"] = variable_with_value(

--- a/tests/rule_based_toolchain/nested_args/nested_args_test.bzl
+++ b/tests/rule_based_toolchain/nested_args/nested_args_test.bzl
@@ -170,6 +170,14 @@ def _requires_types_test(env, targets):
         requires_none = "def",
         args = ["--foo"],
         expr = "mutually_exclusive",
+    ).ok()
+
+    _expect_that_nested(
+        env,
+        requires_not_none = "abc",
+        requires_true = "def",
+        args = ["--foo"],
+        expr = "mutually_exclusive",
     ).err().equals(REQUIRES_MUTUALLY_EXCLUSIVE_ERR)
 
     _expect_that_nested(

--- a/tests/rule_based_toolchain/nested_args/nested_args_test.bzl
+++ b/tests/rule_based_toolchain/nested_args/nested_args_test.bzl
@@ -18,9 +18,12 @@ load("//cc:cc_toolchain_config_lib.bzl", "flag_group", "variable_with_value")
 load(
     "//cc/toolchains/impl:nested_args.bzl",
     "FORMAT_ARGS_ERR",
+    "REQUIRES_BOOLEAN_MUTUALLY_EXCLUSIVE_ERR",
     "REQUIRES_EQUAL_ERR",
     "REQUIRES_MUTUALLY_EXCLUSIVE_ERR",
     "REQUIRES_NONE_ERR",
+    "REQUIRES_NONE_SAME_VARIABLE_ERR",
+    "REQUIRES_NOT_NONE_ERR",
     "format_list",
     "nested_args_provider",
 )
@@ -164,13 +167,38 @@ def _iterate_over_test(env, targets):
     nested.requires_types().contains_exactly({})
 
 def _requires_types_test(env, targets):
-    _expect_that_nested(
+    combined = _expect_that_nested(
         env,
         requires_not_none = "abc",
         requires_none = "def",
         args = ["--foo"],
-        expr = "mutually_exclusive",
+        expr = "requires_not_none_and_requires_none",
     ).ok()
+    combined.legacy_flag_group().equals(flag_group(
+        expand_if_available = "abc",
+        expand_if_not_available = "def",
+        flags = ["--foo"],
+    ))
+    combined.requires_types().contains_exactly({
+        "abc": [struct(
+            msg = REQUIRES_NOT_NONE_ERR,
+            valid_types = ["option"],
+            after_option_unwrap = False,
+        )],
+        "def": [struct(
+            msg = REQUIRES_NONE_ERR,
+            valid_types = ["option"],
+            after_option_unwrap = False,
+        )],
+    })
+
+    _expect_that_nested(
+        env,
+        requires_not_none = "abc",
+        requires_none = "abc",
+        args = ["--foo"],
+        expr = "requires_none_same_variable",
+    ).err().equals(REQUIRES_NONE_SAME_VARIABLE_ERR)
 
     _expect_that_nested(
         env,
@@ -179,6 +207,14 @@ def _requires_types_test(env, targets):
         args = ["--foo"],
         expr = "mutually_exclusive",
     ).err().equals(REQUIRES_MUTUALLY_EXCLUSIVE_ERR)
+
+    _expect_that_nested(
+        env,
+        requires_true = "abc",
+        requires_false = "def",
+        args = ["--foo"],
+        expr = "boolean_checks_mutually_exclusive",
+    ).err().equals(REQUIRES_BOOLEAN_MUTUALLY_EXCLUSIVE_ERR)
 
     _expect_that_nested(
         env,


### PR DESCRIPTION
This combination can be useful during migrations from old bazel build variables
to new ones. You add your args as requiring the new feature to be not
none, and the old feature to be none.
