### PR TITLE
Add excludes to cc_action_type_set

### DIFF
--- a/cc/toolchains/actions.bzl
+++ b/cc/toolchains/actions.bzl
@@ -64,9 +64,13 @@ cc_action_type(
 def _cc_action_type_set_impl(ctx):
     if not ctx.attr.actions and not ctx.attr.allow_empty:
         fail("Each cc_action_type_set must contain at least one action type.")
+    actions = collect_action_types(ctx.attr.actions)
+    if ctx.attr.excludes:
+        excludes = {a: True for a in collect_action_types(ctx.attr.excludes).to_list()}
+        actions = depset([a for a in actions.to_list() if a not in excludes])
     return [ActionTypeSetInfo(
         label = ctx.label,
-        actions = collect_action_types(ctx.attr.actions),
+        actions = actions,
     )]
 
 cc_action_type_set = rule(
@@ -94,6 +98,10 @@ cc_action_type_set(
             providers = [ActionTypeSetInfo],
             mandatory = True,
             doc = "A list of cc_action_type or cc_action_type_set",
+        ),
+        "excludes": attr.label_list(
+            providers = [ActionTypeSetInfo],
+            doc = "A list of cc_action_type or cc_action_type_set to exclude from the action set. Applied after accumulating all actions.",
         ),
         "allow_empty": attr.bool(default = False),
     },

--- a/cc/toolchains/actions.bzl
+++ b/cc/toolchains/actions.bzl
@@ -66,7 +66,7 @@ def _cc_action_type_set_impl(ctx):
         fail("Each cc_action_type_set must contain at least one action type.")
     actions = collect_action_types(ctx.attr.actions)
     if ctx.attr.excludes:
-        excludes = {a: True for a in collect_action_types(ctx.attr.excludes).to_list()}
+        excludes = {a[ActionTypeInfo]: True for a in ctx.attr.excludes}
         actions = depset([a for a in actions.to_list() if a not in excludes])
     return [ActionTypeSetInfo(
         label = ctx.label,
@@ -100,8 +100,8 @@ cc_action_type_set(
             doc = "A list of cc_action_type or cc_action_type_set",
         ),
         "excludes": attr.label_list(
-            providers = [ActionTypeSetInfo],
-            doc = "A list of cc_action_type or cc_action_type_set to exclude from the action set. Applied after accumulating all actions.",
+            providers = [ActionTypeInfo],
+            doc = "A list of cc_action_type to exclude from the action set. Applied after accumulating all actions.",
         ),
         "allow_empty": attr.bool(default = False),
     },

--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -233,23 +233,16 @@ cc_action_type_set(
 )
 
 cc_action_type_set(
-    name = "cpp_compile_without_header_parsing",
-    actions = [
-        ":linkstamp_compile",
-        ":cpp_compile",
-        ":cpp_module_compile",
-        ":cpp_module_codegen",
-        ":clif_match",
-        ":objcpp_compile",
-    ],
-)
-
-cc_action_type_set(
     name = "cpp_compile_actions",
     actions = [
-        ":cpp_compile_without_header_parsing",
+        ":clif_match",
+        ":cpp_compile",
         ":cpp_header_parsing",
+        ":cpp_module_codegen",
+        ":cpp_module_compile",
+        ":linkstamp_compile",
         ":lto_backend",
+        ":objcpp_compile",
     ],
 )
 

--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -253,20 +253,10 @@ cc_action_type_set(
     ],
 )
 
-# This matches `compile_actions` with `lto_backend` omitted, because
-# `lto_backend` actions do not instantiate the full set of build variables.
 cc_action_type_set(
-    name = "source_compile_actions",
+    name = "compile_actions",
     actions = [
-        ":compile_actions_without_header_parsing",
-        ":cpp_header_parsing",
-    ],
-)
-
-cc_action_type_set(
-    name = "compile_actions_without_header_parsing",
-    actions = [
-        ":cpp_compile_without_header_parsing",
+        ":cpp_compile_actions",
         ":c_compile_actions",
         ":assembly_actions",
         ":objc_compile",
@@ -274,10 +264,23 @@ cc_action_type_set(
 )
 
 cc_action_type_set(
-    name = "compile_actions",
+    name = "source_compile_actions",
     actions = [
-        ":source_compile_actions",
+        ":compile_actions",
+    ],
+    excludes = [
+        # `lto_backend` actions do not instantiate the full set of build variables.
         ":lto_backend",
+    ],
+)
+
+cc_action_type_set(
+    name = "compile_actions_without_header_parsing",
+    actions = [
+        ":compile_actions",
+    ],
+    excludes = [
+        ":cpp_header_parsing",
     ],
 )
 

--- a/cc/toolchains/args/compiler_input_flags/BUILD
+++ b/cc/toolchains/args/compiler_input_flags/BUILD
@@ -3,18 +3,29 @@ load("//cc/toolchains:feature.bzl", "cc_feature")
 
 cc_feature(
     name = "feature",
-    args = [":flags"],
+    args = [
+        ":flags",
+        ":header_parsing_args",
+    ],
     overrides = "//cc/toolchains/features/legacy:compiler_input_flags",
     visibility = ["//visibility:public"],
 )
 
 cc_args(
     name = "flags",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = ["//cc/toolchains/actions:compile_actions_without_header_parsing"],
     args = [
         "-c",
         "{source_file}",
     ],
+    format = {"source_file": "//cc/toolchains/variables:source_file"},
+    requires_not_none = "//cc/toolchains/variables:source_file",
+)
+
+cc_args(
+    name = "header_parsing_args",
+    actions = ["//cc/toolchains/actions:cpp_header_parsing"],
+    args = ["{source_file}"],
     format = {"source_file": "//cc/toolchains/variables:source_file"},
     requires_not_none = "//cc/toolchains/variables:source_file",
 )

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -80,7 +80,7 @@ cc_action_type_set(
 | <a id="cc_action_type_set-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="cc_action_type_set-actions"></a>actions |  A list of cc_action_type or cc_action_type_set   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="cc_action_type_set-allow_empty"></a>allow_empty |  -   | Boolean | optional |  `False`  |
-| <a id="cc_action_type_set-excludes"></a>excludes |  A list of cc_action_type or cc_action_type_set to exclude from the action set. Applied after accumulating all actions.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="cc_action_type_set-excludes"></a>excludes |  A list of cc_action_type to exclude from the action set. Applied after accumulating all actions.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="cc_args_list"></a>

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -51,7 +51,7 @@ cc_action_type(
 <pre>
 load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_action_type_set")
 
-cc_action_type_set(<a href="#cc_action_type_set-name">name</a>, <a href="#cc_action_type_set-actions">actions</a>, <a href="#cc_action_type_set-allow_empty">allow_empty</a>)
+cc_action_type_set(<a href="#cc_action_type_set-name">name</a>, <a href="#cc_action_type_set-actions">actions</a>, <a href="#cc_action_type_set-allow_empty">allow_empty</a>, <a href="#cc_action_type_set-excludes">excludes</a>)
 </pre>
 
 Represents a set of actions.
@@ -80,6 +80,7 @@ cc_action_type_set(
 | <a id="cc_action_type_set-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="cc_action_type_set-actions"></a>actions |  A list of cc_action_type or cc_action_type_set   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="cc_action_type_set-allow_empty"></a>allow_empty |  -   | Boolean | optional |  `False`  |
+| <a id="cc_action_type_set-excludes"></a>excludes |  A list of cc_action_type or cc_action_type_set to exclude from the action set. Applied after accumulating all actions.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="cc_args_list"></a>

--- a/tests/rule_based_toolchain/action_type_sets/BUILD
+++ b/tests/rule_based_toolchain/action_type_sets/BUILD
@@ -22,12 +22,6 @@ action_type_set_diff_test(
 )
 
 action_type_set_diff_test(
-    name = "cpp_compile_without_header_parsing_test",
-    action_type_set = "//cc/toolchains/actions:cpp_compile_without_header_parsing",
-    expected = "//tests/rule_based_toolchain/action_type_sets:goldens/cpp_compile_without_header_parsing.txt",
-)
-
-action_type_set_diff_test(
     name = "cpp_compile_actions_test",
     action_type_set = "//cc/toolchains/actions:cpp_compile_actions",
     expected = "//tests/rule_based_toolchain/action_type_sets:goldens/cpp_compile_actions.txt",

--- a/tests/rule_based_toolchain/action_type_sets/goldens/compile_actions_without_header_parsing.txt
+++ b/tests/rule_based_toolchain/action_type_sets/goldens/compile_actions_without_header_parsing.txt
@@ -5,6 +5,7 @@ c++-module-compile
 c-compile
 clif-match
 linkstamp-compile
+lto-backend
 objc++-compile
 objc-compile
 preprocess-assemble

--- a/tests/rule_based_toolchain/action_type_sets/goldens/cpp_compile_without_header_parsing.txt
+++ b/tests/rule_based_toolchain/action_type_sets/goldens/cpp_compile_without_header_parsing.txt
@@ -1,6 +1,0 @@
-c++-compile
-c++-module-codegen
-c++-module-compile
-clif-match
-linkstamp-compile
-objc++-compile

--- a/tests/rule_based_toolchain/actions/BUILD
+++ b/tests/rule_based_toolchain/actions/BUILD
@@ -27,6 +27,31 @@ util.helper_target(
     visibility = ["//tests/rule_based_toolchain:__subpackages__"],
 )
 
+util.helper_target(
+    cc_action_type_set,
+    name = "all_compile_except_c",
+    actions = [
+        ":c_compile",
+        ":cpp_compile",
+    ],
+    excludes = [
+        ":c_compile",
+    ],
+    visibility = ["//tests/rule_based_toolchain:__subpackages__"],
+)
+
+util.helper_target(
+    cc_action_type_set,
+    name = "all_compile_except_c_nested",
+    actions = [
+        ":all_compile",
+    ],
+    excludes = [
+        ":c_compile",
+    ],
+    visibility = ["//tests/rule_based_toolchain:__subpackages__"],
+)
+
 analysis_test_suite(
     name = "test_suite",
     targets = TARGETS,

--- a/tests/rule_based_toolchain/actions/actions_test.bzl
+++ b/tests/rule_based_toolchain/actions/actions_test.bzl
@@ -32,12 +32,24 @@ def _test_action_types_impl(env, targets):
         targets.cpp_compile.label,
     ])
 
+def _test_action_type_set_excludes_impl(env, targets):
+    env.expect.that_target(targets.all_compile_except_c).provider(ActionTypeSetInfo) \
+        .actions().contains_exactly([targets.cpp_compile.label])
+
+def _test_action_type_set_excludes_nested_impl(env, targets):
+    env.expect.that_target(targets.all_compile_except_c_nested).provider(ActionTypeSetInfo) \
+        .actions().contains_exactly([targets.cpp_compile.label])
+
 TARGETS = [
     ":c_compile",
     ":cpp_compile",
     ":all_compile",
+    ":all_compile_except_c",
+    ":all_compile_except_c_nested",
 ]
 
 TESTS = {
     "actions_test": _test_action_types_impl,
+    "action_type_set_excludes_test": _test_action_type_set_excludes_impl,
+    "action_type_set_excludes_nested_test": _test_action_type_set_excludes_nested_impl,
 }


### PR DESCRIPTION
This makes it easier to compose action sets that are very similar to
other ones but excluding a few things. This is used today for
lto_backend, and in this change is also used for header parsing, which
produces a warning when `-c` is passed.
