### PR TITLE
Remove incompatible_use_specific_tool_files use

### DIFF
--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -230,8 +230,7 @@ def finalize_link_action(
             action_name = link_type.action_name,
         )
 
-    if cc_toolchain._cpp_configuration.incompatible_use_specific_tool_files() and \
-       link_type.linker_or_archiver == USE_ARCHIVER:
+    if link_type.linker_or_archiver == USE_ARCHIVER:
         linker_files = cc_toolchain._ar_files
     else:
         linker_files = cc_toolchain._linker_files


### PR DESCRIPTION
This flag was flipped to true before bazel 1.0
