### PR TITLE
Fix soname_flags visibility

### DIFF
--- a/cc/toolchains/args/soname_flags/BUILD
+++ b/cc/toolchains/args/soname_flags/BUILD
@@ -8,7 +8,7 @@ cc_feature(
         "//conditions:default": [],
     }),
     feature_name = "_soname_flags",  # Doesn't override legacy feature, but shouldn't be disabled
-    visibility = ["//cc/toolchains/args:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 cc_args(


### PR DESCRIPTION
Similar to the other `cc_feature`s this should be public if toolchains
want to manually reference it
