### PR TITLE
Allow rules_rs to use cc_common.link

### DIFF
--- a/cc/common/cc_helper_internal.bzl
+++ b/cc/common/cc_helper_internal.bzl
@@ -163,6 +163,7 @@ PRIVATE_STARLARKIFICATION_ALLOWLIST = [
     # Rust rules
     ("", "third_party/bazel_rules/rules_rust/rust/private"),
     ("rules_rust", "rust/private"),
+    ("rules_rs", "rust/private"),
     # Python rules
     ("", "third_party/bazel_rules/rules_python"),
     # Various


### PR DESCRIPTION
[rules_rs](https://github.com/hermeticbuild/rules_rs) is an alternative Rust ruleset that is gaining adoption within the OS community. This change allows it to link against a cc_library using `linkstamp`, just like `rules_rust` is allowed to.

As an aside, this allowlist mechanism feels pretty unfortunate. It explicitly privileges Google rulesets and is mostly internal-only. I suspect the [compile actions list](https://github.com/bazelbuild/rules_cc/blob/bf92fe4236f1600636ab42888f14905a5517551d/cc/common/cc_helper_internal.bzl#L130C1-L130C47) may not even work if [crubit is consumed as a bazel module](https://github.com/google/crubit) instead of vendored into the repo like Google does? In addition, the entire open-source world pays the cost for these allowlist checks. Even after @fmeum 's optimizations in https://github.com/bazelbuild/bazel/pull/28173 and https://github.com/bazelbuild/bazel/pull/28178 they are non-0 cost. Perhaps these can be implemented as static analysis checks within Google instead of the entire world paying runtime cost?