### PR TITLE
Pass through target_system_name

### DIFF
--- a/cc/toolchains/impl/toolchain_config.bzl
+++ b/cc/toolchains/impl/toolchain_config.bzl
@@ -92,8 +92,8 @@ def cc_toolchain_config_impl_helper(ctx):
             # compiler
             compiler = ctx.attr.compiler,
             target_cpu = ctx.attr.cpu,
+            target_system_name = ctx.expand_make_variables("target_system_name", ctx.attr.target_system_name, {}),
             # These fields are only relevant for legacy toolchain resolution.
-            target_system_name = "",
             target_libc = "",
             abi_version = "",
             abi_libc_version = "",
@@ -117,6 +117,7 @@ CC_TOOLCHAIN_CONFIG_PUBLIC_ATTRS = {
     # Attributes new to this rule.
     "compiler": attr.string(default = ""),
     "cpu": attr.string(default = ""),
+    "target_system_name": attr.string(default = ""),
     "tool_map": attr.label(providers = [ToolConfigInfo], mandatory = True),
     "args": attr.label_list(providers = [ArgsListInfo]),
     "known_features": attr.label_list(providers = [FeatureSetInfo]),

--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -50,6 +50,7 @@ def cc_toolchain(
         supports_header_parsing = False,
         supports_param_files = False,
         compiler = "",
+        target_system_name = None,
         **kwargs):
     """A C/C++ toolchain configuration.
 
@@ -138,11 +139,25 @@ def cc_toolchain(
         compiler: (str) The type of compiler used by this toolchain (e.g. "gcc", "clang"). The current
             toolchain's compiler is exposed to `@rules_cc//cc/private/toolchain:compiler
             (compiler_flag)` as a flag value.
+        target_system_name: (str) The target system name for this toolchain. Bazel doesn't use this
+            but starlark rules can read this value through `toolchain_info.target_gnu_system_name`.
+            This string is commonly the target triple you would pass to `clang -target` (e.g. "x86_64-unknown-linux-gnu").
+            If not provided, a best effort default is selected.
         **kwargs: [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes)
             that should be applied to all rules created by this macro.
     """
 
     cc_toolchain_visibility = kwargs.pop("visibility", default = None)
+
+    target_system_name = target_system_name or select({
+        Label("//cc/toolchains/impl:darwin_aarch64"): "aarch64-apple-darwin",
+        Label("//cc/toolchains/impl:darwin_x86_64"): "x86_64-apple-darwin",
+        Label("//cc/toolchains/impl:linux_aarch64"): "aarch64-unknown-linux-gnu",
+        Label("//cc/toolchains/impl:linux_x86_64"): "x86_64-unknown-linux-gnu",
+        Label("//cc/toolchains/impl:windows_x86_32"): "i686-pc-windows-msvc",
+        Label("//cc/toolchains/impl:windows_x86_64"): "x86_64-pc-windows-msvc",
+        "//conditions:default": "",
+    })
 
     if bazel_features.cc.supports_starlarkified_toolchains:
         _cc_toolchain(
@@ -155,6 +170,7 @@ def cc_toolchain(
             enabled_features = enabled_features,
             compiler = compiler,
             cpu = _CPU,
+            target_system_name = target_system_name,
             dynamic_runtime_lib = dynamic_runtime_lib,
             libc_top = libc_top,
             module_map = module_map,
@@ -181,6 +197,7 @@ def cc_toolchain(
         enabled_features = enabled_features,
         compiler = compiler,
         cpu = _CPU,
+        target_system_name = target_system_name,
         visibility = ["//visibility:private"],
         **kwargs
     )

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -791,7 +791,7 @@ load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_toolchain")
 
 cc_toolchain(*, <a href="#cc_toolchain-name">name</a>, <a href="#cc_toolchain-tool_map">tool_map</a>, <a href="#cc_toolchain-args">args</a>, <a href="#cc_toolchain-artifact_name_patterns">artifact_name_patterns</a>, <a href="#cc_toolchain-make_variables">make_variables</a>, <a href="#cc_toolchain-known_features">known_features</a>,
              <a href="#cc_toolchain-enabled_features">enabled_features</a>, <a href="#cc_toolchain-libc_top">libc_top</a>, <a href="#cc_toolchain-module_map">module_map</a>, <a href="#cc_toolchain-dynamic_runtime_lib">dynamic_runtime_lib</a>, <a href="#cc_toolchain-static_runtime_lib">static_runtime_lib</a>,
-             <a href="#cc_toolchain-supports_header_parsing">supports_header_parsing</a>, <a href="#cc_toolchain-supports_param_files">supports_param_files</a>, <a href="#cc_toolchain-compiler">compiler</a>, <a href="#cc_toolchain-kwargs">**kwargs</a>)
+             <a href="#cc_toolchain-supports_header_parsing">supports_header_parsing</a>, <a href="#cc_toolchain-supports_param_files">supports_param_files</a>, <a href="#cc_toolchain-compiler">compiler</a>, <a href="#cc_toolchain-target_system_name">target_system_name</a>, <a href="#cc_toolchain-kwargs">**kwargs</a>)
 </pre>
 
 A C/C++ toolchain configuration.
@@ -853,6 +853,7 @@ Generated rules:
 | <a id="cc_toolchain-supports_header_parsing"></a>supports_header_parsing |  (bool) Whether or not this toolchain supports header parsing actions. See [`cc_toolchain.supports_header_parsing`](https://bazel.build/reference/be/c-cpp#cc_toolchain.supports_header_parsing) for more information.   |  `False` |
 | <a id="cc_toolchain-supports_param_files"></a>supports_param_files |  (bool) Whether or not this toolchain supports linking via param files. See [`cc_toolchain.supports_param_files`](https://bazel.build/reference/be/c-cpp#cc_toolchain.supports_param_files) for more information.   |  `False` |
 | <a id="cc_toolchain-compiler"></a>compiler |  (str) The type of compiler used by this toolchain (e.g. "gcc", "clang"). The current toolchain's compiler is exposed to `@rules_cc//cc/private/toolchain:compiler (compiler_flag)` as a flag value.   |  `""` |
+| <a id="cc_toolchain-target_system_name"></a>target_system_name |  (str) The target system name for this toolchain. Bazel doesn't use this but starlark rules can read this value through `toolchain_info.target_gnu_system_name`. This string is commonly the target triple you would pass to `clang -target` (e.g. "x86_64-unknown-linux-gnu"). If not provided, a best effort default is selected.   |  `None` |
 | <a id="cc_toolchain-kwargs"></a>kwargs |  [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) that should be applied to all rules created by this macro.   |  none |
 
 


### PR DESCRIPTION
This implements another attribute on toolchain configuration for rules
based toolchains. Turns out similar to compiler and cpu many places
reference the `target_gnu_system_name` which comes from this attribute.

I added support for makefile variable expansion on this since it's
potentially derived from a rule, vs a hardcoded string.

Examples:

- https://github.com/bazelbuild/rules_apple/blob/eed702ea4b42dca3081a63bb6abd030878abcb6f/apple/internal/linking_support.bzl#L108
- https://github.com/GoogleCloudPlatform/google-auth-library-perl/blob/f776c0292561df92358a1f86af172651bdb3d8e5/protobuf/protobuf_release.bzl#L16
- https://github.com/JetBrains/android/blob/46bd55242aa52447b13489147ec37cfdcf7902cb/aswb/aspect/build_dependencies_cc_deps.bzl#L64
- https://github.com/protocolbuffers/protobuf-javascript/blob/291b4604a3f9624e0a6b51a1e100368d13f43822/protobuf_javascript_release.bzl#L19
- https://github.com/bazelbuild/intellij/blob/cef70399b849f5393455d30eb8c98e9a7e542624/aspect/intellij_info_impl.bzl#L459
