### PR TITLE
Enable objc_library data tests

### DIFF
--- a/tests/cc/common/BUILD
+++ b/tests/cc/common/BUILD
@@ -1,11 +1,9 @@
 load(":cc_binary_configured_target_tests.bzl", "cc_binary_configured_target_tests")
 load(":cc_common_test.bzl", "cc_common_tests")
-# load(":cc_objc_library_configured_target_tests.bzl", "cc_objc_library_configured_target_tests")
+load(":cc_objc_library_configured_target_tests.bzl", "cc_objc_library_configured_target_tests")
 
 cc_binary_configured_target_tests(name = "cc_binary_configured_target_tests")
 
 cc_common_tests(name = "cc_common_tests")
 
-# TODO(b/360366113): Re-enable when removing .a files from runfiles.
-# The change this was meant to test may break rules_apple.
-# cc_objc_library_configured_target_tests(name = "cc_objc_library_configured_target_tests")
+cc_objc_library_configured_target_tests(name = "cc_objc_library_configured_target_tests")


### PR DESCRIPTION
I flipped the ideal condition for this, so it should work as is, and we
can change the tests if we can ever remove the legacy code
