### PR TITLE
Add new exec_cfg and  non_exec_cfg features

### DIFF
--- a/cc/private/toolchain_config/configure_features.bzl
+++ b/cc/private/toolchain_config/configure_features.bzl
@@ -153,6 +153,11 @@ def configure_features(
         else:
             all_features.append("nonhost")
 
+    if ctx.configuration.is_tool_configuration():
+        all_features.append("exec_cfg")
+    else:
+        all_features.append("non_exec_cfg")
+
     if ctx.configuration.coverage_enabled:
         all_features.extend(_get_coverage_features(cpp_configuration))
 

--- a/cc/private/toolchain_config/legacy_features.bzl
+++ b/cc/private/toolchain_config/legacy_features.bzl
@@ -167,6 +167,28 @@ def get_legacy_features(ctx, platform, existing_feature_names, linker_tool_path)
             )],
         ))
 
+    if "exec_cfg" not in existing_feature_names:
+        result.append(feature(
+            name = "exec_cfg",
+            flag_sets = [flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [flag_group(flags = ["-g0"])],
+            )],
+        ))
+
     if "preprocessor_defines" not in existing_feature_names:
         result.append(feature(
             name = "preprocessor_defines",


### PR DESCRIPTION
This allows adding custom copts when building for the exec config.
Previously this was done implicitly by bazel's exec transition, but
bazel wants to stop doing that because that is brittle and dependent on
crosstool configuration (for example it requires knowing what compiler
is being used on windows). This is added to the "legacy" features to
best effort maintain backwards compatibility

Fixes https://github.com/bazelbuild/bazel/issues/13308
Fixes https://github.com/bazelbuild/bazel/issues/24545
