### PR TITLE
Add PATH to system_library test

### DIFF
--- a/tests/system_library/BUILD
+++ b/tests/system_library/BUILD
@@ -23,6 +23,7 @@ sh_test(
         "//cc:system_library.bzl",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    env_inherit = ["PATH"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],


### PR DESCRIPTION
Depending on where you have `bazel` installed, this is required for the
nested run.
