### PR TITLE
Consolidate renovate configuration files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "config:base"
+  ],
   "bazel": {
     "enabled": false
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-    "extends": [
-        "config:base"
-    ]
-}


### PR DESCRIPTION
Second attempt at disabling the renovate bot: the renovate.json at the root was preventing the one that disables renovate for Bazel module/workspace dependencies from taking effect.