### PR TITLE
Keep exports_filter libraries linked in cc_shared_library

### DIFF
--- a/cc/private/rules_impl/cc_shared_library_impl.bzl
+++ b/cc/private/rules_impl/cc_shared_library_impl.bzl
@@ -470,19 +470,21 @@ def _filter_inputs(
             if len(static_libraries) and owner in dynamic_only_roots:
                 dynamic_only_roots.pop(owner)
 
+            exported_by_filter = _check_if_target_should_be_exported_with_filter(
+                linker_input.owner,
+                ctx.label,
+                ctx.attr.exports_filter,
+            )
+
             linker_input_to_be_linked_statically = linker_input
-            if owner in top_level_linker_input_labels_set:
+            if owner in top_level_linker_input_labels_set or exported_by_filter:
                 linker_input_to_be_linked_statically = _wrap_static_library_with_alwayslink(
                     ctx,
                     feature_configuration,
                     cc_toolchain,
                     linker_input,
                 )
-            if _check_if_target_should_be_exported_with_filter(
-                linker_input.owner,
-                ctx.label,
-                ctx.attr.exports_filter,
-            ):
+            if exported_by_filter:
                 exports[owner] = True
 
             _add_linker_input_to_dict(linker_input.owner, linker_input_to_be_linked_statically)

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc:cc_library.bzl", "cc_library")
 load("//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//cc:cc_test.bzl", "cc_test")
@@ -23,25 +24,27 @@ _NON_WINDOWS = select({
     "//conditions:default": [],
 })
 
+VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
+
 cc_library(
     name = "exported_transitive",
     srcs = ["exported_transitive.cc"],
     hdrs = ["exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )
 
 cc_library(
     name = "exported_transitive_middle",
     srcs = ["exported_transitive_middle.cc"],
     hdrs = ["exported_transitive_middle.h"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "exports_filter_transitive_so",
     exports_filter = [":exported_transitive"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive_middle"],
 )
 
@@ -49,14 +52,14 @@ cc_library(
     name = "uses_exported_transitive",
     srcs = ["uses_exported_transitive.cc"],
     hdrs = ["uses_exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "uses_exported_transitive_so",
     dynamic_deps = [":exports_filter_transitive_so"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":uses_exported_transitive"],
 )
 
@@ -64,5 +67,5 @@ cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
     dynamic_deps = [":uses_exported_transitive_so"],
-    target_compatible_with = _NON_WINDOWS,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -19,32 +19,28 @@ load("//cc:cc_test.bzl", "cc_test")
 
 licenses(["notice"])
 
-_NON_WINDOWS = select({
-    "@platforms//os:windows": ["@platforms//:incompatible"],
-    "//conditions:default": [],
-})
-
 VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
 
 cc_library(
     name = "exported_transitive",
     srcs = ["exported_transitive.cc"],
     hdrs = ["exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    local_defines = ["EXPORTED_TRANSITIVE_EXPORTS"],
+    target_compatible_with = VERSION_GATE,
 )
 
 cc_library(
     name = "exported_transitive_middle",
     srcs = ["exported_transitive_middle.cc"],
     hdrs = ["exported_transitive_middle.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "exports_filter_transitive_so",
     exports_filter = [":exported_transitive"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive_middle"],
 )
 
@@ -52,14 +48,15 @@ cc_library(
     name = "uses_exported_transitive",
     srcs = ["uses_exported_transitive.cc"],
     hdrs = ["uses_exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    local_defines = ["USES_EXPORTED_TRANSITIVE_EXPORTS"],
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "uses_exported_transitive_so",
     dynamic_deps = [":exports_filter_transitive_so"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":uses_exported_transitive"],
 )
 
@@ -67,5 +64,5 @@ cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
     dynamic_deps = [":uses_exported_transitive_so"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -63,6 +63,7 @@ cc_shared_library(
 cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
+    deps = [":uses_exported_transitive"],
     dynamic_deps = [":uses_exported_transitive_so"],
     target_compatible_with = VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -63,7 +63,6 @@ cc_shared_library(
 cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
-    deps = [":uses_exported_transitive"],
     dynamic_deps = [":uses_exported_transitive_so"],
     target_compatible_with = VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -19,32 +19,27 @@ load("//cc:cc_test.bzl", "cc_test")
 
 licenses(["notice"])
 
-_NON_WINDOWS = select({
-    "@platforms//os:windows": ["@platforms//:incompatible"],
-    "//conditions:default": [],
-})
-
 VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
 
 cc_library(
     name = "exported_transitive",
     srcs = ["exported_transitive.cc"],
     hdrs = ["exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
 )
 
 cc_library(
     name = "exported_transitive_middle",
     srcs = ["exported_transitive_middle.cc"],
     hdrs = ["exported_transitive_middle.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "exports_filter_transitive_so",
     exports_filter = [":exported_transitive"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive_middle"],
 )
 
@@ -52,14 +47,14 @@ cc_library(
     name = "uses_exported_transitive",
     srcs = ["uses_exported_transitive.cc"],
     hdrs = ["uses_exported_transitive.h"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "uses_exported_transitive_so",
     dynamic_deps = [":exports_filter_transitive_so"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
     deps = [":uses_exported_transitive"],
 )
 
@@ -67,5 +62,5 @@ cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
     dynamic_deps = [":uses_exported_transitive_so"],
-    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
+    target_compatible_with = VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -19,27 +19,32 @@ load("//cc:cc_test.bzl", "cc_test")
 
 licenses(["notice"])
 
+_NON_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
 
 cc_library(
     name = "exported_transitive",
     srcs = ["exported_transitive.cc"],
     hdrs = ["exported_transitive.h"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )
 
 cc_library(
     name = "exported_transitive_middle",
     srcs = ["exported_transitive_middle.cc"],
     hdrs = ["exported_transitive_middle.h"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "exports_filter_transitive_so",
     exports_filter = [":exported_transitive"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive_middle"],
 )
 
@@ -47,14 +52,14 @@ cc_library(
     name = "uses_exported_transitive",
     srcs = ["uses_exported_transitive.cc"],
     hdrs = ["uses_exported_transitive.h"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "uses_exported_transitive_so",
     dynamic_deps = [":exports_filter_transitive_so"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":uses_exported_transitive"],
 )
 
@@ -62,5 +67,5 @@ cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
     dynamic_deps = [":uses_exported_transitive_so"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -19,28 +19,32 @@ load("//cc:cc_test.bzl", "cc_test")
 
 licenses(["notice"])
 
+_NON_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
 VERSION_GATE = [] if bazel_features.cc.cc_common_is_in_rules_cc else ["@platforms//:incompatible"]
 
 cc_library(
     name = "exported_transitive",
     srcs = ["exported_transitive.cc"],
     hdrs = ["exported_transitive.h"],
-    local_defines = ["EXPORTED_TRANSITIVE_EXPORTS"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )
 
 cc_library(
     name = "exported_transitive_middle",
     srcs = ["exported_transitive_middle.cc"],
     hdrs = ["exported_transitive_middle.h"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "exports_filter_transitive_so",
     exports_filter = [":exported_transitive"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive_middle"],
 )
 
@@ -48,15 +52,14 @@ cc_library(
     name = "uses_exported_transitive",
     srcs = ["uses_exported_transitive.cc"],
     hdrs = ["uses_exported_transitive.h"],
-    local_defines = ["USES_EXPORTED_TRANSITIVE_EXPORTS"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":exported_transitive"],
 )
 
 cc_shared_library(
     name = "uses_exported_transitive_so",
     dynamic_deps = [":exports_filter_transitive_so"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
     deps = [":uses_exported_transitive"],
 )
 
@@ -64,5 +67,5 @@ cc_test(
     name = "exports_filter_transitive_test",
     srcs = ["exports_filter_transitive_test.cc"],
     dynamic_deps = [":uses_exported_transitive_so"],
-    target_compatible_with = VERSION_GATE,
+    target_compatible_with = _NON_WINDOWS + VERSION_GATE,
 )

--- a/tests/cc_shared_library_exports_filter/BUILD
+++ b/tests/cc_shared_library_exports_filter/BUILD
@@ -1,0 +1,68 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//cc:cc_library.bzl", "cc_library")
+load("//cc:cc_shared_library.bzl", "cc_shared_library")
+load("//cc:cc_test.bzl", "cc_test")
+
+licenses(["notice"])
+
+_NON_WINDOWS = select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
+cc_library(
+    name = "exported_transitive",
+    srcs = ["exported_transitive.cc"],
+    hdrs = ["exported_transitive.h"],
+    target_compatible_with = _NON_WINDOWS,
+)
+
+cc_library(
+    name = "exported_transitive_middle",
+    srcs = ["exported_transitive_middle.cc"],
+    hdrs = ["exported_transitive_middle.h"],
+    target_compatible_with = _NON_WINDOWS,
+    deps = [":exported_transitive"],
+)
+
+cc_shared_library(
+    name = "exports_filter_transitive_so",
+    exports_filter = [":exported_transitive"],
+    target_compatible_with = _NON_WINDOWS,
+    deps = [":exported_transitive_middle"],
+)
+
+cc_library(
+    name = "uses_exported_transitive",
+    srcs = ["uses_exported_transitive.cc"],
+    hdrs = ["uses_exported_transitive.h"],
+    target_compatible_with = _NON_WINDOWS,
+    deps = [":exported_transitive"],
+)
+
+cc_shared_library(
+    name = "uses_exported_transitive_so",
+    dynamic_deps = [":exports_filter_transitive_so"],
+    target_compatible_with = _NON_WINDOWS,
+    deps = [":uses_exported_transitive"],
+)
+
+cc_test(
+    name = "exports_filter_transitive_test",
+    srcs = ["exports_filter_transitive_test.cc"],
+    dynamic_deps = [":uses_exported_transitive_so"],
+    target_compatible_with = _NON_WINDOWS,
+)

--- a/tests/cc_shared_library_exports_filter/exported_transitive.cc
+++ b/tests/cc_shared_library_exports_filter/exported_transitive.cc
@@ -1,0 +1,17 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/cc_shared_library_exports_filter/exported_transitive.h"
+
+int exported_transitive() { return 7; }

--- a/tests/cc_shared_library_exports_filter/exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/exported_transitive.h
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-int exported_transitive();
+#ifdef _WIN32
+#if defined(EXPORTED_TRANSITIVE_EXPORTS)
+#define EXPORTED_TRANSITIVE_API __declspec(dllexport)
+#else
+#define EXPORTED_TRANSITIVE_API __declspec(dllimport)
+#endif
+#else
+#define EXPORTED_TRANSITIVE_API
+#endif
+
+EXPORTED_TRANSITIVE_API int exported_transitive();

--- a/tests/cc_shared_library_exports_filter/exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/exported_transitive.h
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
-#if defined(EXPORTED_TRANSITIVE_EXPORTS)
-#define EXPORTED_TRANSITIVE_API __declspec(dllexport)
-#else
-#define EXPORTED_TRANSITIVE_API __declspec(dllimport)
-#endif
-#else
-#define EXPORTED_TRANSITIVE_API
-#endif
-
-EXPORTED_TRANSITIVE_API int exported_transitive();
+int exported_transitive();

--- a/tests/cc_shared_library_exports_filter/exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/exported_transitive.h
@@ -1,0 +1,15 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int exported_transitive();

--- a/tests/cc_shared_library_exports_filter/exported_transitive_middle.cc
+++ b/tests/cc_shared_library_exports_filter/exported_transitive_middle.cc
@@ -1,0 +1,17 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/cc_shared_library_exports_filter/exported_transitive_middle.h"
+
+int exported_transitive_middle() { return 1; }

--- a/tests/cc_shared_library_exports_filter/exported_transitive_middle.h
+++ b/tests/cc_shared_library_exports_filter/exported_transitive_middle.h
@@ -1,0 +1,15 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int exported_transitive_middle();

--- a/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
+++ b/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "uses_exported_transitive.h"
+int uses_exported_transitive();
 
 int main() { return uses_exported_transitive() == 7 ? 0 : 1; }

--- a/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
+++ b/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
@@ -1,0 +1,17 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int uses_exported_transitive();
+
+int main() { return uses_exported_transitive() == 7 ? 0 : 1; }

--- a/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
+++ b/tests/cc_shared_library_exports_filter/exports_filter_transitive_test.cc
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-int uses_exported_transitive();
+#include "uses_exported_transitive.h"
 
 int main() { return uses_exported_transitive() == 7 ? 0 : 1; }

--- a/tests/cc_shared_library_exports_filter/uses_exported_transitive.cc
+++ b/tests/cc_shared_library_exports_filter/uses_exported_transitive.cc
@@ -1,0 +1,17 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tests/cc_shared_library_exports_filter/exported_transitive.h"
+
+int uses_exported_transitive() { return exported_transitive(); }

--- a/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
@@ -1,0 +1,15 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int uses_exported_transitive();

--- a/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
-#if defined(USES_EXPORTED_TRANSITIVE_EXPORTS)
-#define USES_EXPORTED_TRANSITIVE_API __declspec(dllexport)
-#else
-#define USES_EXPORTED_TRANSITIVE_API __declspec(dllimport)
-#endif
-#else
-#define USES_EXPORTED_TRANSITIVE_API
-#endif
-
-USES_EXPORTED_TRANSITIVE_API int uses_exported_transitive();
+int uses_exported_transitive();

--- a/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
+++ b/tests/cc_shared_library_exports_filter/uses_exported_transitive.h
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-int uses_exported_transitive();
+#ifdef _WIN32
+#if defined(USES_EXPORTED_TRANSITIVE_EXPORTS)
+#define USES_EXPORTED_TRANSITIVE_API __declspec(dllexport)
+#else
+#define USES_EXPORTED_TRANSITIVE_API __declspec(dllimport)
+#endif
+#else
+#define USES_EXPORTED_TRANSITIVE_API
+#endif
+
+USES_EXPORTED_TRANSITIVE_API int uses_exported_transitive();


### PR DESCRIPTION
Libraries exposed via exports_filter are expected to be provided by the producing cc_shared_library even when they are otherwise unused by that shared library's own objects. Without special handling they can still be wrapped in start-lib/end-lib and dropped by the linker, which breaks downstream shared libraries that rely on those exported symbols through dynamic_deps.

Any libraries covered by exports_filter are now treated as alwayslink, to avoid this issue.

Fixes bazelbuild/bazel#20428