### PR TITLE
Fix starlark toolchain regressions

### DIFF
--- a/cc/private/rules_impl/cc_toolchain.bzl
+++ b/cc/private/rules_impl/cc_toolchain.bzl
@@ -190,6 +190,7 @@ def _cc_toolchain_impl(ctx):
         cc_provider_in_toolchain = True,
     )
     providers.append(cc_toolchain)
+    providers.append(attributes.cc_toolchain_config_info)
     providers.append(toolchain)
     providers.append(template_variable_info)
     providers.append(DefaultInfo(files = cc_toolchain._all_files_including_libc))

--- a/cc/toolchains/toolchain.bzl
+++ b/cc/toolchains/toolchain.bzl
@@ -153,6 +153,10 @@ def cc_toolchain(
 
     cc_toolchain_visibility = kwargs.pop("visibility", default = None)
 
+    for group in LEGACY_FILE_GROUPS:
+        if group in kwargs:
+            fail("Don't use legacy file groups such as %s. Instead, associate files with `cc_tool` or `cc_args` rules." % group)
+
     target_system_name = target_system_name or select({
         Label("//cc/toolchains/impl:darwin_aarch64"): "aarch64-apple-darwin",
         Label("//cc/toolchains/impl:darwin_x86_64"): "x86_64-apple-darwin",
@@ -170,6 +174,7 @@ def cc_toolchain(
             args = args,
             artifact_name_patterns = artifact_name_patterns,
             make_variables = make_variables,
+            legacy_tools = legacy_tools,
             known_features = known_features,
             enabled_features = enabled_features,
             compiler = compiler,
@@ -185,10 +190,6 @@ def cc_toolchain(
             **kwargs
         )
         return
-
-    for group in LEGACY_FILE_GROUPS:
-        if group in kwargs:
-            fail("Don't use legacy file groups such as %s. Instead, associate files with `cc_tool` or `cc_args` rules." % group)
 
     config_name = "_{}_config".format(name)
     cc_toolchain_config(

--- a/tests/rule_based_toolchain/toolchain_config/BUILD
+++ b/tests/rule_based_toolchain/toolchain_config/BUILD
@@ -3,8 +3,10 @@ load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:feature.bzl", "cc_feature")
 load("//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("//cc/toolchains:legacy_tool.bzl", "cc_legacy_tool")
+load("//cc/toolchains:make_variable.bzl", "cc_make_variable")
 load("//cc/toolchains:tool.bzl", "cc_tool")
 load("//cc/toolchains:tool_map.bzl", "cc_tool_map")
+load("//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load("//cc/toolchains/args:sysroot.bzl", "cc_sysroot")
 load("//cc/toolchains/impl:external_feature.bzl", "cc_external_feature")
 load("//cc/toolchains/impl:toolchain_config.bzl", "cc_legacy_file_group", "cc_toolchain_config")
@@ -228,6 +230,12 @@ cc_legacy_tool(
     tool_name = "gcov",
 )
 
+cc_make_variable(
+    name = "rules_based_make_variable",
+    value = "rules-based-value",
+    variable_name = "RULES_BASED_VAR",
+)
+
 util.helper_target(
     cc_toolchain_config,
     name = "toolchain_config_with_legacy_tools",
@@ -235,6 +243,24 @@ util.helper_target(
         ":legacy_gcov",
     ],
     tool_map = ":empty_tool_map",
+)
+
+cc_toolchain(
+    name = "rules_based_cc_toolchain",
+    compiler = "rules-based-compiler",
+    legacy_tools = [
+        ":legacy_gcov",
+    ],
+    make_variables = [":rules_based_make_variable"],
+    tags = ["manual"],
+    target_system_name = "rules-based-system",
+    tool_map = ":empty_tool_map",
+)
+
+alias(
+    name = "rules_based_cc_toolchain_generated_config",
+    actual = ":_rules_based_cc_toolchain_config",
+    tags = ["manual"],
 )
 
 analysis_test_suite(

--- a/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
+++ b/tests/rule_based_toolchain/toolchain_config/toolchain_config_test.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for the cc_toolchain_config rule."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "//cc:cc_toolchain_config_lib.bzl",
     legacy_action_config = "action_config",
@@ -24,6 +25,7 @@ load(
     legacy_tool = "tool",
     legacy_tool_path = "tool_path",  # buildifier: disable=deprecated-function
 )
+load("//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 load("//cc/toolchains:cc_toolchain_info.bzl", "ActionTypeInfo", "ToolchainConfigInfo")
 load("//cc/toolchains/impl:legacy_converter.bzl", "convert_toolchain")
 load("//cc/toolchains/impl:toolchain_config_info.bzl", _toolchain_config_info = "toolchain_config_info")
@@ -291,6 +293,48 @@ def _legacy_tools_produce_tool_paths_test(env, targets):
         legacy_tool_path(name = "gcov", path = "/usr/bin/gcov"),
     ])
 
+def _expect_rules_based_cc_toolchain_config(env, cc_toolchain_config):
+    if bazel_features.cc.supports_starlarkified_toolchains:
+        compiler = cc_toolchain_config.compiler
+        target_system_name = cc_toolchain_config.target_system_name
+        make_variables = [(m.name, m.value) for m in cc_toolchain_config.make_variables]
+        tool_paths = [(t.name, t.path) for t in cc_toolchain_config.tool_paths]
+    else:
+        compiler = cc_toolchain_config.compiler()
+        target_system_name = cc_toolchain_config.target_system_name()
+        make_variables = cc_toolchain_config.make_variables()
+        tool_paths = cc_toolchain_config.tool_paths()
+
+    env.expect.that_str(compiler).equals("rules-based-compiler")
+    env.expect.that_str(target_system_name).equals("rules-based-system")
+    env.expect.that_collection(make_variables).contains_exactly([
+        ("RULES_BASED_VAR", "rules-based-value"),
+    ])
+    env.expect.that_collection(tool_paths).contains_exactly([
+        ("gcov", "/usr/bin/gcov"),
+    ])
+
+def _rules_based_cc_toolchain_returns_cc_toolchain_config_info_test(env, targets):
+    if not bazel_features.cc.supports_starlarkified_toolchains:
+        return
+
+    env.expect.that_target(targets.rules_based_cc_toolchain).has_provider(CcToolchainConfigInfo)
+    _expect_rules_based_cc_toolchain_config(
+        env,
+        targets.rules_based_cc_toolchain[CcToolchainConfigInfo],
+    )
+
+def _rules_based_cc_toolchain_generated_config_has_same_values_test(env, targets):
+    if bazel_features.cc.supports_starlarkified_toolchains:
+        return
+
+    generated_config = targets.rules_based_cc_toolchain_generated_config
+    env.expect.that_target(generated_config).has_provider(CcToolchainConfigInfo)
+    _expect_rules_based_cc_toolchain_config(
+        env,
+        generated_config[CcToolchainConfigInfo],
+    )
+
 TARGETS = [
     "//tests/rule_based_toolchain/actions:c_compile",
     "//tests/rule_based_toolchain/actions:cpp_compile",
@@ -313,8 +357,11 @@ TARGETS = [
     ":simple_feature",
     ":simple_feature2",
     ":same_feature_name",
+    ":rules_based_cc_toolchain",
     ":toolchain_config_with_legacy_tools",
-]
+] + ([
+    ":rules_based_cc_toolchain_generated_config",
+] if not bazel_features.cc.supports_starlarkified_toolchains else [])
 
 # @unsorted-dict-items
 TESTS = {
@@ -327,4 +374,6 @@ TESTS = {
     "toolchain_collects_files_test": _toolchain_collects_files_test,
     "tool_env_wires_into_toolchain_test": _tool_env_wires_into_toolchain_test,
     "legacy_tools_produce_tool_paths_test": _legacy_tools_produce_tool_paths_test,
+    "rules_based_cc_toolchain_returns_cc_toolchain_config_info_test": _rules_based_cc_toolchain_returns_cc_toolchain_config_info_test,
+    "rules_based_cc_toolchain_generated_config_has_same_values_test": _rules_based_cc_toolchain_generated_config_has_same_values_test,
 }


### PR DESCRIPTION
Many commits landed at the same time as
0b11998c6c922d55d11688f3045bbfc2e8c22f0a leading to some failures in how
they were combined.

- CcToolchainConfigInfo was not returned, at the very least useful for debugging
- Legacy tools got dropped accidentally
