### PR TITLE
Remove use_module_maps from layering_check

### DIFF
--- a/cc/toolchains/args/layering_check/BUILD
+++ b/cc/toolchains/args/layering_check/BUILD
@@ -6,7 +6,6 @@
 # ],
 # known_features = [
 #     "@rules_cc//cc/toolchains/args/layering_check:layering_check",
-#     "@rules_cc//cc/toolchains/args/layering_check:use_module_maps",
 # ],
 #
 # And make sure you have 'module_map' set to a module map file that contains
@@ -25,13 +24,11 @@ cc_feature(
     feature_name = "module_maps",
 )
 
+# This is no longer necessary, and does nothing. It will be
+# removed in a future release.
 cc_feature(
     name = "use_module_maps",
-    args = [
-        ":dependent_module_map_files_args",
-    ],
     feature_name = "use_module_maps",
-    requires_any_of = [":module_maps"],
 )
 
 cc_feature(
@@ -40,9 +37,9 @@ cc_feature(
         ":layering_check_args",
         ":module_map_file_args",
         ":module_name_args",
+        ":dependent_module_map_files_args",
     ],
     feature_name = "layering_check",
-    implies = [":use_module_maps"],
 )
 
 cc_args(


### PR DESCRIPTION
In today's unix toolchain this feature is used to allow adding extra
compiler flags, otherwise it is not special. This simplifies what users
have to do to setup layering_check. If users want the same custom
compiler flags they can add another cc_args that is dependent on the
layering_check feature.
