### PR TITLE
Fallback to get_tool_for_action with empty tool_paths

### DIFF
--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utility functions for C++ rules."""
 
+load("//cc:action_names.bzl", "ACTION_NAMES")
 load("//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE")
 load("//cc/private:paths.bzl", "is_path_absolute")
 load("//cc/private/rules_impl:objc_common.bzl", "objc_common")
@@ -466,21 +467,35 @@ def _get_compilation_contexts_from_deps(deps):
 def _tool_path(cc_toolchain, tool):
     return cc_toolchain._tool_paths.get(tool, None)
 
-def _get_toolchain_global_make_variables(cc_toolchain):
+def _tool_path_for_action(cc_toolchain, tool, feature_configuration, action_name):
+    path = cc_toolchain._tool_paths.get(tool, None)
+    if path:
+        return path
+    if action_name != None and cc_common.action_is_enabled(
+        feature_configuration = feature_configuration,
+        action_name = action_name,
+    ):
+        return cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+        ) or ""
+    return ""
+
+def _get_toolchain_global_make_variables(cc_toolchain, feature_configuration):
     result = {
-        "CC": _tool_path(cc_toolchain, "gcc"),
-        "AR": _tool_path(cc_toolchain, "ar"),
-        "NM": _tool_path(cc_toolchain, "nm"),
-        "LD": _tool_path(cc_toolchain, "ld"),
-        "STRIP": _tool_path(cc_toolchain, "strip"),
+        "CC": _tool_path_for_action(cc_toolchain, "gcc", feature_configuration, ACTION_NAMES.c_compile),
+        "AR": _tool_path_for_action(cc_toolchain, "ar", feature_configuration, ACTION_NAMES.cpp_link_static_library),
+        "NM": _tool_path_for_action(cc_toolchain, "nm", feature_configuration, None),
+        "LD": _tool_path_for_action(cc_toolchain, "ld", feature_configuration, ACTION_NAMES.cpp_link_executable),
+        "STRIP": _tool_path_for_action(cc_toolchain, "strip", feature_configuration, ACTION_NAMES.strip),
         "C_COMPILER": cc_toolchain.compiler,
     }  # buildifier: disable=unsorted-dict-items
 
-    obj_copy_tool = _tool_path(cc_toolchain, "objcopy")
+    obj_copy_tool = _tool_path_for_action(cc_toolchain, "objcopy", feature_configuration, ACTION_NAMES.objcopy_embed_data)
     if obj_copy_tool != None:
         # objcopy is optional in Crostool.
         result["OBJCOPY"] = obj_copy_tool
-    gcov_tool = _tool_path(cc_toolchain, "gcov-tool")
+    gcov_tool = _tool_path_for_action(cc_toolchain, "gcov-tool", feature_configuration, None)
     if gcov_tool != None:
         # gcovtool is optional in Crostool.
         result["GCOVTOOL"] = gcov_tool

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -516,7 +516,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
 
     runtimes_copts = semantics.get_cc_runtimes_copts(ctx)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, compilation_outputs) = cc_common.compile(

--- a/cc/private/rules_impl/cc_import.bzl
+++ b/cc/private/rules_impl/cc_import.bzl
@@ -161,7 +161,7 @@ def _cc_import_impl(ctx):
             linker_inputs = depset([linker_input]),
         )
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     runtimes_deps = semantics.get_cc_runtimes(ctx, True)

--- a/cc/private/rules_impl/cc_library_impl.bzl
+++ b/cc/private/rules_impl/cc_library_impl.bzl
@@ -50,7 +50,7 @@ def _cc_library_impl(ctx):
     compilation_contexts = cc_helper.get_compilation_contexts_from_deps(interface_deps)
     implementation_compilation_contexts = cc_helper.get_compilation_contexts_from_deps(ctx.attr.implementation_deps)
 
-    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    additional_make_variable_substitutions = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration)
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, srcs_compilation_outputs) = cc_common.compile(

--- a/cc/private/rules_impl/cc_toolchain.bzl
+++ b/cc/private/rules_impl/cc_toolchain.bzl
@@ -181,7 +181,7 @@ def _cc_toolchain_impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(cc_toolchain) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
+    template_vars = cc_toolchain._additional_make_variables | cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration) | cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain)
     template_variable_info = TemplateVariableInfo(template_vars)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/cc/private/rules_impl/cc_toolchain_alias.bzl
+++ b/cc/private/rules_impl/cc_toolchain_alias.bzl
@@ -27,8 +27,14 @@ def _impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx, mandatory = ctx.attr.mandatory)
     if not cc_toolchain:
         return []
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     make_variables = cc_toolchain._additional_make_variables
-    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(cc_toolchain)
+    cc_provider_make_variables = cc_helper.get_toolchain_global_make_variables(cc_toolchain, feature_configuration)
     template_variable_info = TemplateVariableInfo(make_variables | cc_provider_make_variables)
     toolchain = ToolchainInfo(
         cc = cc_toolchain,

--- a/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
+++ b/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
@@ -24,23 +24,6 @@ load(":cc_toolchain_info.bzl", "CcToolchainInfo")
 
 visibility("private")
 
-_TOOL_PATH_ONLY_TOOLS = [
-    "gcov-tool",
-    "gcov",
-    "llvm-profdata",
-    "llvm-cov",
-]
-
-_REQUIRED_TOOLS = [
-    "ar",
-    "cpp",
-    "gcc",
-    "ld",
-    "nm",
-    "objdump",
-    "strip",
-]
-
 _SYSROOT_START = "%sysroot%/"
 _WORKSPACE_START = "%workspace%/"
 _CROSSTOOL_START = "%crosstool_top%/"
@@ -82,22 +65,6 @@ def _compute_tool_paths(toolchain_config_info, crosstool_top_path):
             fail("The include path '" + path_str + "' is not normalized.")
         tool_paths_collector[tool.name] = get_relative_path(crosstool_top_path, path_str)
 
-    # These tools can only be declared using tool paths, so action-only toolchains should still
-    # be allowed to declared them while still being treated as an action-only toolchain. If a tool
-    # that can be specified with actions is declared using paths, the toolchain will be treated as
-    # a tool-path toolchain to enforce users to migrate their toolchain fully.
-    contains_all = True
-    for key in tool_paths_collector.keys():
-        if key not in _TOOL_PATH_ONLY_TOOLS:
-            contains_all = False
-            break
-    if contains_all:
-        for tool in _REQUIRED_TOOLS:
-            tool_paths_collector[tool] = get_relative_path(crosstool_top_path, tool)
-    else:
-        for tool in _REQUIRED_TOOLS:
-            if tool not in tool_paths_collector.keys():
-                fail("Tool path for '" + tool + "' is missing")
     return tool_paths_collector
 
 def _resolve_include_dir(target_label, s, sysroot, crosstool_path):


### PR DESCRIPTION
If the toolchain doesn't configure tool_paths, these make variables
should still be set correctly
