### PR TITLE
Fix requires_any_of with capabilities

### DIFF
--- a/cc/toolchains/impl/toolchain_config_info.bzl
+++ b/cc/toolchains/impl/toolchain_config_info.bzl
@@ -71,7 +71,7 @@ def _get_known_features(features, capability_features, fail):
                 ))
         feature_names[ft.name] = ft
 
-    return {_feature_key(feature): None for feature in features}
+    return {_feature_key(feature): None for feature in capability_features + features}
 
 def _can_theoretically_be_enabled(requirement, known_features):
     return all([

--- a/tests/rule_based_toolchain/toolchain_config/BUILD
+++ b/tests/rule_based_toolchain/toolchain_config/BUILD
@@ -158,6 +158,14 @@ util.helper_target(
 )
 
 util.helper_target(
+    cc_args,
+    name = "requires_supports_pic_args",
+    actions = ["//tests/rule_based_toolchain/actions:c_compile"],
+    args = ["--pic"],
+    requires_any_of = ["//cc/toolchains/capabilities:supports_pic"],
+)
+
+util.helper_target(
     cc_feature,
     name = "requires_all_simple_feature",
     args = [":c_compile_args"],

--- a/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
+++ b/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
@@ -171,6 +171,26 @@ def _args_missing_requirements_invalid_test(env, targets):
         "It is impossible to enable %s" % targets.requires_all_simple_args.label,
     )
 
+def _args_requiring_capability_valid_test(env, targets):
+    # A cc_args with requires_any_of pointing at a capability should be valid
+    # when the tool_map contains a tool that provides that capability.
+    _expect_that_toolchain(
+        env,
+        args = [targets.requires_supports_pic_args],
+        tool_map = targets.compile_tool_map,
+        expr = "capability_from_tool",
+    ).ok()
+
+    # Without a tool providing the capability, it should fail.
+    _expect_that_toolchain(
+        env,
+        args = [targets.requires_supports_pic_args],
+        tool_map = targets.empty_tool_map,
+        expr = "capability_missing",
+    ).err().contains(
+        "It is impossible to enable %s" % targets.requires_supports_pic_args.label,
+    )
+
 def _toolchain_collects_files_test(env, targets):
     tc = env.expect.that_target(
         targets.collects_files_toolchain_config,
@@ -275,6 +295,7 @@ TARGETS = [
     ":requires_any_simple_feature",
     ":requires_all_simple_feature",
     ":requires_all_simple_args",
+    ":requires_supports_pic_args",
     ":simple_feature",
     ":simple_feature2",
     ":same_feature_name",
@@ -288,5 +309,6 @@ TESTS = {
     "feature_config_implies_missing_feature_invalid_test": _feature_config_implies_missing_feature_invalid_test,
     "feature_missing_requirements_invalid_test": _feature_missing_requirements_invalid_test,
     "args_missing_requirements_invalid_test": _args_missing_requirements_invalid_test,
+    "args_requiring_capability_valid_test": _args_requiring_capability_valid_test,
     "toolchain_collects_files_test": _toolchain_collects_files_test,
 }


### PR DESCRIPTION
Previously this failed because the features weren't ever added to the
entire feature list
