### PR TITLE
MSVC `determinism` feature should use `/Brepro` with linking

### DIFF
--- a/cc/private/toolchain/windows_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/windows_cc_toolchain_config.bzl
@@ -389,7 +389,7 @@ def _impl(ctx):
             enabled = True,
             flag_sets = [
                 flag_set(
-                    actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                    actions = all_link_actions + [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
                     flag_groups = [
                         flag_group(
                             flags = [


### PR DESCRIPTION
The `/Brepro` (undocumented) argument to MSVC applies to both the compiler and the linker.

The recent commit 94bda81 in #408 fixed determinism with MSVC by passing the argument to the compiler, but not the linker.  

Since the flag is undocumented, it is not clear whether it makes a difference when linking MSVC-compiled objects that were themselves compiled with `/Brepro`, but passing it to the linker helps ensure that it is applies in all cases, such as when linker is used with objects built from other languages.

This change adds `all_link_actions` to the list of actions that get the argument.

See https://github.com/llvm/llvm-project/issues/37777 for some of the scant documentation that`lld-link` (and thus real `link.exe`) accepts this option.