### PR TITLE
add windows DEF linker args

### DIFF
--- a/cc/toolchains/args/def_file/BUILD
+++ b/cc/toolchains/args/def_file/BUILD
@@ -1,0 +1,18 @@
+load("//cc/toolchains:args.bzl", "cc_args")
+load("//cc/toolchains:feature.bzl", "cc_feature")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_feature(
+    name = "def_file",
+    args = [":def_file_args"],
+    feature_name = "def_file",
+)
+
+cc_args(
+    name = "def_file_args",
+    actions = ["//cc/toolchains/actions:link_actions"],
+    args = ["{def_file_path}"],
+    format = {"def_file_path": "//cc/toolchains/variables:def_file_path"},
+    requires_not_none = "//cc/toolchains/variables:def_file_path",
+)

--- a/tests/rule_based_toolchain/legacy_features_as_args/BUILD
+++ b/tests/rule_based_toolchain/legacy_features_as_args/BUILD
@@ -9,6 +9,7 @@ load(":goldens/unix/libraries_to_link.bzl", _UNIX_LIBRARIES_TO_LINK = "GOLDEN")
 load(":goldens/unix/linker_param_file.bzl", _UNIX_LINKER_PARAM_FILE = "GOLDEN")
 load(":goldens/unix/runtime_library_search_directories.bzl", _UNIX_RUNTIME_LIBRARY_SEARCH_DIRECTORIES = "GOLDEN")
 load(":goldens/unix/shared_flag.bzl", _UNIX_SHARED_FLAG = "GOLDEN")
+load(":goldens/windows/def_file_gnu.bzl", _WINDOWS_DEF_FILE_GNU = "GOLDEN")
 
 # These tests validate that the produced legacy feature implementations
 # properly reflect the implementations housed in the Java source of truth at
@@ -31,6 +32,14 @@ platform(
     name = "macos",
     constraint_values = [
         "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
 )
@@ -89,6 +98,13 @@ compare_feature_implementation(
     expected = _UNIX_LINKER_PARAM_FILE,
     feature_name = "linker_param_file_test",
     platform = ":linux",
+)
+
+compare_feature_implementation(
+    name = "def_file_test",
+    actual_implementation = "//cc/toolchains/args/def_file:def_file_args",
+    expected = _WINDOWS_DEF_FILE_GNU,
+    platform = ":windows",
 )
 
 compare_feature_implementation(

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/def_file_gnu.bzl
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/def_file_gnu.bzl
@@ -1,0 +1,33 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expected def_file legacy feature textproto for GNU-style Windows linkers."""
+
+visibility("private")
+
+GOLDEN = """enabled: false
+flag_sets {
+  actions: "c++-link-dynamic-library"
+  actions: "c++-link-executable"
+  actions: "c++-link-nodeps-dynamic-library"
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
+  flag_groups {
+    expand_if_available: "def_file_path"
+    flags: "%{def_file_path}"
+  }
+}
+name: "def_file_test"
+"""


### PR DESCRIPTION
Upstreaming this from https://github.com/hermeticbuild/hermetic-llvm/pull/593 which use case is windows clang based cross compilation.

I think this feature and args definition belong inside rules_cc since it's based on internal rules_cc variables and marker feature checks.

Original feature is msvc only (which is not correct) beause windows can now be compiled with clang and rules_cc.
I didn't port msvc flags here because none of existing features in rule based toolchain does and that there is an ongoing MSVC support pull request in flight already.