### PR TITLE
Support C++20 modules in the rules-based toolchain API

### DIFF
--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -273,6 +273,15 @@ cc_action_type_set(
 )
 
 cc_action_type_set(
+    name = "cpp20_module_actions",
+    actions = [
+        ":cpp20_module_compile",
+        ":cpp20_module_codegen",
+        ":cpp_module_deps_scanning",
+    ],
+)
+
+cc_action_type_set(
     name = "compile_actions_without_header_parsing",
     actions = [
         ":compile_actions",

--- a/cc/toolchains/args/compile_flags/BUILD
+++ b/cc/toolchains/args/compile_flags/BUILD
@@ -37,7 +37,10 @@ cc_feature(
 
 cc_args(
     name = "user_compile_flags",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     args = ["{user_compile_flags}"],
     format = {"user_compile_flags": "//cc/toolchains/variables:user_compile_flags"},
     iterate_over = "//cc/toolchains/variables:user_compile_flags",

--- a/cc/toolchains/args/compiler_input_flags/BUILD
+++ b/cc/toolchains/args/compiler_input_flags/BUILD
@@ -13,7 +13,10 @@ cc_feature(
 
 cc_args(
     name = "flags",
-    actions = ["//cc/toolchains/actions:compile_actions_without_header_parsing"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions_without_header_parsing",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     args = [
         "-c",
         "{source_file}",

--- a/cc/toolchains/args/compiler_output_flags/BUILD
+++ b/cc/toolchains/args/compiler_output_flags/BUILD
@@ -34,7 +34,10 @@ cc_args(
 
 cc_args(
     name = "output_flags",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     args = [
         "-o",
         "{output_file}",

--- a/cc/toolchains/args/dependency_file/BUILD
+++ b/cc/toolchains/args/dependency_file/BUILD
@@ -10,7 +10,10 @@ cc_feature(
 
 cc_args(
     name = "flags",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     args = [
         "-MD",
         "-MF",

--- a/cc/toolchains/legacy_file_group.bzl
+++ b/cc/toolchains/legacy_file_group.bzl
@@ -28,6 +28,9 @@ LEGACY_FILE_GROUPS = {
         Label("//cc/toolchains/actions:c_compile"),
         Label("//cc/toolchains/actions:cpp_compile"),
         Label("//cc/toolchains/actions:cpp_header_parsing"),
+        Label("//cc/toolchains/actions:cpp20_module_compile"),
+        Label("//cc/toolchains/actions:cpp20_module_codegen"),
+        Label("//cc/toolchains/actions:cpp_module_deps_scanning"),
     ],
     # There are no actions listed for coverage and objcopy in action_names.bzl.
     "coverage_files": [],

--- a/cc/toolchains/variables/BUILD
+++ b/cc/toolchains/variables/BUILD
@@ -3,6 +3,22 @@ load("//cc/toolchains/impl:variables.bzl", "cc_builtin_variables", "cc_variable"
 package(default_visibility = ["//visibility:public"])
 
 cc_variable(
+    name = "cpp_module_modmap_file",
+    actions = [
+        "//cc/toolchains/actions:cpp_compile",
+        "//cc/toolchains/actions:cpp20_module_compile",
+        "//cc/toolchains/actions:cpp20_module_codegen",
+    ],
+    type = types.option(types.file),
+)
+
+cc_variable(
+    name = "cpp_module_output_file",
+    actions = ["//cc/toolchains/actions:cpp20_module_compile"],
+    type = types.option(types.file),
+)
+
+cc_variable(
     name = "cs_fdo_instrument_path",
     actions = [
         "//cc/toolchains/actions:link_actions",
@@ -19,7 +35,10 @@ cc_variable(
 
 cc_variable(
     name = "dependency_file",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     type = types.option(types.file),
 )
 
@@ -424,6 +443,7 @@ cc_variable(
     name = "output_file",
     actions = [
         "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
         "//cc/toolchains/actions:strip",
     ],
     type = types.option(types.file),
@@ -485,7 +505,10 @@ cc_variable(
 
 cc_variable(
     name = "source_file",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     type = types.option(types.file),
 )
 
@@ -566,7 +589,10 @@ cc_variable(
 
 cc_variable(
     name = "user_compile_flags",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:compile_actions",
+        "//cc/toolchains/actions:cpp20_module_actions",
+    ],
     type = types.option(types.list(types.string)),
 )
 
@@ -581,6 +607,8 @@ cc_builtin_variables(
     srcs = [
         ":attr_linkopts",
         ":cc_library_exec_paths",
+        ":cpp_module_modmap_file",
+        ":cpp_module_output_file",
         ":cs_fdo_instrument_path",
         ":def_file_path",
         ":dep_linkopts",


### PR DESCRIPTION
Add toolchain variables and and an action type set for C++20 module actions, allowing them to be configured in a rule-based toolchain.