### PR TITLE
Add best effort macOS reproducibility flags

### DIFF
--- a/cc/private/toolchain/BUILD.tpl
+++ b/cc/private/toolchain/BUILD.tpl
@@ -101,7 +101,7 @@ cc_toolchain(
     strip_files = ":empty",
     supports_header_parsing = 1,
     supports_param_files = 1,
-    toolchain_config = ":%{cc_toolchain_identifier}",    
+    toolchain_config = ":%{cc_toolchain_identifier}",
     toolchain_identifier = "%{cc_toolchain_identifier}",
 )
 
@@ -132,6 +132,7 @@ cc_toolchain_config(
     coverage_link_flags = [%{coverage_link_flags}],
     supports_start_end_lib = %{supports_start_end_lib},
     extra_flags_per_feature = %{extra_flags_per_feature},
+    features = [%{toolchain_features}],
 )
 
 # Android tooling requires a default toolchain for the armeabi-v7a cpu.

--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -163,6 +163,9 @@ def _is_linker_option_supported(repository_ctx, cc, force_linker_flags, option, 
     ])
     return result.stderr.find(pattern) == -1
 
+def _is_oso_prefix_supported(repository_ctx, ld):
+    return repository_ctx.execute([ld, "-v", "-oso_prefix", "."]).return_code == 0
+
 def _find_linker_path(repository_ctx, cc, linker, is_clang):
     """Checks if a given linker is supported by the C compiler.
 
@@ -416,6 +419,10 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
     auto_configure_warning_maybe(repository_ctx, "CC used: " + str(cc))
     tool_paths = _get_tool_paths(repository_ctx, overridden_tools)
     tool_paths["cpp-module-deps-scanner"] = "deps_scanner_wrapper.sh"
+
+    toolchain_features = []
+    if darwin and _is_oso_prefix_supported(repository_ctx, tool_paths["ld"]):
+        toolchain_features.append("macos_reproducible")
 
     # The parse_header tool needs to be a wrapper around the compiler as it has
     # to touch the output file.
@@ -760,6 +767,7 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
                 "-Wl,--start-lib",
                 "--start-lib",
             ) else "False",
+            "%{toolchain_features}": get_starlark_list(toolchain_features),
             "%{target_cpu}": escape_string(get_env_var(
                 repository_ctx,
                 "BAZEL_TARGET_CPU",

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -473,6 +473,18 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["opt"])],
             ),
         ],
+        env_sets = [
+            env_set(
+                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
+                env_entries = ([
+                    env_entry(
+                        # Required for hermetic links on macOS
+                        key = "ZERO_AR_DATE",
+                        value = "1",
+                    ),
+                ]),
+            ),
+        ],
     )
 
     fastbuild_feature = feature(name = "fastbuild")
@@ -1741,7 +1753,7 @@ def _impl(ctx):
 
     macos_reproducible_feature = feature(
         name = "macos_reproducible",
-        enabled = True,
+        enabled = "macos_reproducible" in ctx.features,
         flag_sets = [
             flag_set(
                 actions = all_compile_actions,
@@ -1750,18 +1762,6 @@ def _impl(ctx):
             flag_set(
                 actions = all_link_actions,
                 flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,."])],
-            ),
-        ],
-        env_sets = [
-            env_set(
-                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
-                env_entries = ([
-                    env_entry(
-                        # Required for hermetic links on macOS
-                        key = "ZERO_AR_DATE",
-                        value = "1",
-                    ),
-                ]),
             ),
         ],
     )

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -473,18 +473,6 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["opt"])],
             ),
         ],
-        env_sets = [
-            env_set(
-                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
-                env_entries = ([
-                    env_entry(
-                        # Required for hermetic links on macOS
-                        key = "ZERO_AR_DATE",
-                        value = "1",
-                    ),
-                ]),
-            ),
-        ],
     )
 
     fastbuild_feature = feature(name = "fastbuild")
@@ -1750,6 +1738,33 @@ def _impl(ctx):
         ],
     )
 
+    macos_reproducible_feature = feature(
+        name = "macos_reproducible",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = ["-ffile-compilation-dir=."])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,."])],
+            ),
+        ],
+        env_sets = [
+            env_set(
+                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
+                env_entries = ([
+                    env_entry(
+                        # Required for hermetic links on macOS
+                        key = "ZERO_AR_DATE",
+                        value = "1",
+                    ),
+                ]),
+            ),
+        ],
+    )
+
     # Kept for backwards compatibility with the crosstool that moved. Without
     # linking the objc runtime binaries don't link CoreFoundation for free,
     # which breaks abseil.
@@ -1913,6 +1928,7 @@ def _impl(ctx):
             cpp_module_modmap_file_feature,
             cpp20_module_compile_flags_feature,
             macos_minimum_os_feature,
+            macos_reproducible_feature,
             macos_default_link_flags_feature,
             dependency_file_feature,
             runtime_library_search_directories_feature,

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -473,18 +473,6 @@ def _impl(ctx):
                 with_features = [with_feature_set(features = ["opt"])],
             ),
         ],
-        env_sets = [
-            env_set(
-                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
-                env_entries = ([
-                    env_entry(
-                        # Required for hermetic links on macOS
-                        key = "ZERO_AR_DATE",
-                        value = "1",
-                    ),
-                ]),
-            ),
-        ],
     )
 
     fastbuild_feature = feature(name = "fastbuild")
@@ -1751,6 +1739,33 @@ def _impl(ctx):
         ],
     )
 
+    macos_reproducible_feature = feature(
+        name = "macos_reproducible",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = ["-ffile-compilation-dir=."])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,."])],
+            ),
+        ],
+        env_sets = [
+            env_set(
+                actions = all_link_actions + lto_index_actions + [ACTION_NAMES.cpp_link_static_library],
+                env_entries = ([
+                    env_entry(
+                        # Required for hermetic links on macOS
+                        key = "ZERO_AR_DATE",
+                        value = "1",
+                    ),
+                ]),
+            ),
+        ],
+    )
+
     # Kept for backwards compatibility with the crosstool that moved. Without
     # linking the objc runtime binaries don't link CoreFoundation for free,
     # which breaks abseil.
@@ -1914,6 +1929,7 @@ def _impl(ctx):
             cpp_module_modmap_file_feature,
             cpp20_module_compile_flags_feature,
             macos_minimum_os_feature,
+            macos_reproducible_feature,
             macos_default_link_flags_feature,
             dependency_file_feature,
             runtime_library_search_directories_feature,


### PR DESCRIPTION
Without `-ffile-compilation-dir=.` (or a similar flag), debug info in
`.o` files contains the absolute path to the compile time execroot.
Without `-Wl,-oso_prefix,.` final binaries contain `N_OSO` stabs that
contain absolute paths to the files link time execroot.

This still leaves 1 known hole that is the absolute path to Xcode is
embedded in debug info, but that doesn't break debuggability like these
2 issues do, it just makes the binaries non hermetic. Fixing that one
requires a compiler wrapper.

All of these issues are fixed in apple_support, but for folks not using
that toolchain these are pretty low risk to add here. The only issue is
if people have very old versions of Xcode / the Xcode command line tools
these flags won't exist.

More info about these paths in https://www.smileykeith.com/2025/09/21/understanding-apple-debug-info/
