### PR TITLE
Add parse_headers_as_c feature

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -124,15 +124,23 @@ def parse_headers_support(parse_headers_tool_path):
                     flag_groups = [
                         flag_group(
                             flags = [
-                                # Note: This treats all headers as C++ headers, which may lead to
-                                # parsing failures for C headers that are not valid C++.
-                                # For such headers, use features = ["-parse_headers"] to selectively
-                                # disable parsing.
                                 "-xc++-header",
                                 "-fsyntax-only",
                             ],
                         ),
                     ],
+                    with_features = [with_feature_set(not_features = ["parse_headers_as_c"])],
+                ),
+                flag_set(
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-xc-header",
+                                "-fsyntax-only",
+                            ],
+                        ),
+                    ],
+                    with_features = [with_feature_set(features = ["parse_headers_as_c"])],
                 ),
             ],
             implies = [
@@ -148,6 +156,7 @@ def parse_headers_support(parse_headers_tool_path):
     ]
     features = [
         feature(name = "parse_headers"),
+        feature(name = "parse_headers_as_c"),
     ]
     return action_configs, features
 


### PR DESCRIPTION
This allows C libraries to still use header parsing. This is an
alternative to https://github.com/bazelbuild/bazel/pull/22971 with just
a new feature instead of a new action.

Fixes https://github.com/bazelbuild/bazel/issues/23460
