### PR TITLE
Make objc_library(data = ...) work, and propagate runfiles of deps

### DIFF
--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -109,7 +109,15 @@ def _objc_library_impl(ctx):
     return [
         DefaultInfo(
             files = depset(files),
-            data_runfiles = ctx.runfiles(files = files),
+            runfiles = ctx.runfiles(
+                files = files + ctx.files.data,
+            ).merge_all([
+                dep[DefaultInfo].default_runfiles
+                for dep in ctx.attr.deps
+            ]).merge_all([
+                dep[DefaultInfo].default_runfiles
+                for dep in ctx.attr.implementation_deps
+            ]),
         ),
         CcInfo(
             compilation_context = compilation_context,


### PR DESCRIPTION
Right now objc_library()'s runfiles object does not include the files passed to the data argument. It also doesn't inherit the runfiles of dependencies and implementation dependencies.