### PR TITLE
Add action types for llvm-profdata and gcov

### DIFF
--- a/cc/action_names.bzl
+++ b/cc/action_names.bzl
@@ -52,6 +52,12 @@ PREPROCESS_ASSEMBLE_ACTION_NAME = "preprocess-assemble"
 # Name of the coverage action.
 LLVM_COV = "llvm-cov"
 
+# Name of the profile data merging action.
+LLVM_PROFDATA = "llvm-profdata"
+
+# Name of the coverage action when using gcov.
+GCOV = "gcov"
+
 # Name of the action producing ThinLto index.
 LTO_INDEXING_ACTION_NAME = "lto-indexing"
 
@@ -126,6 +132,8 @@ ACTION_NAMES = struct(
     assemble = ASSEMBLE_ACTION_NAME,
     preprocess_assemble = PREPROCESS_ASSEMBLE_ACTION_NAME,
     llvm_cov = LLVM_COV,
+    llvm_profdata = LLVM_PROFDATA,
+    gcov = GCOV,
     lto_indexing = LTO_INDEXING_ACTION_NAME,
     lto_backend = LTO_BACKEND_ACTION_NAME,
     cpp_header_analysis = CPP_HEADER_ANALYSIS_ACTION_NAME,

--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -464,17 +464,11 @@ def _get_compilation_contexts_from_deps(deps):
             compilation_contexts.append(dep[CcInfo].compilation_context)
     return compilation_contexts
 
-def _tool_path(cc_toolchain, tool, ctx = None, action_name = None):
+def _tool_path(cc_toolchain, tool, feature_configuration = None, action_name = None):
     tool = cc_toolchain._tool_paths.get(tool, None)
     if tool:
         return tool
-    if ctx != None and action_name != None:
-        feature_configuration = cc_common.configure_features(
-            ctx = ctx,
-            cc_toolchain = cc_toolchain,
-            requested_features = ctx.features,
-            unsupported_features = ctx.disabled_features,
-        )
+    if feature_configuration != None and action_name != None:
         if not cc_common.action_is_enabled(
             feature_configuration = feature_configuration,
             action_name = action_name,
@@ -1035,11 +1029,18 @@ def _get_coverage_environment(ctx, cc_config, cc_toolchain):
     if not ctx.configuration.coverage_enabled:
         return {}
 
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     # buildifier: disable=unsorted-dict-items
     env = {
-        "COVERAGE_GCOV_PATH": _tool_path(cc_toolchain, "gcov", ctx, ACTION_NAMES.gcov),
-        "LLVM_COV": _tool_path(cc_toolchain, "llvm-cov", ctx, ACTION_NAMES.llvm_cov),
-        "LLVM_PROFDATA": _tool_path(cc_toolchain, "llvm-profdata", ctx, ACTION_NAMES.llvm_profdata),
+        "COVERAGE_GCOV_PATH": _tool_path(cc_toolchain, "gcov", feature_configuration, ACTION_NAMES.gcov),
+        "LLVM_COV": _tool_path(cc_toolchain, "llvm-cov", feature_configuration, ACTION_NAMES.llvm_cov),
+        "LLVM_PROFDATA": _tool_path(cc_toolchain, "llvm-profdata", feature_configuration, ACTION_NAMES.llvm_profdata),
         "GENERATE_LLVM_LCOV": "1" if cc_config.generate_llvm_lcov() else "0",
     }
     for k in list(env.keys()):

--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -1025,16 +1025,9 @@ def _linkopts(ctx, additional_make_variable_substitutions, cc_toolchain):
         fail("in linkopts attribute of cc_library rule {}: Apple builds do not support statically linked binaries".format(ctx.label))
     return tokens
 
-def _get_coverage_environment(ctx, cc_config, cc_toolchain):
+def _get_coverage_environment(ctx, cc_config, cc_toolchain, feature_configuration):
     if not ctx.configuration.coverage_enabled:
         return {}
-
-    feature_configuration = cc_common.configure_features(
-        ctx = ctx,
-        cc_toolchain = cc_toolchain,
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
-    )
 
     # buildifier: disable=unsorted-dict-items
     env = {
@@ -1050,7 +1043,7 @@ def _get_coverage_environment(ctx, cc_config, cc_toolchain):
         env["FDO_DIR"] = cc_config.fdo_instrument()
     return env
 
-def _create_cc_instrumented_files_info(ctx, cc_config, cc_toolchain, metadata_files, virtual_to_original_headers = None):
+def _create_cc_instrumented_files_info(ctx, cc_config, cc_toolchain, feature_configuration, metadata_files, virtual_to_original_headers = None):
     source_extensions = extensions.CC_SOURCE + \
                         extensions.C_SOURCE + \
                         extensions.CC_HEADER + \
@@ -1058,7 +1051,7 @@ def _create_cc_instrumented_files_info(ctx, cc_config, cc_toolchain, metadata_fi
                         extensions.ASSEMBLER
     coverage_environment = {}
     if ctx.configuration.coverage_enabled:
-        coverage_environment = _get_coverage_environment(ctx, cc_config, cc_toolchain)
+        coverage_environment = _get_coverage_environment(ctx, cc_config, cc_toolchain, feature_configuration)
     coverage_support_files = cc_toolchain._coverage_files if ctx.configuration.coverage_enabled else depset([])
     info = coverage_common.instrumented_files_info(
         ctx = ctx,

--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for C++ rules."""
 
+load("//cc:action_names.bzl", "ACTION_NAMES")
 load("//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE")
 load("//cc/private:paths.bzl", "is_path_absolute")
 load("//cc/private/rules_impl:objc_common.bzl", "objc_common")
@@ -463,8 +464,28 @@ def _get_compilation_contexts_from_deps(deps):
             compilation_contexts.append(dep[CcInfo].compilation_context)
     return compilation_contexts
 
-def _tool_path(cc_toolchain, tool):
-    return cc_toolchain._tool_paths.get(tool, None)
+def _tool_path(cc_toolchain, tool, ctx = None, action_name = None):
+    tool = cc_toolchain._tool_paths.get(tool, None)
+    if tool:
+        return tool
+    if ctx != None and action_name != None:
+        feature_configuration = cc_common.configure_features(
+            ctx = ctx,
+            cc_toolchain = cc_toolchain,
+            requested_features = ctx.features,
+            unsupported_features = ctx.disabled_features,
+        )
+        if not cc_common.action_is_enabled(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ):
+            return None
+
+        return cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        )
+    return None
 
 def _get_toolchain_global_make_variables(cc_toolchain):
     result = {
@@ -1016,9 +1037,9 @@ def _get_coverage_environment(ctx, cc_config, cc_toolchain):
 
     # buildifier: disable=unsorted-dict-items
     env = {
-        "COVERAGE_GCOV_PATH": _tool_path(cc_toolchain, "gcov"),
-        "LLVM_COV": _tool_path(cc_toolchain, "llvm-cov"),
-        "LLVM_PROFDATA": _tool_path(cc_toolchain, "llvm-profdata"),
+        "COVERAGE_GCOV_PATH": _tool_path(cc_toolchain, "gcov", ctx, ACTION_NAMES.gcov),
+        "LLVM_COV": _tool_path(cc_toolchain, "llvm-cov", ctx, ACTION_NAMES.llvm_cov),
+        "LLVM_PROFDATA": _tool_path(cc_toolchain, "llvm-profdata", ctx, ACTION_NAMES.llvm_profdata),
         "GENERATE_LLVM_LCOV": "1" if cc_config.generate_llvm_lcov() else "0",
     }
     for k in list(env.keys()):

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -107,6 +107,7 @@ def _add_transitive_info_providers(ctx, cc_toolchain, cpp_config, feature_config
         ctx = ctx,
         cc_config = cpp_config,
         cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
         metadata_files = additional_meta_data + gcno_files + pic_gcno_files,
         virtual_to_original_headers =
             compilation_context.virtual_to_original_headers() if hasattr(compilation_context, "virtual_to_original_headers") else compilation_context._virtual_to_original_headers,

--- a/cc/private/rules_impl/cc_library_impl.bzl
+++ b/cc/private/rules_impl/cc_library_impl.bzl
@@ -273,6 +273,7 @@ def _cc_library_impl(ctx):
         ctx = ctx,
         cc_config = ctx.fragments.cpp,
         cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
         metadata_files = gcno_files + pic_gcno_files,
     )
 

--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -16,6 +16,7 @@
 
 load("//cc:build_settings.bzl", "cc")
 load("//cc:find_cc_toolchain.bzl", "find_cc_toolchain", "use_cc_toolchain")
+load("//cc/common:cc_common.bzl", "cc_common")
 load("//cc/common:cc_helper.bzl", "cc_helper")
 load("//cc/common:cc_info.bzl", "CcInfo")
 load("//cc/common:semantics.bzl", cc_semantics = "semantics")
@@ -86,12 +87,18 @@ def _objc_library_impl(ctx):
         pic_gcno_files = compilation_outputs.pic_gcno_files()
     else:
         pic_gcno_files = compilation_outputs._pic_gcno_files
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     instrumented_files_info = coverage_common.instrumented_files_info(
         ctx = ctx,
         source_attributes = ["srcs", "non_arc_srcs", "hdrs"],
         dependency_attributes = ["deps", "data", "binary", "xctest_app"],
         extensions = extensions.NON_CPP_SOURCES + extensions.CPP_SOURCES + extensions.HEADERS,
-        coverage_environment = cc_helper.get_coverage_environment(ctx, ctx.fragments.cpp, cc_toolchain),
+        coverage_environment = cc_helper.get_coverage_environment(ctx, ctx.fragments.cpp, cc_toolchain, feature_configuration),
         # TODO(cmita): Use ctx.coverage_instrumented() instead when rules_swift can access
         # cc_toolchain.coverage_files and the coverage_support_files parameter of
         # coverage_common.instrumented_files_info(...)

--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -89,6 +89,16 @@ cc_action_type(
 )
 
 cc_action_type(
+    name = "llvm_profdata",
+    action_name = ACTION_NAMES.llvm_profdata,
+)
+
+cc_action_type(
+    name = "gcov",
+    action_name = ACTION_NAMES.gcov,
+)
+
+cc_action_type(
     name = "lto_indexing",
     action_name = ACTION_NAMES.lto_indexing,
 )
@@ -324,6 +334,8 @@ cc_action_type_set(
         ":assemble",
         ":preprocess_assemble",
         ":llvm_cov",
+        ":llvm_profdata",
+        ":gcov",
         ":lto_indexing",
         ":lto_backend",
         ":lto_index_for_executable",


### PR DESCRIPTION
Previously these tools were fetched directly with their paths from the
toolchain. That meant these were inaccessible to custom rules (that
don't have access to the `_tool_paths` private API), and didn't work if
configured with the `tool()` helper. Now both are fetched similar to how
`dwp` is looked up. This way toolchains can register these actions for
coverage.
