### PR TITLE
Disable platform specific tests with target_compatible_with

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -85,7 +85,6 @@ windows_coverage_flags: &windows_coverage_flags
   # Test failures are not collected under `coverage` invocations.
   # https://github.com/bazelbuild/continuous-integration/issues/1838
   - "--test_output=errors"
-  - "--test_tag_filters=-no_windows"
 
 
 coverage_flags_bazel_less_than_9: &coverage_flags_bazel_less_than_9
@@ -97,15 +96,6 @@ windows_coverage_flags_bazel_less_than_9: &windows_coverage_flags_bazel_less_tha
   # See above
   - "--test_env=IGNORE_COVERAGE_COLLECTION_FAILURES=1"
   - "--test_output=errors"
-  - "--test_tag_filters=-no_windows"
-
-
-windows_test_flags: &windows_test_flags
-  - "--test_tag_filters=-no_windows"
-
-macos_test_flags: &macos_test_flags
-  - "--test_tag_filters=-no_macos"
-
 
 buildifier:
   version: latest
@@ -132,21 +122,18 @@ tasks:
     platform: macos
     build_targets: *build_targets_head
     test_targets: *test_targets_head
-    test_flags: *macos_test_flags
   macos_head:
     name: MacOS (Bazel HEAD)
     bazel: last_green
     platform: macos_arm64
     build_targets: *build_targets_head
     test_targets: *test_targets_head
-    test_flags: *macos_test_flags
   windows_head:
     name: Windows (Bazel HEAD)
     bazel: last_green
     platform: windows
     build_targets: *build_targets_head
     test_targets: *test_targets_head
-    test_flags: *windows_test_flags
 
   # Bazel@rolling
   ubuntu2004_rolling:
@@ -161,7 +148,6 @@ tasks:
     platform: macos
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *macos_test_flags
     coverage_flags: *common_coverage_flags
     coverage_targets: *coverage_targets
   macos_rolling:
@@ -170,7 +156,6 @@ tasks:
     platform: macos_arm64
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *macos_test_flags
     coverage_flags: *common_coverage_flags
     coverage_targets: *coverage_targets
   windows_rolling:
@@ -179,7 +164,6 @@ tasks:
     platform: windows
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *windows_test_flags
     coverage_flags: *windows_coverage_flags
     coverage_targets: *test_targets
 
@@ -202,7 +186,6 @@ tasks:
       - "--experimental_cc_static_library"
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *macos_test_flags
     coverage_flags: *coverage_flags_bazel_less_than_9
     coverage_targets: *coverage_targets_bazel_6
   macos_bazel_7:
@@ -213,7 +196,6 @@ tasks:
       - "--experimental_cc_static_library"
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *macos_test_flags
     coverage_flags: *coverage_flags_bazel_less_than_9
     coverage_targets: *coverage_targets_bazel_6
   windows_bazel_7:
@@ -224,7 +206,6 @@ tasks:
       - "--experimental_cc_static_library"
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *windows_test_flags
 
 # Bazel 8
   ubuntu2004_bazel_8:
@@ -241,7 +222,6 @@ tasks:
     platform: macos
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *macos_test_flags
     coverage_flags: *coverage_flags_bazel_less_than_9
     coverage_targets: *coverage_targets_bazel_6
   macos_bazel_8:
@@ -250,7 +230,6 @@ tasks:
     platform: macos_arm64
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *macos_test_flags
     coverage_flags: *coverage_flags_bazel_less_than_9
     coverage_targets: *coverage_targets_bazel_6
   windows_bazel_8:
@@ -259,7 +238,6 @@ tasks:
     platform: windows
     build_targets: *build_targets_bazel_6
     test_targets: *test_targets_bazel_6
-    test_flags: *windows_test_flags
     coverage_flags: *windows_coverage_flags_bazel_less_than_9
     coverage_targets: *test_targets_bazel_6
 
@@ -278,7 +256,6 @@ tasks:
     platform: macos
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *macos_test_flags
     coverage_flags: *common_coverage_flags
     coverage_targets: *coverage_targets
   macos:
@@ -287,7 +264,6 @@ tasks:
     platform: macos_arm64
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *macos_test_flags
     coverage_flags: *common_coverage_flags
     coverage_targets: *coverage_targets
   windows:
@@ -295,7 +271,6 @@ tasks:
     bazel: 9.x
     build_targets: *build_targets
     test_targets: *test_targets
-    test_flags: *windows_test_flags
     coverage_flags: *windows_coverage_flags
     coverage_targets: *test_targets
   ubuntu_bzlmod:

--- a/tests/integration/BUILD
+++ b/tests/integration/BUILD
@@ -13,10 +13,11 @@ rules_cc_integration_test(
 
 rules_cc_integration_test(
     name = "lto_tests",
-    tags = [
-        "no_macos",
-        "no_windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     test_script = "lto_tests.sh",
 )
 
@@ -24,9 +25,10 @@ rules_cc_integration_test(
     name = "cc_shared_library_tests",
     # These could probably be made to work on all CI platforms,
     # but the default toolchains are not properly configured for it.
-    tags = [
-        "no_macos",
-        "no_windows",
-    ],
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     test_script = "cc_shared_library_tests.sh",
 )


### PR DESCRIPTION
This way when developing locally with `bazel test ...` you don't get
these tests that were previously only excluded on CI
