### PR TITLE
Add macOS ThinLTO arguments

### DIFF
--- a/cc/toolchains/args/thin_lto/BUILD
+++ b/cc/toolchains/args/thin_lto/BUILD
@@ -45,6 +45,7 @@ cc_args(
         ":lto_index_actions",
     ],
     args = select({
+        "@platforms//os:macos": ["-Wl,--thinlto-index-only={thinlto_indexing_param_file}"],
         "@platforms//os:windows": ["-Wl,--thinlto-index-only={thinlto_indexing_param_file}"],
         "//conditions:default": ["-Wl,-plugin-opt,thinlto-index-only={thinlto_indexing_param_file}"],
     }),
@@ -60,6 +61,7 @@ cc_args(
         ":lto_index_actions",
     ],
     args = select({
+        "@platforms//os:macos": ["-Wl,--thinlto-emit-imports-files"],
         "@platforms//os:windows": ["-Wl,--thinlto-emit-imports-files"],
         "//conditions:default": ["-Wl,-plugin-opt,thinlto-emit-imports-files"],
     }),
@@ -71,6 +73,7 @@ cc_args(
         ":lto_index_actions",
     ],
     args = select({
+        "@platforms//os:macos": ["-Wl,--thinlto-prefix-replace={thinlto_prefix_replace}"],
         "@platforms//os:windows": ["-Wl,--thinlto-prefix-replace={thinlto_prefix_replace}"],
         "//conditions:default": ["-Wl,-plugin-opt,thinlto-prefix-replace={thinlto_prefix_replace}"],
     }),
@@ -86,6 +89,7 @@ cc_args(
         ":lto_index_actions",
     ],
     args = select({
+        "@platforms//os:macos": ["-Wl,--thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
         "@platforms//os:windows": ["-Wl,--thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
         "//conditions:default": ["-Wl,-plugin-opt,thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
     }),
@@ -101,6 +105,7 @@ cc_args(
         ":lto_index_actions",
     ],
     args = select({
+        "@platforms//os:macos": ["-Wl,--lto-obj-path={thinlto_merged_object_file}"],
         "@platforms//os:windows": ["-Wl,/lto-obj-path:{thinlto_merged_object_file}"],
         "//conditions:default": ["-Wl,-plugin-opt,obj-path={thinlto_merged_object_file}"],
     }),

--- a/tests/rule_based_toolchain/legacy_features_as_args/BUILD
+++ b/tests/rule_based_toolchain/legacy_features_as_args/BUILD
@@ -3,6 +3,7 @@ load(":goldens/macos/archiver_flags.bzl", _MACOS_ARCHIVER_FLAGS = "GOLDEN")
 load(":goldens/macos/force_pic_flags.bzl", _MACOS_FORCE_PIC_FLAGS = "GOLDEN")
 load(":goldens/macos/libraries_to_link.bzl", _MACOS_LIBRARIES_TO_LINK = "GOLDEN")
 load(":goldens/macos/runtime_library_search_directories.bzl", _MACOS_RUNTIME_LIBRARY_SEARCH_DIRECTORIES = "GOLDEN")
+load(":goldens/macos/thin_lto.bzl", _MACOS_THIN_LTO = "GOLDEN")
 load(":goldens/unix/archiver_flags.bzl", _UNIX_ARCHIVER_FLAGS = "GOLDEN")
 load(":goldens/unix/force_pic_flags.bzl", _UNIX_FORCE_PIC_FLAGS = "GOLDEN")
 load(":goldens/unix/libraries_to_link.bzl", _UNIX_LIBRARIES_TO_LINK = "GOLDEN")
@@ -139,6 +140,13 @@ compare_feature_implementation(
     expected = _UNIX_SHARED_FLAG,
     feature_name = "shared_flag_test",
     platform = ":linux",
+)
+
+compare_cc_feature_implementation(
+    name = "thin_lto_macos_test",
+    actual_implementation = "//cc/toolchains/args/thin_lto:feature",
+    expected = _MACOS_THIN_LTO,
+    platform = ":macos",
 )
 
 compare_cc_feature_implementation(

--- a/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/thin_lto.bzl
+++ b/tests/rule_based_toolchain/legacy_features_as_args/goldens/macos/thin_lto.bzl
@@ -1,0 +1,122 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expected thin_lto legacy feature textproto on macOS."""
+
+visibility("private")
+
+GOLDEN = """enabled: false
+flag_sets {
+  actions: "c++-compile"
+  actions: "c++-link-dynamic-library"
+  actions: "c++-link-executable"
+  actions: "c++-link-nodeps-dynamic-library"
+  actions: "c-compile"
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  actions: "objc-executable"
+  flag_groups {
+    flags: "-flto=thin"
+  }
+}
+flag_sets {
+  actions: "assemble"
+  actions: "c++-compile"
+  actions: "c++-header-parsing"
+  actions: "c++-module-codegen"
+  actions: "c++-module-compile"
+  actions: "c-compile"
+  actions: "clif-match"
+  actions: "linkstamp-compile"
+  actions: "lto-backend"
+  actions: "objc++-compile"
+  actions: "objc-compile"
+  actions: "preprocess-assemble"
+  flag_groups {
+    expand_if_available: "lto_indexing_bitcode_file"
+    flags: "-Xclang"
+    flags: "-fthin-link-bitcode=%{lto_indexing_bitcode_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_merged_object_file"
+    flags: "-Wl,--lto-obj-path=%{thinlto_merged_object_file}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_index"
+    flags: "-c"
+    flags: "-fthinlto-index=%{thinlto_index}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_output_object_file"
+    flags: "-o"
+    flags: "%{thinlto_output_object_file}"
+  }
+}
+flag_sets {
+  actions: "lto-backend"
+  flag_groups {
+    expand_if_available: "thinlto_input_bitcode_file"
+    flags: "-x"
+    flags: "ir"
+    flags: "%{thinlto_input_bitcode_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_indexing_param_file"
+    flags: "-Wl,--thinlto-index-only=%{thinlto_indexing_param_file}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    flags: "-Wl,--thinlto-emit-imports-files"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_prefix_replace"
+    flags: "-Wl,--thinlto-prefix-replace=%{thinlto_prefix_replace}"
+  }
+}
+flag_sets {
+  actions: "lto-index-for-dynamic-library"
+  actions: "lto-index-for-executable"
+  actions: "lto-index-for-nodeps-dynamic-library"
+  flag_groups {
+    expand_if_available: "thinlto_object_suffix_replace"
+    flags: "-Wl,--thinlto-object-suffix-replace=%{thinlto_object_suffix_replace}"
+  }
+}
+name: "thin_lto"
+"""


### PR DESCRIPTION
The `thin_lto` feature currently sends GNU plugin options to every non-Windows linker. Mach-O LLD implements distributed ThinLTO with direct `--thinlto-*` options instead, so macOS indexing actions fail when they inherit the ELF spellings. This selects Mach-O LLD's direct indexing, imports, prefix replacement, suffix replacement, and merged-object options on macOS while preserving the existing arguments on other platforms.

The merged regular LTO object uses `--lto-obj-path`, which is proposed in llvm/llvm-project#203365. Mach-O LLD's existing `-object_path_lto` treats a ThinLTO path as a directory and generates `0.<arch>.lto.o`; rules_cc requires `thinlto_merged_object_file` to be an exact declared output consumed by the final link.

Validation: `bazel test //tests/rule_based_toolchain/legacy_features_as_args:thin_lto_macos_test --test_output=errors`.
