### PR TITLE
Fix external_include_paths still using -iquote

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -467,14 +467,16 @@ def _init_cc_compilation_context(
         system_include_dirs_for_context = list(system_include_dirs)
         include_dirs_for_context = list(include_dirs)
     else:
-        # Do not add system_include_dirs and include_dirs directly to compilation context.
+        # Do not add include dirs directly to the regular compilation context; all public search
+        # paths for external repositories are reclassified as external includes.
+        quote_include_dirs_for_context = []
         system_include_dirs_for_context = []
         include_dirs_for_context = []
 
         external_include_dirs.append(repo_path)
         external_include_dirs.append(gen_include_dir)
         external_include_dirs.append(bin_include_dir)
-        external_include_dirs.extend(quote_include_dirs_for_context)
+        external_include_dirs.extend(quote_include_dirs)
         external_include_dirs.extend(system_include_dirs)
         external_include_dirs.extend(include_dirs)
 

--- a/tests/cc/common/cc_binary_configured_target_tests.bzl
+++ b/tests/cc/common/cc_binary_configured_target_tests.bzl
@@ -428,12 +428,15 @@ def _test_sanitize_pwd_macos_no_pwd_impl(env, target):
     link_action = link_action_subject.from_target(env, target)
     link_action.env().keys().not_contains("PWD")
 
-def _system_include_paths_from_argv(argv):
-    system_include_paths = []
+def _include_paths_from_argv(argv, flag):
+    include_paths = []
     for i in range(len(argv) - 1):
-        if argv[i] == "-isystem":
-            system_include_paths.append(argv[i + 1])
-    return system_include_paths
+        if argv[i] == flag:
+            include_paths.append(argv[i + 1])
+    return include_paths
+
+def _system_include_paths_from_argv(argv):
+    return _include_paths_from_argv(argv, "-isystem")
 
 def _test_system_include_paths_reclassifies_local_includes_without_propagation(name, **kwargs):
     util.helper_target(
@@ -1165,6 +1168,44 @@ def _setup_cc_runtimes_mock():
         tags = ["manual", "notap"],
     )
 
+def _test_external_include_paths_reclassifies_external_quote_includes(name, **kwargs):
+    util.helper_target(
+        cc_binary,
+        name = name + "/hello",
+        srcs = ["hello.cc"],
+        deps = ["@googletest//:gtest"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_external_include_paths_reclassifies_external_quote_includes_impl,
+        target = name + "/hello",
+        test_features = [FEATURE_NAMES.external_include_paths],
+        **kwargs
+    )
+
+def _test_external_include_paths_reclassifies_external_quote_includes_impl(env, target):
+    executable = target[DefaultInfo].files_to_run.executable
+    link_action = env.expect.that_target(target).action_generating(executable.short_path)
+    hello_obj_files = [
+        f
+        for f in link_action.actual.inputs.to_list()
+        if f.basename.startswith("hello.") and f.extension in ["o", "obj"]
+    ]
+
+    env.expect.that_collection(hello_obj_files).has_size(1)
+    compile_action = env.expect.that_target(target).action_generating(hello_obj_files[0].short_path)
+    quote_include_paths = _include_paths_from_argv(compile_action.actual.argv, "-iquote")
+    system_include_paths = _system_include_paths_from_argv(compile_action.actual.argv)
+
+    if not quote_include_paths:
+        fail("expected the compile action to still have non-external -iquote paths")
+    env.expect.that_collection(system_include_paths).contains_predicate(
+        matching.contains("googletest"),
+    )
+    env.expect.that_collection(quote_include_paths).transform(
+        filter = matching.contains("googletest"),
+    ).contains_exactly([])
+
 def cc_binary_configured_target_tests(name):
     """Creates the test suite for cc_binary tests.
 
@@ -1203,6 +1244,7 @@ def cc_binary_configured_target_tests(name):
             _test_sanitize_pwd_feature_enabled,
             _test_sanitize_pwd_feature_disabled,
             _test_sanitize_pwd_macos_no_pwd,
+            _test_external_include_paths_reclassifies_external_quote_includes,
             _test_system_include_paths_reclassifies_local_includes_after_includes,
             _test_system_include_paths_reclassifies_local_includes_without_propagation,
             # _test_cc_runtimes_added_to_libraries,  # copybara-comment-this-out-please

--- a/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
+++ b/tests/cc/testutil/toolchains/cc_toolchain_config.bzl
@@ -1049,9 +1049,12 @@ _external_include_paths_feature = feature(
             actions = [ACTION_NAMES.cpp_compile],
             flag_groups = [
                 flag_group(
+                    expand_if_available = "external_include_paths",
                     flags = [
                         "-isystem",
+                        "%{external_include_paths}",
                     ],
+                    iterate_over = "external_include_paths",
                 ),
             ],
         ),


### PR DESCRIPTION
Previously if you had an external repo but were setting
`--features=external_include_paths` it would still contribute `-iquote`
paths before the `-isystem` paths it was adding, so this wasn't working
at all. This was only the case with clang. This also depends on the
toolchain's ordering of these flags but in the default toolchains this
feature comes after the default include paths feature.

Fixes https://github.com/bazelbuild/rules_cc/issues/729
