### PR TITLE
Optimize _virtual_includes when paths are only stripped

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -103,7 +103,7 @@ def _compute_public_headers(
     if include_prefix and include_prefix.startswith("/"):
         include_prefix = include_prefix[1:]
 
-    if strip_prefix == None and not include_prefix:
+    if (strip_prefix == None and not include_prefix) or not public_headers_artifacts:
         # If CppOptions.experimentalStarlarkCompiling is enabled, then
         # strip_include_prefix and include_prefix are not None.
         # If the option is disabled, their default values (from CcCompilationHelper) are None.
@@ -120,6 +120,41 @@ def _compute_public_headers(
             virtual_include_path = None,
             virtual_to_original_headers = [],
         )
+
+    # When only stripping, we don't need to use _virtual_include path
+    if strip_prefix and not include_prefix:
+        module_map_headers = []
+        virtual_to_original_headers_list = []
+        include_paths = {}
+        for original_header in public_headers_artifacts:
+            repo_relative_path = _repo_relative_path(original_header)
+            if not repo_relative_path.startswith(strip_prefix):
+                if not must_use_strip_prefix:
+                    module_map_headers.append(original_header)
+                    continue
+
+                fail("header '{}' is not under the specified strip prefix '{}'".format(repo_relative_path, strip_prefix))
+            include_path = original_header.root.path
+            workspace_root = original_header.owner.workspace_root
+            if not include_path:  # this is a source/non-generated file
+                include_path = workspace_root
+            elif workspace_root.startswith("external/"):
+                # in non-sibling repo layout, we need to add workspace root as well
+                include_path = include_path + "/" + workspace_root
+            include_path = get_relative_path(include_path, strip_prefix)
+            include_paths[include_path] = True
+            module_map_headers.append(original_header)
+
+        virtual_headers = module_map_headers + non_module_map_headers
+
+        # We can only handle 1 include path. In case there are more, fallback to _virtual_imports.
+        if len(include_paths.keys()) == 1:
+            return struct(
+                headers = virtual_headers,
+                module_map_headers = module_map_headers,
+                virtual_include_path = include_paths.keys()[0],
+                virtual_to_original_headers = virtual_to_original_headers_list,
+            )
 
     module_map_headers = []
     virtual_to_original_headers_list = []

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -60,6 +60,7 @@ def _compute_public_headers(
         non_module_map_headers,
         is_sibling_repository_layout,
         shorten_virtual_includes,
+        skip_virtual_includes,
         *,
         must_use_strip_prefix = True):
     if include_prefix:
@@ -122,7 +123,7 @@ def _compute_public_headers(
         )
 
     # When only stripping, we don't need to use _virtual_include path
-    if strip_prefix and not include_prefix:
+    if skip_virtual_includes and strip_prefix and not include_prefix:
         module_map_headers = []
         virtual_to_original_headers_list = []
         include_paths = {}
@@ -454,6 +455,7 @@ def _init_cc_compilation_context(
     quote_include_dirs_for_context = [repo_path, gen_include_dir, bin_include_dir] + quote_include_dirs
     external = repo_name != "" and _enabled(feature_configuration, "external_include_paths")
     shorten_virtual_includes = _enabled(feature_configuration, "shorten_virtual_includes")
+    skip_virtual_includes = _enabled(feature_configuration, "skip_virtual_includes")
     external_include_dirs = []
     declared_include_srcs = []
 
@@ -486,6 +488,7 @@ def _init_cc_compilation_context(
         non_module_map_headers,
         sibling_repo_layout,
         shorten_virtual_includes,
+        skip_virtual_includes,
     )
     if public_headers.virtual_include_path:
         if external:
@@ -504,6 +507,7 @@ def _init_cc_compilation_context(
         non_module_map_headers,
         sibling_repo_layout,
         shorten_virtual_includes,
+        skip_virtual_includes,
         must_use_strip_prefix = False,
     )
     if textual_headers.virtual_include_path:
@@ -543,6 +547,7 @@ def _init_cc_compilation_context(
         non_module_map_headers,
         sibling_repo_layout,
         shorten_virtual_includes,
+        skip_virtual_includes,
     )
 
     separate_module = None

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1821,14 +1821,7 @@ def _impl(ctx):
 
     no_dotd_file_feature = feature(name = "no_dotd_file")
 
-    skip_virtual_includes_requires = [feature_set(features = ["dependency_file"])]
-    if ctx.attr.compiler == "clang":
-        skip_virtual_includes_requires.append(feature_set(features = ["layering_check"]))
-    skip_virtual_includes_feature = feature(
-        name = "skip_virtual_includes",
-        enabled = True,
-        requires = skip_virtual_includes_requires,
-    )
+    skip_virtual_includes_feature = feature(name = "skip_virtual_includes")
 
     # TODO(#8303): Mac crosstool should also declare every feature.
     if is_linux:

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -1821,6 +1821,15 @@ def _impl(ctx):
 
     no_dotd_file_feature = feature(name = "no_dotd_file")
 
+    skip_virtual_includes_requires = [feature_set(features = ["dependency_file"])]
+    if ctx.attr.compiler == "clang":
+        skip_virtual_includes_requires.append(feature_set(features = ["layering_check"]))
+    skip_virtual_includes_feature = feature(
+        name = "skip_virtual_includes",
+        enabled = True,
+        requires = skip_virtual_includes_requires,
+    )
+
     # TODO(#8303): Mac crosstool should also declare every feature.
     if is_linux:
         # Linux artifact name patterns are the default.
@@ -1898,6 +1907,7 @@ def _impl(ctx):
             archive_param_file_feature,
             set_install_name_feature,
             no_dotd_file_feature,
+            skip_virtual_includes_feature,
         ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = False)
     else:
         # macOS artifact name patterns differ from the defaults only for dynamic
@@ -1950,6 +1960,7 @@ def _impl(ctx):
             archive_param_file_feature,
             generate_linkmap_feature,
             no_dotd_file_feature,
+            skip_virtual_includes_feature,
         ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = True)
 
     parse_headers_action_configs, parse_headers_features = parse_headers_support(

--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -21,6 +21,7 @@ load(
     "env_entry",
     "env_set",
     "feature",
+    "feature_set",
     "flag_group",
     "flag_set",
     "get_profile_correction_flags",
@@ -1003,6 +1004,12 @@ def _impl(ctx):
             enabled = ctx.attr.shorten_virtual_includes,
         )
 
+        skip_virtual_includes_feature = feature(
+            name = "skip_virtual_includes",
+            enabled = True,
+            requires = [feature_set(features = ["parse_showincludes"])],
+        )
+
         treat_warnings_as_errors_feature = feature(
             name = "treat_warnings_as_errors",
             flag_sets = [
@@ -1342,6 +1349,7 @@ def _impl(ctx):
             parse_showincludes_feature,
             no_dotd_file_feature,
             shorten_virtual_includes_feature,
+            skip_virtual_includes_feature,
             generate_pdb_file_feature,
             generate_linkmap_feature,
             shared_flag_feature,

--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -21,7 +21,6 @@ load(
     "env_entry",
     "env_set",
     "feature",
-    "feature_set",
     "flag_group",
     "flag_set",
     "get_profile_correction_flags",
@@ -1004,11 +1003,7 @@ def _impl(ctx):
             enabled = ctx.attr.shorten_virtual_includes,
         )
 
-        skip_virtual_includes_feature = feature(
-            name = "skip_virtual_includes",
-            enabled = True,
-            requires = [feature_set(features = ["parse_showincludes"])],
-        )
+        skip_virtual_includes_feature = feature(name = "skip_virtual_includes")
 
         treat_warnings_as_errors_feature = feature(
             name = "treat_warnings_as_errors",

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -109,22 +109,7 @@ def _test_isolated_includes_impl(env, target):
     else:
         subject.compilation_context().system_include_dirs().contains_at_least(expected_includes)
 
-def _test_strip_include_prefix_no_virtual_includes(name):
-    """Tests that strip_include_prefix without include_prefix avoids _virtual_includes."""
-    util.helper_target(
-        cc_library,
-        name = name + "/lib",
-        hdrs = ["v1/foo.h"],
-        strip_include_prefix = "v1",
-    )
-
-    cc_analysis_test(
-        name = name,
-        impl = _test_strip_include_prefix_no_virtual_includes_impl,
-        target = name + "/lib",
-    )
-
-def _test_strip_include_prefix_no_virtual_includes_impl(env, target):
+def _no_virtual_includes_impl(env, target):
     subject = cc_info_subject.from_target(env, target)
 
     # The include dir should be the direct stripped path, not a _virtual_includes path.
@@ -144,6 +129,66 @@ def _test_strip_include_prefix_no_virtual_includes_impl(env, target):
                 "expected no _virtual_includes in header path",
                 "actual: {}".format(header.path),
             )
+
+def _uses_virtual_includes_impl(env, target):
+    subject = cc_info_subject.from_target(env, target)
+
+    include_dirs = subject.compilation_context().include_dirs()
+    include_dirs.contains_at_least_predicates(
+        [matching.custom(
+            "contains '_virtual_includes'",
+            lambda s: "_virtual_includes" in s,
+        )],
+    )
+
+def _test_strip_include_prefix_uses_virtual_includes_by_default(name):
+    """Tests that strip_include_prefix alone still uses _virtual_includes when skip_virtual_includes is not active."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["v1/foo.h"],
+        strip_include_prefix = "v1",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _uses_virtual_includes_impl,
+        target = name + "/lib",
+    )
+
+def _test_strip_include_prefix_no_virtual_includes_with_layering_check(name):
+    """Tests that layering_check auto-enables the skip_virtual_includes optimization."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["v1/foo.h"],
+        strip_include_prefix = "v1",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _no_virtual_includes_impl,
+        target = name + "/lib",
+        with_features = ["layering_check", "skip_virtual_includes"],
+        test_features = ["layering_check"],
+    )
+
+def _test_skip_virtual_includes_can_be_disabled(name):
+    """Tests that --features=-skip_virtual_includes overrides the default even when layering_check is on."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["v1/foo.h"],
+        strip_include_prefix = "v1",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _uses_virtual_includes_impl,
+        target = name + "/lib",
+        with_features = ["layering_check", "skip_virtual_includes"],
+        test_features = ["layering_check", "-skip_virtual_includes"],
+    )
 
 def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes(name):
     """Tests that strip_include_prefix with include_prefix still uses _virtual_includes."""
@@ -187,6 +232,8 @@ def _test_strip_include_prefix_error_not_under_prefix(name):
         impl = _test_strip_include_prefix_error_not_under_prefix_impl,
         target = name + "/lib",
         expect_failure = True,
+        with_features = ["layering_check", "skip_virtual_includes"],
+        test_features = ["layering_check"],
     )
 
 def _test_strip_include_prefix_error_not_under_prefix_impl(env, target):
@@ -205,7 +252,9 @@ def cc_common_tests(name):
     ]
     if bazel_features.cc.cc_common_is_in_rules_cc:
         tests.extend([
-            _test_strip_include_prefix_no_virtual_includes,
+            _test_strip_include_prefix_uses_virtual_includes_by_default,
+            _test_strip_include_prefix_no_virtual_includes_with_layering_check,
+            _test_skip_virtual_includes_can_be_disabled,
             _test_strip_include_prefix_with_include_prefix_uses_virtual_includes,
             _test_strip_include_prefix_error_not_under_prefix,
         ])

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -142,7 +142,7 @@ def _uses_virtual_includes_impl(env, target):
     )
 
 def _test_strip_include_prefix_uses_virtual_includes_by_default(name):
-    """Tests that strip_include_prefix alone still uses _virtual_includes when skip_virtual_includes is not active."""
+    """Tests that strip_include_prefix uses _virtual_includes by default (skip_virtual_includes off)."""
     util.helper_target(
         cc_library,
         name = name + "/lib",
@@ -156,8 +156,8 @@ def _test_strip_include_prefix_uses_virtual_includes_by_default(name):
         target = name + "/lib",
     )
 
-def _test_strip_include_prefix_no_virtual_includes_with_layering_check(name):
-    """Tests that layering_check auto-enables the skip_virtual_includes optimization."""
+def _test_strip_include_prefix_no_virtual_includes_when_enabled(name):
+    """Tests that --features=skip_virtual_includes avoids _virtual_includes."""
     util.helper_target(
         cc_library,
         name = name + "/lib",
@@ -169,29 +169,11 @@ def _test_strip_include_prefix_no_virtual_includes_with_layering_check(name):
         name = name,
         impl = _no_virtual_includes_impl,
         target = name + "/lib",
-        with_features = ["layering_check", "skip_virtual_includes"],
-        test_features = ["layering_check"],
-    )
-
-def _test_skip_virtual_includes_can_be_disabled(name):
-    """Tests that --features=-skip_virtual_includes overrides the default even when layering_check is on."""
-    util.helper_target(
-        cc_library,
-        name = name + "/lib",
-        hdrs = ["v1/foo.h"],
-        strip_include_prefix = "v1",
-    )
-
-    cc_analysis_test(
-        name = name,
-        impl = _uses_virtual_includes_impl,
-        target = name + "/lib",
-        with_features = ["layering_check", "skip_virtual_includes"],
-        test_features = ["layering_check", "-skip_virtual_includes"],
+        test_features = ["skip_virtual_includes"],
     )
 
 def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes(name):
-    """Tests that strip_include_prefix with include_prefix still uses _virtual_includes."""
+    """Tests that strip_include_prefix with include_prefix still uses _virtual_includes even when skip is on."""
     util.helper_target(
         cc_library,
         name = name + "/lib",
@@ -202,20 +184,9 @@ def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes(name):
 
     cc_analysis_test(
         name = name,
-        impl = _test_strip_include_prefix_with_include_prefix_uses_virtual_includes_impl,
+        impl = _uses_virtual_includes_impl,
         target = name + "/lib",
-    )
-
-def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes_impl(env, target):
-    subject = cc_info_subject.from_target(env, target)
-
-    # When include_prefix is set, _virtual_includes should be used.
-    include_dirs = subject.compilation_context().include_dirs()
-    include_dirs.contains_at_least_predicates(
-        [matching.custom(
-            "contains '_virtual_includes'",
-            lambda s: "_virtual_includes" in s,
-        )],
+        test_features = ["skip_virtual_includes"],
     )
 
 def _test_strip_include_prefix_error_not_under_prefix(name):
@@ -232,8 +203,7 @@ def _test_strip_include_prefix_error_not_under_prefix(name):
         impl = _test_strip_include_prefix_error_not_under_prefix_impl,
         target = name + "/lib",
         expect_failure = True,
-        with_features = ["layering_check", "skip_virtual_includes"],
-        test_features = ["layering_check"],
+        test_features = ["skip_virtual_includes"],
     )
 
 def _test_strip_include_prefix_error_not_under_prefix_impl(env, target):
@@ -253,8 +223,7 @@ def cc_common_tests(name):
     if bazel_features.cc.cc_common_is_in_rules_cc:
         tests.extend([
             _test_strip_include_prefix_uses_virtual_includes_by_default,
-            _test_strip_include_prefix_no_virtual_includes_with_layering_check,
-            _test_skip_virtual_includes_can_be_disabled,
+            _test_strip_include_prefix_no_virtual_includes_when_enabled,
             _test_strip_include_prefix_with_include_prefix_uses_virtual_includes,
             _test_strip_include_prefix_error_not_under_prefix,
         ])

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -5,6 +5,7 @@ load("@rules_testing//lib:analysis_test.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "matching")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:cc_library.bzl", "cc_library")
+load("//cc/common:cc_info.bzl", "CcInfo")
 load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
 load("//tests/cc/testutil:cc_info_subject.bzl", "cc_info_subject")
 
@@ -108,12 +109,107 @@ def _test_isolated_includes_impl(env, target):
     else:
         subject.compilation_context().system_include_dirs().contains_at_least(expected_includes)
 
+def _test_strip_include_prefix_no_virtual_includes(name):
+    """Tests that strip_include_prefix without include_prefix avoids _virtual_includes."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["v1/foo.h"],
+        strip_include_prefix = "v1",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _test_strip_include_prefix_no_virtual_includes_impl,
+        target = name + "/lib",
+    )
+
+def _test_strip_include_prefix_no_virtual_includes_impl(env, target):
+    subject = cc_info_subject.from_target(env, target)
+
+    # The include dir should be the direct stripped path, not a _virtual_includes path.
+    include_dirs = subject.compilation_context().include_dirs()
+    include_dirs.contains_none_of(
+        [matching.custom(
+            "contains '_virtual_includes'",
+            lambda s: "_virtual_includes" in s,
+        )],
+    )
+
+    # The direct public headers should be the original source files, not symlinks.
+    direct_public_headers = target[CcInfo].compilation_context.direct_public_headers
+    for header in direct_public_headers:
+        if "_virtual_includes" in header.path:
+            env.expect.meta.add_failure(
+                "expected no _virtual_includes in header path",
+                "actual: {}".format(header.path),
+            )
+
+def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes(name):
+    """Tests that strip_include_prefix with include_prefix still uses _virtual_includes."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["v1/foo.h"],
+        strip_include_prefix = "v1",
+        include_prefix = "mylib",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _test_strip_include_prefix_with_include_prefix_uses_virtual_includes_impl,
+        target = name + "/lib",
+    )
+
+def _test_strip_include_prefix_with_include_prefix_uses_virtual_includes_impl(env, target):
+    subject = cc_info_subject.from_target(env, target)
+
+    # When include_prefix is set, _virtual_includes should be used.
+    include_dirs = subject.compilation_context().include_dirs()
+    include_dirs.contains_at_least_predicates(
+        [matching.custom(
+            "contains '_virtual_includes'",
+            lambda s: "_virtual_includes" in s,
+        )],
+    )
+
+def _test_strip_include_prefix_error_not_under_prefix(name):
+    """Tests that headers not under strip_include_prefix produce an error."""
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+        hdrs = ["other/foo.h"],
+        strip_include_prefix = "v1",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _test_strip_include_prefix_error_not_under_prefix_impl,
+        target = name + "/lib",
+        expect_failure = True,
+    )
+
+def _test_strip_include_prefix_error_not_under_prefix_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.custom(
+            "contains 'is not under the specified strip prefix'",
+            lambda s: "is not under the specified strip prefix" in s,
+        ),
+    )
+
 def cc_common_tests(name):
+    tests = [
+        _test_same_cc_file_twice,
+        _test_same_header_file_twice,
+        _test_isolated_includes,
+    ]
+    if bazel_features.cc.cc_common_is_in_rules_cc:
+        tests.extend([
+            _test_strip_include_prefix_no_virtual_includes,
+            _test_strip_include_prefix_with_include_prefix_uses_virtual_includes,
+            _test_strip_include_prefix_error_not_under_prefix,
+        ])
     test_suite(
         name = name,
-        tests = [
-            _test_same_cc_file_twice,
-            _test_same_header_file_twice,
-            _test_isolated_includes,
-        ],
+        tests = tests,
     )

--- a/tests/cc/testutil/cc_info_subject.bzl
+++ b/tests/cc/testutil/cc_info_subject.bzl
@@ -48,6 +48,14 @@ def _new_cc_compilation_context_subject(cc_compilation_context, meta):
             self.actual.external_includes.to_list(),
             self.meta.derive("external_include_dirs"),
         ),
+        direct_public_headers = lambda: subjects.collection(
+            self.actual.direct_public_headers,
+            self.meta.derive("direct_public_headers"),
+        ),
+        headers = lambda: subjects.depset_file(
+            self.actual.headers,
+            meta = self.meta.derive("headers"),
+        ),
     )
     return public
 

--- a/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
+++ b/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
@@ -48,8 +48,6 @@ _shorten_virtual_includes_feature = feature(
 
 _skip_virtual_includes_feature = feature(
     name = FEATURE_NAMES.skip_virtual_includes,
-    enabled = True,
-    requires = [feature_set(features = [FEATURE_NAMES.layering_check])],
 )
 
 _supports_interface_shared_libraries_feature = feature(

--- a/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
+++ b/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
@@ -46,6 +46,12 @@ _shorten_virtual_includes_feature = feature(
     enabled = True,
 )
 
+_skip_virtual_includes_feature = feature(
+    name = FEATURE_NAMES.skip_virtual_includes,
+    enabled = True,
+    requires = [feature_set(features = [FEATURE_NAMES.layering_check])],
+)
+
 _supports_interface_shared_libraries_feature = feature(
     name = FEATURE_NAMES.supports_interface_shared_libraries,
     enabled = True,
@@ -1395,6 +1401,7 @@ _feature_name_to_feature = {
     FEATURE_NAMES.generate_linkmap: _generate_linkmap_feature,
     FEATURE_NAMES.shorten_virtual_includes: _shorten_virtual_includes_feature,
     FEATURE_NAMES.preprocessor_defines: _preprocessor_defines_feature,
+    FEATURE_NAMES.skip_virtual_includes: _skip_virtual_includes_feature,
     "header_modules_feature_configuration": _header_modules_feature_configuration,
     "env_var_feature_configuration": _env_var_feature_configuration,
     "host_and_nonhost_configuration": _host_and_nonhost_configuration,

--- a/tests/cc/testutil/toolchains/features.bzl
+++ b/tests/cc/testutil/toolchains/features.bzl
@@ -95,4 +95,5 @@ FEATURE_NAMES = struct(
     generate_linkmap = "generate_linkmap",
     shorten_virtual_includes = "shorten_virtual_includes",
     preprocessor_defines = "preprocessor_defines",
+    skip_virtual_includes = "skip_virtual_includes",
 )


### PR DESCRIPTION
In this case it's not neccessary to create _virtual_includes, just
setting the correct include path is enough.

This should alleviate Windows problems with too long paths.

This is a reapply of https://github.com/bazelbuild/bazel/commit/a091d90cded797ce8f6206b56ffd6f89e27e2c76

Fixes https://github.com/bazelbuild/bazel/issues/17591
