### PR TITLE
Add Windows ThinLTO arguments

### DIFF
--- a/cc/private/link/lto_backends.bzl
+++ b/cc/private/link/lto_backends.bzl
@@ -475,6 +475,7 @@ def _create_lto_backend_action(
     outputs = _get_lto_backend_action_outputs(object_file, dwo_file)
 
     _path_variables = _paths_build_variables(
+        feature_configuration,
         index,
         object_file,
         dwo_file,
@@ -495,7 +496,7 @@ def _create_lto_backend_action(
         env = env,
     )
 
-def _paths_build_variables(index, object_file, dwo_file, bitcode_file):
+def _paths_build_variables(feature_configuration, index, object_file, dwo_file, bitcode_file):
     build_variables = {}
 
     # Ideally, those strings would come directly from the execPath of the Artifacts of
@@ -507,7 +508,9 @@ def _paths_build_variables(index, object_file, dwo_file, bitcode_file):
         build_variables["thinlto_index"] = index
     else:
         # An empty input indicates not to perform cross-module optimization.
-        build_variables["thinlto_index"] = "/dev/null"
+        build_variables["thinlto_index"] = (
+            "NUL" if feature_configuration.is_enabled("targets_windows") else "/dev/null"
+        )
 
     # The output from the LTO backend step is a native object file.
     build_variables["thinlto_output_object_file"] = object_file

--- a/cc/toolchains/args/libraries_to_link/BUILD
+++ b/cc/toolchains/args/libraries_to_link/BUILD
@@ -56,7 +56,10 @@ cc_nested_args(
 
 cc_nested_args(
     name = "start_lib_arg",
-    args = ["-Wl,--start-lib"],
+    args = select({
+        "@platforms//os:windows": ["-Wl,/start-lib"],
+        "//conditions:default": ["-Wl,--start-lib"],
+    }),
     requires_false = "//cc/toolchains/variables:libraries_to_link.is_whole_archive",
 )
 
@@ -69,7 +72,10 @@ cc_nested_args(
 
 cc_nested_args(
     name = "end_lib_arg",
-    args = ["-Wl,--end-lib"],
+    args = select({
+        "@platforms//os:windows": ["-Wl,/end-lib"],
+        "//conditions:default": ["-Wl,--end-lib"],
+    }),
     requires_false = "//cc/toolchains/variables:libraries_to_link.is_whole_archive",
 )
 

--- a/cc/toolchains/args/thin_lto/BUILD
+++ b/cc/toolchains/args/thin_lto/BUILD
@@ -44,9 +44,10 @@ cc_args(
     actions = [
         ":lto_index_actions",
     ],
-    args = [
-        "-Wl,-plugin-opt,thinlto-index-only={thinlto_indexing_param_file}",
-    ],
+    args = select({
+        "@platforms//os:windows": ["-Wl,--thinlto-index-only={thinlto_indexing_param_file}"],
+        "//conditions:default": ["-Wl,-plugin-opt,thinlto-index-only={thinlto_indexing_param_file}"],
+    }),
     format = {
         "thinlto_indexing_param_file": "//cc/toolchains/variables:thinlto_indexing_param_file",
     },
@@ -58,9 +59,10 @@ cc_args(
     actions = [
         ":lto_index_actions",
     ],
-    args = [
-        "-Wl,-plugin-opt,thinlto-emit-imports-files",
-    ],
+    args = select({
+        "@platforms//os:windows": ["-Wl,--thinlto-emit-imports-files"],
+        "//conditions:default": ["-Wl,-plugin-opt,thinlto-emit-imports-files"],
+    }),
 )
 
 cc_args(
@@ -68,9 +70,10 @@ cc_args(
     actions = [
         ":lto_index_actions",
     ],
-    args = [
-        "-Wl,-plugin-opt,thinlto-prefix-replace={thinlto_prefix_replace}",
-    ],
+    args = select({
+        "@platforms//os:windows": ["-Wl,--thinlto-prefix-replace={thinlto_prefix_replace}"],
+        "//conditions:default": ["-Wl,-plugin-opt,thinlto-prefix-replace={thinlto_prefix_replace}"],
+    }),
     format = {
         "thinlto_prefix_replace": "//cc/toolchains/variables:thinlto_prefix_replace",
     },
@@ -82,9 +85,10 @@ cc_args(
     actions = [
         ":lto_index_actions",
     ],
-    args = [
-        "-Wl,-plugin-opt,thinlto-object-suffix-replace={thinlto_object_suffix_replace}",
-    ],
+    args = select({
+        "@platforms//os:windows": ["-Wl,--thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
+        "//conditions:default": ["-Wl,-plugin-opt,thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
+    }),
     format = {
         "thinlto_object_suffix_replace": "//cc/toolchains/variables:thinlto_object_suffix_replace",
     },
@@ -96,9 +100,10 @@ cc_args(
     actions = [
         ":lto_index_actions",
     ],
-    args = [
-        "-Wl,-plugin-opt,obj-path={thinlto_merged_object_file}",
-    ],
+    args = select({
+        "@platforms//os:windows": ["-Wl,/lto-obj-path:{thinlto_merged_object_file}"],
+        "//conditions:default": ["-Wl,-plugin-opt,obj-path={thinlto_merged_object_file}"],
+    }),
     format = {
         "thinlto_merged_object_file": "//cc/toolchains/variables:thinlto_merged_object_file",
     },

--- a/tests/rule_based_toolchain/legacy_features_as_args/BUILD
+++ b/tests/rule_based_toolchain/legacy_features_as_args/BUILD
@@ -1,4 +1,4 @@
-load(":compare_feature.bzl", "compare_feature_implementation")
+load(":compare_feature.bzl", "compare_cc_feature_implementation", "compare_feature_implementation")
 load(":goldens/macos/archiver_flags.bzl", _MACOS_ARCHIVER_FLAGS = "GOLDEN")
 load(":goldens/macos/force_pic_flags.bzl", _MACOS_FORCE_PIC_FLAGS = "GOLDEN")
 load(":goldens/macos/libraries_to_link.bzl", _MACOS_LIBRARIES_TO_LINK = "GOLDEN")
@@ -10,6 +10,8 @@ load(":goldens/unix/linker_param_file.bzl", _UNIX_LINKER_PARAM_FILE = "GOLDEN")
 load(":goldens/unix/runtime_library_search_directories.bzl", _UNIX_RUNTIME_LIBRARY_SEARCH_DIRECTORIES = "GOLDEN")
 load(":goldens/unix/shared_flag.bzl", _UNIX_SHARED_FLAG = "GOLDEN")
 load(":goldens/windows/def_file_gnu.bzl", _WINDOWS_DEF_FILE_GNU = "GOLDEN")
+load(":goldens/windows/libraries_to_link.bzl", _WINDOWS_LIBRARIES_TO_LINK = "GOLDEN")
+load(":goldens/windows/thin_lto.bzl", _WINDOWS_THIN_LTO = "GOLDEN")
 
 # These tests validate that the produced legacy feature implementations
 # properly reflect the implementations housed in the Java source of truth at
@@ -93,6 +95,14 @@ compare_feature_implementation(
 )
 
 compare_feature_implementation(
+    name = "libraries_to_link_windows_test",
+    actual_implementation = "//cc/toolchains/args/libraries_to_link",
+    expected = _WINDOWS_LIBRARIES_TO_LINK,
+    feature_name = "libraries_to_link_test",
+    platform = ":windows",
+)
+
+compare_feature_implementation(
     name = "linker_param_file_test",
     actual_implementation = "//cc/toolchains/args/linker_param_file",
     expected = _UNIX_LINKER_PARAM_FILE,
@@ -129,4 +139,11 @@ compare_feature_implementation(
     expected = _UNIX_SHARED_FLAG,
     feature_name = "shared_flag_test",
     platform = ":linux",
+)
+
+compare_cc_feature_implementation(
+    name = "thin_lto_windows_test",
+    actual_implementation = "//cc/toolchains/args/thin_lto:feature",
+    expected = _WINDOWS_THIN_LTO,
+    platform = ":windows",
 )

--- a/tests/rule_based_toolchain/legacy_features_as_args/compare_feature.bzl
+++ b/tests/rule_based_toolchain/legacy_features_as_args/compare_feature.bzl
@@ -14,8 +14,8 @@
 """Test helper for cc_arg_list validation."""
 
 load("//cc:cc_toolchain_config_lib.bzl", "feature")
-load("//cc/toolchains:cc_toolchain_info.bzl", "ArgsListInfo")
-load("//cc/toolchains/impl:legacy_converter.bzl", "convert_args")
+load("//cc/toolchains:cc_toolchain_info.bzl", "ArgsListInfo", "FeatureInfo")
+load("//cc/toolchains/impl:legacy_converter.bzl", "convert_args", "convert_feature")
 load("//tests/rule_based_toolchain:testing_rules.bzl", "analysis_test")
 
 def _feature_textproto(feature_impl):
@@ -37,6 +37,9 @@ def _compare_feature_implementation_impl(env, target):
         env_sets = [es for one_arg in converted_args for es in one_arg.env_sets],
     )
     env.expect.that_str(_feature_textproto(feature_impl)).equals(env.ctx.attr.expected)
+
+def _compare_cc_feature_implementation_impl(env, target):
+    env.expect.that_str(_feature_textproto(convert_feature(target[FeatureInfo]))).equals(env.ctx.attr.expected)
 
 def compare_feature_implementation(name, actual_implementation, expected, platform, feature_name = None):
     """Compares the feature implementation of a given ArgsListInfo against an expected textproto.
@@ -64,6 +67,34 @@ def compare_feature_implementation(name, actual_implementation, expected, platfo
         attr_values = {
             "expected": expected,
             "feature_name": feature_name,
+            "size": "small",
+        },
+        config_settings = {
+            "//command_line_option:platforms": [native.package_relative_label(platform)],
+        },
+    )
+
+def compare_cc_feature_implementation(name, actual_implementation, expected, platform):
+    """Compares a cc_feature implementation against an expected textproto.
+
+    Args:
+        name: The name of the test.
+        actual_implementation: The label of the cc_feature to test.
+        expected: The expected textproto output.
+        platform: The platform to test with.
+    """
+    analysis_test(
+        name = name,
+        target = actual_implementation,
+        impl = _compare_cc_feature_implementation_impl,
+        attrs = {
+            "expected": attr.string(mandatory = True),
+            "target": {
+                "providers": [FeatureInfo],
+            },
+        },
+        attr_values = {
+            "expected": expected,
             "size": "small",
         },
         config_settings = {

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/libraries_to_link.bzl
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/libraries_to_link.bzl
@@ -1,0 +1,126 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expected libraries_to_link legacy feature textproto on Windows."""
+
+visibility("private")
+
+GOLDEN = """enabled: false
+flag_sets {
+  actions: "c++-link-dynamic-library"
+  actions: "c++-link-executable"
+  actions: "c++-link-nodeps-dynamic-library"
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
+  flag_groups {
+    flag_groups {
+      expand_if_available: "thinlto_param_file"
+      flags: "-Wl,@%{thinlto_param_file}"
+    }
+    flag_groups {
+      expand_if_available: "libraries_to_link"
+      flag_groups {
+        flag_groups {
+          expand_if_equal {
+            name: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+          flag_groups {
+            expand_if_false: "libraries_to_link.is_whole_archive"
+            flags: "-Wl,/start-lib"
+          }
+        }
+        flag_groups {
+          flag_groups {
+            expand_if_true: "libraries_to_link.is_whole_archive"
+            flag_groups {
+              expand_if_equal {
+                name: "libraries_to_link.type"
+                value: "static_library"
+              }
+              flags: "-Wl,-whole-archive"
+            }
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "object_file_group"
+            }
+            flags: "%{libraries_to_link.object_files}"
+            iterate_over: "libraries_to_link.object_files"
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "object_file"
+            }
+            flags: "%{libraries_to_link.name}"
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "interface_library"
+            }
+            flags: "%{libraries_to_link.name}"
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "static_library"
+            }
+            flags: "%{libraries_to_link.name}"
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "dynamic_library"
+            }
+            flags: "-l%{libraries_to_link.name}"
+          }
+          flag_groups {
+            expand_if_equal {
+              name: "libraries_to_link.type"
+              value: "versioned_dynamic_library"
+            }
+            flags: "-l:%{libraries_to_link.name}"
+          }
+          flag_groups {
+            expand_if_true: "libraries_to_link.is_whole_archive"
+            flag_groups {
+              expand_if_equal {
+                name: "libraries_to_link.type"
+                value: "static_library"
+              }
+              flags: "-Wl,-no-whole-archive"
+            }
+          }
+        }
+        flag_groups {
+          expand_if_equal {
+            name: "libraries_to_link.type"
+            value: "object_file_group"
+          }
+          flag_groups {
+            expand_if_false: "libraries_to_link.is_whole_archive"
+            flags: "-Wl,/end-lib"
+          }
+        }
+        iterate_over: "libraries_to_link"
+      }
+    }
+  }
+}
+name: "libraries_to_link_test"
+"""

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/thin_lto.bzl
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/windows/thin_lto.bzl
@@ -1,0 +1,122 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expected thin_lto legacy feature textproto on Windows."""
+
+visibility("private")
+
+GOLDEN = """enabled: false
+flag_sets {
+  actions: "c++-compile"
+  actions: "c++-link-dynamic-library"
+  actions: "c++-link-executable"
+  actions: "c++-link-nodeps-dynamic-library"
+  actions: "c-compile"
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
+  flag_groups {
+    flags: "-flto=thin"
+  }
+}
+flag_sets {
+  actions: "assemble"
+  actions: "c++-compile"
+  actions: "c++-header-parsing"
+  actions: "c++-module-codegen"
+  actions: "c++-module-compile"
+  actions: "c-compile"
+  actions: "clif-match"
+  actions: "linkstamp-compile"
+  actions: "lto-backend"
+  actions: "objc++-compile"
+  actions: "objc-compile"
+  actions: "preprocess-assemble"
+  flag_groups {
+    expand_if_available: "lto_indexing_bitcode_file"
+    flags: "-Xclang"
+    flags: "-fthin-link-bitcode=%{lto_indexing_bitcode_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_merged_object_file"
+    flags: "-Wl,/lto-obj-path:%{thinlto_merged_object_file}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_index"
+    flags: "-c"
+    flags: "-fthinlto-index=%{thinlto_index}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_output_object_file"
+    flags: "-o"
+    flags: "%{thinlto_output_object_file}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_input_bitcode_file"
+    flags: "-x"
+    flags: "ir"
+    flags: "%{thinlto_input_bitcode_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_indexing_param_file"
+    flags: "-Wl,--thinlto-index-only=%{thinlto_indexing_param_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    flags: "-Wl,--thinlto-emit-imports-files"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_prefix_replace"
+    flags: "-Wl,--thinlto-prefix-replace=%{thinlto_prefix_replace}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_object_suffix_replace"
+    flags: "-Wl,--thinlto-object-suffix-replace=%{thinlto_object_suffix_replace}"
+  }
+}
+name: "thin_lto"
+"""


### PR DESCRIPTION
Windows rule-based toolchains currently reuse ELF LLD ThinLTO plugin options and `/dev/null`, which are not valid for LLD's COFF driver or Windows backend actions. This change selects the LLD COFF ThinLTO options, uses `/start-lib` and `/end-lib` for object-file groups, and uses `NUL` for indexless Windows backend actions.

This allows Windows toolchains that use LLD and provide `supports_start_end_lib` to enable rules_cc distributed ThinLTO.