### PR TITLE
Fix interface library soname

### DIFF
--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -18,6 +18,7 @@ A module to create C/C++ link actions in a consistent way.
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//cc/common:cc_helper_internal.bzl",
+    "root_relative_path",
     "wrap_with_check_private_api",
     _use_pic_for_binaries = "use_pic_for_binaries",
     _use_pic_for_dynamic_libs = "use_pic_for_dynamic_libs",
@@ -301,8 +302,9 @@ def _create_dynamic_link_actions(
         if not feature_configuration.is_enabled("targets_windows"):
             link_action_kwargs["linkopts"].append("-Wl,-soname=" + _cc_internal.dynamic_library_soname(
                 actions,
-                linker_output.short_path,
-                False,
+                # Must match https://github.com/bazelbuild/bazel/blob/795af54db5c348af5ca8b2961a982b399206ea20/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java#L169.
+                root_relative_path(linker_output),
+                dynamic_link_type != LINK_TARGET_TYPE.NODEPS_DYNAMIC_LIBRARY,
             ))
 
     mnemonic = "ObjcLink" if dynamic_link_type == LINK_TARGET_TYPE.OBJC_EXECUTABLE else None


### PR DESCRIPTION
This path case is a bit complicated, copied from the other use of
dynamic_library_soname. The boolean at the end was originally fixed in:

https://github.com/bazelbuild/bazel/commit/044a14cca2747aeff258fc71eaeb153c08cb34d5

But it wasn't copied directly to the original version of the starlark
implementation in:

https://github.com/bazelbuild/bazel/commit/25cf03c04a743ad6698d5e722f3e9d5c5a019c47

This mismatch results in missing binaries at runtime
