### PR TITLE
Pass through cpu to rules based toolchains

### DIFF
--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -51,6 +51,7 @@ def cc_toolchain(
         supports_header_parsing = False,
         supports_param_files = False,
         compiler = "",
+        cpu = "",
         target_system_name = None,
         **kwargs):
     """A C/C++ toolchain configuration.
@@ -143,6 +144,10 @@ def cc_toolchain(
         compiler: (str) The type of compiler used by this toolchain (e.g. "gcc", "clang"). The current
             toolchain's compiler is exposed to `@rules_cc//cc/private/toolchain:compiler
             (compiler_flag)` as a flag value.
+        cpu: (str) DEPRECATED: CPU string (ex: "darwin_arm64", "k8") exposed
+            through the `target_cpu` attribute of the toolchain configuration. We
+            should not add new readers of this value, but there are many existing
+            ones in the wild.
         target_system_name: (str) The target system name for this toolchain. Bazel doesn't use this
             but starlark rules can read this value through `toolchain_info.target_gnu_system_name`.
             This string is commonly the target triple you would pass to `clang -target` (e.g. "x86_64-unknown-linux-gnu").
@@ -173,7 +178,7 @@ def cc_toolchain(
             known_features = known_features,
             enabled_features = enabled_features,
             compiler = compiler,
-            cpu = _CPU,
+            cpu = cpu or _CPU,
             target_system_name = target_system_name,
             dynamic_runtime_lib = dynamic_runtime_lib,
             libc_top = libc_top,
@@ -201,7 +206,7 @@ def cc_toolchain(
         known_features = known_features,
         enabled_features = enabled_features,
         compiler = compiler,
-        cpu = _CPU,
+        cpu = cpu or _CPU,
         target_system_name = target_system_name,
         visibility = ["//visibility:private"],
         **kwargs

--- a/docs/toolchain_api.md
+++ b/docs/toolchain_api.md
@@ -791,7 +791,7 @@ load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_toolchain")
 
 cc_toolchain(*, <a href="#cc_toolchain-name">name</a>, <a href="#cc_toolchain-tool_map">tool_map</a>, <a href="#cc_toolchain-args">args</a>, <a href="#cc_toolchain-artifact_name_patterns">artifact_name_patterns</a>, <a href="#cc_toolchain-make_variables">make_variables</a>, <a href="#cc_toolchain-legacy_tools">legacy_tools</a>,
              <a href="#cc_toolchain-known_features">known_features</a>, <a href="#cc_toolchain-enabled_features">enabled_features</a>, <a href="#cc_toolchain-libc_top">libc_top</a>, <a href="#cc_toolchain-module_map">module_map</a>, <a href="#cc_toolchain-dynamic_runtime_lib">dynamic_runtime_lib</a>,
-             <a href="#cc_toolchain-static_runtime_lib">static_runtime_lib</a>, <a href="#cc_toolchain-supports_header_parsing">supports_header_parsing</a>, <a href="#cc_toolchain-supports_param_files">supports_param_files</a>, <a href="#cc_toolchain-compiler">compiler</a>,
+             <a href="#cc_toolchain-static_runtime_lib">static_runtime_lib</a>, <a href="#cc_toolchain-supports_header_parsing">supports_header_parsing</a>, <a href="#cc_toolchain-supports_param_files">supports_param_files</a>, <a href="#cc_toolchain-compiler">compiler</a>, <a href="#cc_toolchain-cpu">cpu</a>,
              <a href="#cc_toolchain-target_system_name">target_system_name</a>, <a href="#cc_toolchain-kwargs">**kwargs</a>)
 </pre>
 
@@ -855,6 +855,7 @@ Generated rules:
 | <a id="cc_toolchain-supports_header_parsing"></a>supports_header_parsing |  (bool) Whether or not this toolchain supports header parsing actions. See [`cc_toolchain.supports_header_parsing`](https://bazel.build/reference/be/c-cpp#cc_toolchain.supports_header_parsing) for more information.   |  `False` |
 | <a id="cc_toolchain-supports_param_files"></a>supports_param_files |  (bool) Whether or not this toolchain supports linking via param files. See [`cc_toolchain.supports_param_files`](https://bazel.build/reference/be/c-cpp#cc_toolchain.supports_param_files) for more information.   |  `False` |
 | <a id="cc_toolchain-compiler"></a>compiler |  (str) The type of compiler used by this toolchain (e.g. "gcc", "clang"). The current toolchain's compiler is exposed to `@rules_cc//cc/private/toolchain:compiler (compiler_flag)` as a flag value.   |  `""` |
+| <a id="cc_toolchain-cpu"></a>cpu |  (str) DEPRECATED: CPU string (ex: "darwin_arm64", "k8") exposed through the `target_cpu` attribute of the toolchain configuration. We should not add new readers of this value, but there are many existing ones in the wild.   |  `""` |
 | <a id="cc_toolchain-target_system_name"></a>target_system_name |  (str) The target system name for this toolchain. Bazel doesn't use this but starlark rules can read this value through `toolchain_info.target_gnu_system_name`. This string is commonly the target triple you would pass to `clang -target` (e.g. "x86_64-unknown-linux-gnu"). If not provided, a best effort default is selected.   |  `None` |
 | <a id="cc_toolchain-kwargs"></a>kwargs |  [common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) that should be applied to all rules created by this macro.   |  none |
 


### PR DESCRIPTION
As mentioned in
https://github.com/bazelbuild/rules_cc/pull/327#issuecomment-2617939160
there are still many places using this. I'm trying to convert the Apple
toolchain to be rules based and we have to allow that repo to determine
this since it defines custom constraints and custom platforms that
define what "CPU" value should be set.
