### PR TITLE
Split supports_dynamic_linker multiple uses

### DIFF
--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -427,8 +427,12 @@ def _maybe_do_lto_indexing(*, link_type, linking_mode, compilation_outputs, libr
     has_lto_bitcode_inputs = lto_compilation_context.lto_bitcode_inputs
 
     # TODO(b/338618120): deduplicate prefer_static_lib, prefer_pic_libs computed in finalize_link_action as well
-    prefer_static_libs = linking_mode == LINKING_MODE.STATIC or \
-                         not feature_configuration.is_enabled("supports_dynamic_linker")
+    # supports_dynamic_library_deps is the intended feature for controlling
+    # whether dynamic libraries can be consumed as deps. Fall back to
+    # supports_dynamic_linker for toolchains that haven't adopted the new feature.
+    supports_dynamic_deps = feature_configuration.is_enabled("supports_dynamic_library_deps") or \
+                            feature_configuration.is_enabled("supports_dynamic_linker")
+    prefer_static_libs = linking_mode == LINKING_MODE.STATIC or not supports_dynamic_deps
     prefer_pic_libs = is_dynamic_library(link_type)
 
     static_libraries_to_link = []

--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -136,8 +136,12 @@ def finalize_link_action(
                          feature_configuration.is_enabled("supports_start_end_lib"))
 
     # TODO(b/338618120): deduplicate prefer_static_lib, prefer_pic_libs
-    prefer_static_libs = linking_mode == LINKING_MODE.STATIC or \
-                         not feature_configuration.is_enabled("supports_dynamic_linker")
+    # supports_dynamic_library_deps is the intended feature for controlling
+    # whether dynamic libraries can be consumed as deps. Fall back to
+    # supports_dynamic_linker for toolchains that haven't adopted the new feature.
+    supports_dynamic_deps = feature_configuration.is_enabled("supports_dynamic_library_deps") or \
+                            feature_configuration.is_enabled("supports_dynamic_linker")
+    prefer_static_libs = linking_mode == LINKING_MODE.STATIC or not supports_dynamic_deps
 
     # TODO(b/412540147): We select PIC libraries iff creating a dynamic library. Match PIC flags.
     prefer_pic_libs = is_dynamic_library(link_type)

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -635,6 +635,7 @@ def _impl(ctx):
     )
 
     supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+    supports_dynamic_library_deps_feature = feature(name = "supports_dynamic_library_deps", enabled = True)
 
     user_compile_flags_feature = feature(
         name = "user_compile_flags",
@@ -1886,6 +1887,7 @@ def _impl(ctx):
             static_libgcc_feature,
             fdo_optimize_feature,
             supports_dynamic_linker_feature,
+            supports_dynamic_library_deps_feature,
             fastbuild_feature,
             dbg_feature,
             opt_feature,
@@ -1948,6 +1950,7 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
+            supports_dynamic_library_deps_feature,
             generate_linkmap_feature,
             no_dotd_file_feature,
         ] + layering_check_features(ctx.attr.compiler, ctx.attr.extra_flags_per_feature, is_macos = True)

--- a/cc/toolchains/capabilities/BUILD
+++ b/cc/toolchains/capabilities/BUILD
@@ -15,5 +15,9 @@ cc_tool_capability(
 )
 
 cc_tool_capability(
+    name = "supports_dynamic_library_deps",
+)
+
+cc_tool_capability(
     name = "supports_pic",
 )

--- a/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
+++ b/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
@@ -41,6 +41,11 @@ _supports_dynamic_linker_feature = feature(
     enabled = True,
 )
 
+_supports_dynamic_library_deps_feature = feature(
+    name = FEATURE_NAMES.supports_dynamic_library_deps,
+    enabled = True,
+)
+
 _shorten_virtual_includes_feature = feature(
     name = FEATURE_NAMES.shorten_virtual_includes,
     enabled = True,
@@ -1316,6 +1321,7 @@ _feature_name_to_feature = {
     FEATURE_NAMES.no_legacy_features: _no_legacy_features_feature,
     FEATURE_NAMES.do_not_split_linking_cmdline: _do_not_split_linking_cmdline_feature,
     FEATURE_NAMES.supports_dynamic_linker: _supports_dynamic_linker_feature,
+    FEATURE_NAMES.supports_dynamic_library_deps: _supports_dynamic_library_deps_feature,
     FEATURE_NAMES.supports_interface_shared_libraries: _supports_interface_shared_libraries_feature,
     FEATURE_NAMES.pic: _pic_feature,
     FEATURE_NAMES.define_with_space: _define_with_space,

--- a/tests/cc/testutil/toolchains/features.bzl
+++ b/tests/cc/testutil/toolchains/features.bzl
@@ -6,6 +6,7 @@ FEATURE_NAMES = struct(
     no_legacy_features = "no_legacy_features",
     do_not_split_linking_cmdline = "do_not_split_linking_cmdline",
     supports_dynamic_linker = "supports_dynamic_linker",
+    supports_dynamic_library_deps = "supports_dynamic_library_deps",
     supports_interface_shared_libraries = "supports_interface_shared_libraries",
     pic = "pic",
     define_with_space = "define_with_space",


### PR DESCRIPTION
supports_dynamic_linker is used both for nodeps libraries and if you can
link dynamic libs to a final binary. macOS supports the latter but not
the former. Now if the toolchain defaults
`supports_dynamic_library_deps` it can indicate that only linking
dynamic libs is supported.

Fixes https://github.com/bazelbuild/bazel/issues/25521
