### PR TITLE
Add sanitize_pwd feature for PWD overwriting

### DIFF
--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -360,9 +360,11 @@ def _create_action(
         action_name = action_name,
         variables = build_variables,
     )
-    if "requires_darwin" not in execution_info:
-        # This prevents gcc from writing the unpredictable (and often irrelevant)
-        # value of getcwd() into the debug info.
+    if not feature_configuration.is_enabled("sanitize_pwd") and "requires_darwin" not in execution_info:
+        # Legacy behavior: prevents gcc from writing the unpredictable (and often
+        # irrelevant) value of getcwd() into the debug info.
+        # New toolchains should use the sanitize_pwd feature instead.
+        # This is mostly solved with -fdebug-prefix-map, and similar flags now.
         env = env | {"PWD": "/proc/self/cwd"}
     exec_group = None
     toolchain = None

--- a/cc/toolchains/args/BUILD
+++ b/cc/toolchains/args/BUILD
@@ -16,6 +16,7 @@ cc_feature_set(
     name = "experimental_replace_legacy_action_config_features",
     all_of = [
         ":backfill_legacy_args",
+        "//cc/toolchains/args/sanitize_pwd:feature",
         "//cc/toolchains/args/archiver_flags:feature",
         "//cc/toolchains/args/pic_flags:feature",
         "//cc/toolchains/args/libraries_to_link:feature",

--- a/cc/toolchains/args/sanitize_pwd/BUILD
+++ b/cc/toolchains/args/sanitize_pwd/BUILD
@@ -1,0 +1,24 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_feature(
+    name = "feature",
+    args = [":sanitize_pwd"],
+    # The feature name matters: finalize_link_action.bzl checks for
+    # "sanitize_pwd" by name to skip legacy PWD env logic.
+    feature_name = "sanitize_pwd",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "sanitize_pwd",
+    actions = [
+        "//cc/toolchains/actions:ar_actions",
+        "//cc/toolchains/actions:link_actions",
+        "//cc/toolchains/actions:objc_fully_link",
+    ],
+    env = select({
+        "@platforms//os:macos": {},
+        "//conditions:default": {"PWD": "/proc/self/cwd"},
+    }),
+)

--- a/tests/cc/common/cc_binary_configured_target_tests.bzl
+++ b/tests/cc/common/cc_binary_configured_target_tests.bzl
@@ -1,7 +1,8 @@
 """Tests for cc_binary."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
-load("@rules_testing//lib:truth.bzl", "matching")
+load("@rules_testing//lib:truth.bzl", "matching", "subjects")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:action_names.bzl", "ACTION_NAMES")
 load("//cc:cc_binary.bzl", _actual_cc_binary = "cc_binary")
@@ -300,16 +301,89 @@ def _test_missing_action_config_for_strip_is_a_rule_error_impl(env, target):
         matching.contains("Expected action_config for 'strip' to be configured."),
     )
 
+def _test_sanitize_pwd_feature_enabled(name, **kwargs):
+    """sanitize_pwd is on by default, PWD should be set via the feature's env_set."""
+    util.helper_target(
+        cc_binary,
+        name = name + "/hello",
+        srcs = ["hello.cc"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_sanitize_pwd_feature_enabled_impl,
+        target = name + "/hello",
+        config_settings = {
+            "//command_line_option:platforms": str(Label("//tests/cc/testutil/toolchains:linux_x86_64")),
+        },
+        **kwargs
+    )
+
+def _test_sanitize_pwd_feature_enabled_impl(env, target):
+    link_action = link_action_subject.from_target(env, target)
+    link_action.env().get("PWD", factory = subjects.str).equals("/proc/self/cwd")
+
+def _test_sanitize_pwd_feature_disabled(name, **kwargs):
+    """When sanitize_pwd is explicitly disabled, the legacy requires_darwin fallback still applies."""
+    util.helper_target(
+        cc_binary,
+        name = name + "/hello",
+        srcs = ["hello.cc"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_sanitize_pwd_feature_disabled_impl,
+        target = name + "/hello",
+        config_settings = {
+            "//command_line_option:features": ["-sanitize_pwd"],
+        },
+        **kwargs
+    )
+
+def _test_sanitize_pwd_feature_disabled_impl(env, target):
+    link_action = link_action_subject.from_target(env, target)
+    link_action.env().get("PWD", factory = subjects.str).equals("/proc/self/cwd")
+
+def _test_sanitize_pwd_macos_no_pwd(name, **kwargs):
+    """On macOS, sanitize_pwd is enabled but should not set PWD."""
+    util.helper_target(
+        cc_binary,
+        name = name + "/hello",
+        srcs = ["hello.cc"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_sanitize_pwd_macos_no_pwd_impl,
+        target = name + "/hello",
+        config_settings = {
+            "//command_line_option:platforms": str(Label("//tests/cc/testutil/toolchains:macos_arm64")),
+        },
+        **kwargs
+    )
+
+def _test_sanitize_pwd_macos_no_pwd_impl(env, target):
+    link_action = link_action_subject.from_target(env, target)
+    link_action.env().keys().not_contains("PWD")
+
 def cc_binary_configured_target_tests(name):
+    tests = [
+        _test_files_to_build,
+        _test_headers_not_passed_to_linking_action,
+        _test_no_duplicate_linkopts,
+        _test_action_graph,
+        _test_runtime_dynamic_libraries_copy_behavior,
+        _test_pic,
+        _test_missing_action_config_for_strip_is_a_rule_error,
+    ]
+
+    # sanitize_pwd is implemented in Starlark in rules_cc, requires Bazel 9+.
+    if bazel_features.cc.cc_common_is_in_rules_cc:
+        tests.extend([
+            _test_sanitize_pwd_feature_enabled,
+            _test_sanitize_pwd_feature_disabled,
+            _test_sanitize_pwd_macos_no_pwd,
+        ])
+
     test_suite(
         name = name,
-        tests = [
-            _test_files_to_build,
-            _test_headers_not_passed_to_linking_action,
-            _test_no_duplicate_linkopts,
-            _test_action_graph,
-            _test_runtime_dynamic_libraries_copy_behavior,
-            _test_pic,
-            _test_missing_action_config_for_strip_is_a_rule_error,
-        ],
+        tests = tests,
     )

--- a/tests/cc/testutil/cc_analysis_test.bzl
+++ b/tests/cc/testutil/cc_analysis_test.bzl
@@ -35,6 +35,7 @@ def cc_analysis_test(name, with_features = None, test_features = [], with_action
 
     mock_toolchains = [
         "//tests/cc/testutil/toolchains:cc-toolchain-k8-compiler",
+        "//tests/cc/testutil/toolchains:cc-toolchain-macos-compiler",
     ] + ADDITIONAL_MOCK_TOOLCHAINS
 
     config_settings = {

--- a/tests/cc/testutil/link_action_subject.bzl
+++ b/tests/cc/testutil/link_action_subject.bzl
@@ -10,6 +10,7 @@ def _link_action_subject_new(actual, meta):
         inputs = lambda: subjects.collection([f.short_path for f in actual.inputs.to_list()], meta = meta.derive("inputs")),
         outputs = lambda: subjects.collection([f.short_path for f in actual.outputs.to_list()], meta = meta.derive("outputs")),
         argv = lambda: subjects.collection(actual.argv, meta = meta.derive("argv")),
+        env = lambda: subjects.dict(actual.env, meta = meta.derive("env")),
     )
 
 def _link_action_subject_from_target(env, target):

--- a/tests/cc/testutil/toolchains/BUILD
+++ b/tests/cc/testutil/toolchains/BUILD
@@ -7,6 +7,22 @@ load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 package(default_visibility = ["//tests:__subpackages__"])
 
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
 toolchain_type(name = "toolchain_type")
 
 toolchain_type(name = "test_runner_toolchain_type")
@@ -284,6 +300,52 @@ cc_toolchain_config(
     target_system_name = "local",
     tool_paths = {},
     toolchain_identifier = "mock-toolchain-k8",
+)
+
+toolchain(
+    name = "cc-toolchain-macos-compiler",
+    target_compatible_with = ["@platforms//os:macos"],
+    toolchain = ":cc-compiler-macos-compiler",
+    toolchain_type = "//cc:toolchain_type",
+)
+
+cc_toolchain_config(
+    name = "macos-compiler_config",
+    abi_libc_version = "local",
+    abi_version = "local",
+    action_configs = [],
+    artifact_name_patterns = {},
+    builtin_sysroot = "/usr/grte/v1",
+    cc_target_os = "macos",
+    compiler = "compiler",
+    cpu = "darwin_arm64",
+    cxx_builtin_include_directories = [],
+    feature_names = [],
+    host_system_name = "local",
+    make_variables = {},
+    target_libc = "macosx",  # NOTE: This value is read for legacy features
+    target_system_name = "local",
+    tool_paths = {},
+    toolchain_identifier = "mock-toolchain-macos",
+)
+
+cc_toolchain(
+    name = "cc-compiler-macos-compiler",
+    all_files = ":every-file",
+    ar_files = "ar-k8",
+    as_files = "as-k8",
+    compiler_files = "compile-k8",
+    coverage_files = "coverage-file",
+    dwp_files = "dwp-k8",
+    licenses = ["unencumbered"],
+    linker_files = "link-k8",
+    module_map = "crosstool.cppmap",
+    objcopy_files = "objcopy-k8",
+    output_licenses = ["unencumbered"],
+    strip_files = ":every-file",
+    supports_header_parsing = 1,
+    toolchain_config = ":macos-compiler_config",
+    toolchain_identifier = "mock-toolchain-macos",
 )
 
 cc_toolchain(

--- a/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
+++ b/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
@@ -1495,7 +1495,34 @@ def _impl(ctx):
         ],
     )
 
-    hard_coded_default_features = [default_compile_flags_feature, default_link_flags_feature]
+    sanitize_pwd_feature = feature(
+        name = "sanitize_pwd",
+        enabled = True,
+        env_sets = [env_set(
+            actions = [
+                ACTION_NAMES.cpp_link_executable,
+                ACTION_NAMES.cpp_link_dynamic_library,
+                ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ACTION_NAMES.cpp_link_static_library,
+                ACTION_NAMES.lto_index_for_executable,
+                ACTION_NAMES.lto_index_for_dynamic_library,
+                ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+                ACTION_NAMES.objc_executable,
+                ACTION_NAMES.objc_fully_link,
+                ACTION_NAMES.objcpp_executable,
+            ],
+            env_entries = [env_entry(
+                key = "PWD",
+                value = "/proc/self/cwd",
+            )],
+        )] if ctx.attr.target_libc != "macosx" else [],
+    )
+
+    hard_coded_default_features = [
+        default_compile_flags_feature,
+        default_link_flags_feature,
+        sanitize_pwd_feature,
+    ]
     cmdline_registered_features = [
         _feature_name_to_feature[f]
         for f in ctx.attr._with_features[BuildSettingInfo].value


### PR DESCRIPTION
This logic around overwriting PWD for non-macOS builds doesn't work
correctly for cross compilation. Setting this value ends up breaking
`-ffile-compilation-dir`. Now if the toolchain defines the
`sanitize_pwd` feature this `execution_info` logic is skipped (even if
this feature does nothing). This also defines this features for all
toolchains that use legacy features.
