### PR TITLE
Disable macOS toolchain by default

### DIFF
--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -25,7 +25,7 @@ def _should_disable_toolchain(repository_ctx):
     """Returns true if the toolchain should be disabled based on environment variables."""
     env = repository_ctx.os.environ
     disabled_via_env = "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1"
-    macos_legacy_support = env.get("BAZEL_USE_LEGACY_MACOS_TOOLCHAIN", "1") == "1"
+    macos_legacy_support = env.get("BAZEL_USE_LEGACY_MACOS_TOOLCHAIN", "0") == "1"
     return disabled_via_env or (repository_ctx.os.name.startswith("mac os") and not macos_legacy_support)
 
 def cc_autoconf_toolchains_impl(repository_ctx):

--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -24,9 +24,14 @@ load(":windows_cc_configure.bzl", "configure_windows_toolchain")
 def _should_disable_toolchain(repository_ctx):
     """Returns true if the toolchain should be disabled based on environment variables."""
     env = repository_ctx.os.environ
-    disabled_via_env = "BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN" in env and env["BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN"] == "1"
+    if env.get("BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN") == "1":
+        return True
+
     macos_legacy_support = env.get("BAZEL_USE_LEGACY_MACOS_TOOLCHAIN", "0") == "1"
-    return disabled_via_env or (repository_ctx.os.name.startswith("mac os") and not macos_legacy_support)
+    if repository_ctx.os.name.startswith("mac os") and not macos_legacy_support:
+        return True
+
+    return False
 
 def cc_autoconf_toolchains_impl(repository_ctx):
     """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain.

--- a/cc/private/toolchain/cc_configure.bzl
+++ b/cc/private/toolchain/cc_configure.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Rules for configuring the C++ toolchain (experimental)."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     ":lib_cc_configure.bzl",
     "get_cpu_value",
@@ -26,6 +27,10 @@ def _should_disable_toolchain(repository_ctx):
     env = repository_ctx.os.environ
     if env.get("BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN") == "1":
         return True
+
+    # Keep macOS toolchain before bazel 9.x
+    if not bazel_features.cc.cc_common_is_in_rules_cc:
+        return False
 
     macos_legacy_support = env.get("BAZEL_USE_LEGACY_MACOS_TOOLCHAIN", "0") == "1"
     if repository_ctx.os.name.startswith("mac os") and not macos_legacy_support:

--- a/tests/integration/cc_tests.sh
+++ b/tests/integration/cc_tests.sh
@@ -203,6 +203,7 @@ def _cc_aspect_impl(target, ctx):
           feature_configuration = feature_configuration,
           name = ctx.label.name + "_aspect",
           cc_toolchain = toolchain,
+          disallow_dynamic_library = True,
           compilation_outputs = compilation_outputs,
       )
     )
@@ -240,6 +241,7 @@ def _cc_skylark_library_impl(ctx):
           feature_configuration=feature_configuration,
           linking_contexts = dep_linking_contexts,
           name = ctx.label.name,
+          disallow_dynamic_library = True,
           compilation_outputs=compilation_outputs)
      )
     return [CcInfo(

--- a/tests/integration/test_launcher.sh
+++ b/tests/integration/test_launcher.sh
@@ -59,6 +59,7 @@ cd "$scratch_workspace"
 cat > MODULE.bazel << EOF
 module(name = "test_module")
 
+# TODO: Remove when we drop bazel 8.x support
 # Bring in macOS toolchain for basic testing
 bazel_dep(name = "apple_support", version = "2.6.1")
 bazel_dep(name = "rules_cc", version = "0.0.0")

--- a/tests/integration/test_launcher.sh
+++ b/tests/integration/test_launcher.sh
@@ -59,6 +59,8 @@ cd "$scratch_workspace"
 cat > MODULE.bazel << EOF
 module(name = "test_module")
 
+# Bring in macOS toolchain for basic testing
+bazel_dep(name = "apple_support", version = "2.6.1")
 bazel_dep(name = "rules_cc", version = "0.0.0")
 local_path_override(
     module_name = "rules_cc",

--- a/tests/integration/test_launcher.sh
+++ b/tests/integration/test_launcher.sh
@@ -59,9 +59,6 @@ cd "$scratch_workspace"
 cat > MODULE.bazel << EOF
 module(name = "test_module")
 
-# TODO: Remove when we drop bazel 8.x support
-# Bring in macOS toolchain for basic testing
-bazel_dep(name = "apple_support", version = "2.6.1")
 bazel_dep(name = "rules_cc", version = "0.0.0")
 local_path_override(
     module_name = "rules_cc",


### PR DESCRIPTION
You can get back the previous toolchain with
`--repo_env=BAZEL_USE_LEGACY_MACOS_TOOLCHAIN=1` for now. Please report
any issues you hit!

Work towards https://github.com/bazelbuild/rules_cc/issues/754
