### PR TITLE
Set target_libc to macosx for Apple platforms

### DIFF
--- a/cc/toolchains/impl/toolchain_config.bzl
+++ b/cc/toolchains/impl/toolchain_config.bzl
@@ -95,9 +95,9 @@ def cc_toolchain_config_impl_helper(ctx):
             # compiler
             compiler = ctx.attr.compiler,
             target_cpu = ctx.attr.cpu,
+            target_libc = ctx.attr.target_libc,  # Used by legacy features to determine if we're building for Apple platfroms or not
             target_system_name = ctx.expand_make_variables("target_system_name", ctx.attr.target_system_name, {}),
             # These fields are only relevant for legacy toolchain resolution.
-            target_libc = "",
             abi_version = "",
             abi_libc_version = "",
         ),
@@ -120,6 +120,7 @@ CC_TOOLCHAIN_CONFIG_PUBLIC_ATTRS = {
     # Attributes new to this rule.
     "compiler": attr.string(default = ""),
     "cpu": attr.string(default = ""),
+    "target_libc": attr.string(default = ""),
     "target_system_name": attr.string(default = ""),
     "tool_map": attr.label(providers = [ToolConfigInfo], mandatory = True),
     "args": attr.label_list(providers = [ArgsListInfo]),

--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -163,6 +163,11 @@ def cc_toolchain(
         "//conditions:default": "",
     })
 
+    target_libc = select({
+        Label("//cc/settings:apple_constraint"): "macosx",
+        "//conditions:default": "",
+    })
+
     if bazel_features.cc.supports_starlarkified_toolchains:
         _cc_toolchain(
             name = name,
@@ -174,6 +179,7 @@ def cc_toolchain(
             enabled_features = enabled_features,
             compiler = compiler,
             cpu = _CPU,
+            target_libc = target_libc,
             target_system_name = target_system_name,
             dynamic_runtime_lib = dynamic_runtime_lib,
             libc_top = libc_top,
@@ -202,6 +208,7 @@ def cc_toolchain(
         enabled_features = enabled_features,
         compiler = compiler,
         cpu = _CPU,
+        target_libc = target_libc,
         target_system_name = target_system_name,
         visibility = ["//visibility:private"],
         **kwargs

--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -213,7 +213,7 @@ def cc_toolchain(
         known_features = known_features,
         enabled_features = enabled_features,
         compiler = compiler,
-        cpu = _CPU,
+        cpu = cpu or _CPU,
         target_libc = target_libc,
         target_system_name = target_system_name,
         visibility = ["//visibility:private"],


### PR DESCRIPTION
This is read by the legacy features logic to determine how to pass Apple
specific flags. Theoretically this is readable by anyone as well,
similar to the other ones, but I don't think it's widely used.
