### PR TITLE
Add has_configured_linker_path cc_tool_capability

### DIFF
--- a/cc/toolchains/capabilities/BUILD
+++ b/cc/toolchains/capabilities/BUILD
@@ -17,3 +17,7 @@ cc_tool_capability(
 cc_tool_capability(
     name = "supports_pic",
 )
+
+cc_tool_capability(
+    name = "has_configured_linker_path",
+)


### PR DESCRIPTION
This is similar to `supports_interface_shared_libraries` and is used for
interface libraries
