### PR TITLE
Remove intermediate_artifacts from objc_common

### DIFF
--- a/cc/private/rules_impl/objc_common.bzl
+++ b/cc/private/rules_impl/objc_common.bzl
@@ -57,7 +57,6 @@ def _create_context_and_provider(
         ctx,
         compilation_attributes,
         compilation_artifacts,
-        intermediate_artifacts,
         deps,
         implementation_deps,
         attr_linkopts,

--- a/cc/private/rules_impl/objc_compilation_support.bzl
+++ b/cc/private/rules_impl/objc_compilation_support.bzl
@@ -98,7 +98,6 @@ def _build_common_variables(
         compilation_artifacts = compilation_artifacts,
         deps = deps,
         implementation_deps = implementation_deps,
-        intermediate_artifacts = intermediate_artifacts,
         attr_linkopts = attr_linkopts,
         direct_cc_compilation_contexts = direct_cc_compilation_contexts,
         includes = cc_helper.include_dirs(ctx, {}) if hasattr(ctx.attr, "includes") else [],


### PR DESCRIPTION
This is unused now.
