### PR TITLE
Respect runfiles of `deps` in `cc_shared_library`

### DIFF
--- a/cc/private/rules_impl/cc_shared_library_impl.bzl
+++ b/cc/private/rules_impl/cc_shared_library_impl.bzl
@@ -729,6 +729,8 @@ def _cc_shared_library_impl(ctx):
     runfiles = ctx.runfiles(
         files = runfiles_files,
     )
+    for dep in ctx.attr.deps:
+        runfiles = runfiles.merge(dep[DefaultInfo].data_runfiles)
     for dep in ctx.attr.dynamic_deps:
         runfiles = runfiles.merge(dep[DefaultInfo].data_runfiles)
 

--- a/tests/cc/common/BUILD
+++ b/tests/cc/common/BUILD
@@ -1,6 +1,9 @@
 load(":cc_binary_configured_target_tests.bzl", "cc_binary_configured_target_tests")
 load(":cc_common_test.bzl", "cc_common_tests")
+load(":cc_shared_library_configured_target_tests.bzl", "cc_shared_library_configured_target_tests")
 
 cc_binary_configured_target_tests(name = "cc_binary_configured_target_tests")
 
 cc_common_tests(name = "cc_common_tests")
+
+cc_shared_library_configured_target_tests(name = "cc_shared_library_configured_target_tests")

--- a/tests/cc/common/cc_shared_library_configured_target_tests.bzl
+++ b/tests/cc/common/cc_shared_library_configured_target_tests.bzl
@@ -1,0 +1,44 @@
+"""Tests for cc_shared_library."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load("@rules_testing//lib:analysis_test.bzl", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
+load("@rules_testing//lib:util.bzl", "util")
+load("//cc:cc_library.bzl", "cc_library")
+load("//cc:cc_shared_library.bzl", "cc_shared_library")
+load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
+
+def _test_runfiles(name, **kwargs):
+    util.helper_target(
+        cc_shared_library,
+        name = name + "/runfiles/0",
+        deps = [name + "/runfiles/1"],
+    )
+    file1 = util.empty_file(name = name + "/runfiles/file1")
+    util.helper_target(
+        cc_library,
+        name = name + "/runfiles/1",
+        data = [file1],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_runfiles_impl,
+        target = name + "/runfiles/0",
+        **kwargs
+    )
+
+def _test_runfiles_impl(env, target):
+    env.expect.that_target(target).data_runfiles().contains_predicate(
+        matching.str_endswith("lib0.so"),
+    )
+    env.expect.that_target(target).data_runfiles().contains_predicate(
+        matching.str_endswith("file1"),
+    )
+
+def cc_shared_library_configured_target_tests(name):
+    test_suite(
+        name = name,
+        tests = [
+            _test_runfiles,
+        ] if bazel_features.cc.cc_common_is_in_rules_cc else [],
+    )


### PR DESCRIPTION
One of the providers of `cc_shared_library` is `DefaultInfo`, so that one can use the produced library as a standalone artifact (without further consumption by CC rules). An example would be to just `dlopen` that from another program. For that to work, it needs to provide the complete runfiles as well, especially these needed by the (static) libraries it consists of.

This change adds the missing collection of runfiles over `deps`.