### PR TITLE
Remove uses of bazel_features ge

### DIFF
--- a/tests/alwayslink_srcs/BUILD
+++ b/tests/alwayslink_srcs/BUILD
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_features//private:util.bzl", _bazel_version_ge = "ge")  # buildifier: disable=bzl-visibility
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc:cc_library.bzl", "cc_library")
 load("//cc:cc_test.bzl", "cc_test")
 
 licenses(["notice"])
 
-VERSION_GATE = [] if _bazel_version_ge("9.0.0-pre.20250911") else ["@platforms//:incompatible"]
+VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
 
 # Library that provides the registration state (was_registered/set_registered).
 cc_library(

--- a/tests/validate_static_library_env/validate_static_library_env_test.bzl
+++ b/tests/validate_static_library_env/validate_static_library_env_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Analysis test for validate_static_library environment propagation."""
 
-load("@bazel_features//private:util.bzl", _bazel_version_ge = "ge")
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
 load("@rules_testing//lib:util.bzl", "util")
 load("//cc:cc_static_library.bzl", "cc_static_library")
@@ -42,7 +42,7 @@ def maybe_define_validate_static_library_env_targets():
     # cc_static_library is implemented in rules_cc only for Bazel 9+.
     # For older Bazel versions, the native rule is used and does not wire
     # env vars from rules_cc toolchains for ValidateStaticLibrary.
-    if not _bazel_version_ge("9.0.0-pre.20250911"):
+    if not bazel_features.cc.cc_common_is_in_rules_cc:
         return
 
     util.helper_target(


### PR DESCRIPTION
We want to use the cc specific one for this instead, this replaces all our
incorrect uses