### PR TITLE
Disable interface library -soname if already passed

### DIFF
--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -298,7 +298,7 @@ def _create_dynamic_link_actions(
         so_interface, _ = _get_linked_artifact(actions, name, LINK_TARGET_TYPE.INTERFACE_DYNAMIC_LIBRARY, cc_toolchain, link_artifact_name_suffix)
 
         # TODO(b/28946988): Remove this hard-coded flag.
-        if not feature_configuration.is_enabled("targets_windows"):
+        if not feature_configuration.is_enabled("targets_windows") and not feature_configuration.is_enabled("set_soname"):
             link_action_kwargs["linkopts"].append("-Wl,-soname=" + _cc_internal.dynamic_library_soname(
                 actions,
                 linker_output.short_path,


### PR DESCRIPTION
The default toolchain already passes a linker flag for `-soname` which
results in a different soname than the one being computed here. The one
from the toolchain is correct, so if that's already being passed, we
don't need to pass this one. This is probably a good path to removing
this one off logic entirely.

This also fixes the ability to produce interface libraries on macOS