### PR TITLE
Add new cpp_compile exec group

### DIFF
--- a/cc/private/rules_impl/cc_binary.bzl
+++ b/cc/private/rules_impl/cc_binary.bzl
@@ -59,6 +59,7 @@ be <code>main</code>.
     },
     fragments = ["cpp"] + semantics.additional_fragments(),
     exec_groups = {
+        "cpp_compile": exec_group(toolchains = use_cc_toolchain()),
         "cpp_link": exec_group(toolchains = use_cc_toolchain()),
     } | semantics.extra_exec_groups,
     toolchains = use_cc_toolchain() +

--- a/cc/private/rules_impl/cc_library.bzl
+++ b/cc/private/rules_impl/cc_library.bzl
@@ -428,6 +428,7 @@ See <a href="${link cc_binary.linkshared}"><code>cc_binary.linkshared</code></a>
     fragments = ["cpp"] + semantics.additional_fragments(),
     provides = [CcInfo],
     exec_groups = {
+        "cpp_compile": exec_group(toolchains = use_cc_toolchain()),
         "cpp_link": exec_group(toolchains = use_cc_toolchain()),
     },
 )

--- a/cc/private/rules_impl/cc_test.bzl
+++ b/cc/private/rules_impl/cc_test.bzl
@@ -109,6 +109,7 @@ attributes common to all test rules (*_test)</a>.</p>
     },
     fragments = ["cpp", "coverage"] + semantics.additional_fragments(),
     exec_groups = {
+        "cpp_compile": exec_group(toolchains = use_cc_toolchain()),
         "cpp_link": exec_group(toolchains = use_cc_toolchain()),
         # testing.ExecutionInfo defaults to an exec_group of "test".
         "test": exec_group(toolchains = [config_common.toolchain_type(_CC_TEST_TOOLCHAIN_TYPE, mandatory = False)]),

--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -137,6 +137,9 @@ in binary targets that depend on this library."""),
     ),
     fragments = ["objc", "apple", "cpp"],
     cfg = semantics.apple_crosstool_transition,
+    exec_groups = {
+        "cpp_compile": exec_group(toolchains = use_cc_toolchain()),
+    },
     toolchains = use_cc_toolchain() + cc_semantics.get_runtimes_toolchain(),
     provides = [CcInfo],
 )

--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -144,6 +144,9 @@ in binary targets that depend on this library."""),
     ),
     fragments = ["objc", "apple", "cpp"],
     cfg = semantics.apple_crosstool_transition,
+    exec_groups = {
+        "cpp_compile": exec_group(toolchains = use_cc_toolchain()),
+    },
     toolchains = use_cc_toolchain() + cc_semantics.get_runtimes_toolchain(),
     provides = [CcInfo],
 )


### PR DESCRIPTION
Similar to cpp_link this allows users to customize resources required by
these actions.

Work towards https://github.com/bazelbuild/bazel/issues/17368

Depends on https://github.com/bazelbuild/bazel/pull/29283
