### PR TITLE
Disable Rennovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "bazel": {
+    "enabled": false
+  },
+  "bazel-module": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
This bot has not been helpful: rules_cc needs to maximize backwards compatibility with all dependencies.