### PR TITLE
Decouple supports_start_end_lib from lld / gold

### DIFF
--- a/cc/private/toolchain/unix_cc_configure.bzl
+++ b/cc/private/toolchain/unix_cc_configure.bzl
@@ -753,7 +753,13 @@ def configure_unix_toolchain(repository_ctx, cpu_value, overridden_tools):
                     "-gc-sections",
                 ),
             ),
-            "%{supports_start_end_lib}": "True" if gold_or_lld_linker_path else "False",
+            "%{supports_start_end_lib}": "True" if _is_linker_option_supported(
+                repository_ctx,
+                cc,
+                force_linker_flags,
+                "-Wl,--start-lib",
+                "--start-lib",
+            ) else "False",
             "%{target_cpu}": escape_string(get_env_var(
                 repository_ctx,
                 "BAZEL_TARGET_CPU",


### PR DESCRIPTION
More linkers than just lld and gold (e.g., mold) support these flags. We should probe for support directly, like we do with all other linker flags.