### PR TITLE
Pass ctx through C++ action construction

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -46,6 +46,17 @@ _UNBOUND = _UnboundValueProviderDoNotUse()
 
 _OLD_STARLARK_API_ALLOWLISTED_PACKAGES = [("", "tools/build_defs/cc"), ("_builtins", ""), ("", "third_party/gloop/tools/build_defs/cc")]
 
+def _ctx_from_ctx_or_actions(ctx, actions):
+    if ctx != None and actions != None:
+        fail("exactly one of ctx or actions must be specified")
+    if ctx == None:
+        if actions == None:
+            fail("exactly one of ctx or actions must be specified")
+        ctx = actions
+    if type(ctx) == "actions":
+        return _cc_internal.actions2ctx_cheat(ctx)
+    return ctx
+
 def _check_all_sources_contain_tuples_or_none_of_them(files):
     no_tuple = False
     has_tuple = False
@@ -63,7 +74,8 @@ def _check_all_sources_contain_tuples_or_none_of_them(files):
 
 def _link(
         *,
-        actions,
+        ctx = None,
+        actions = None,
         name,
         feature_configuration,
         cc_toolchain,
@@ -88,6 +100,8 @@ def _link(
         use_shareable_artifact_factory = _UNBOUND,
         build_config = _UNBOUND,
         emit_interface_shared_library = _UNBOUND):
+    ctx = _ctx_from_ctx_or_actions(ctx, actions)
+
     if output_type == "archive":
         _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
 
@@ -125,7 +139,7 @@ def _link(
         emit_interface_shared_library = False
 
     return link(
-        actions = actions,
+        ctx = ctx,
         name = name,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
@@ -346,7 +360,8 @@ def _is_cc_toolchain_resolution_enabled_do_not_use(*, ctx):
 
 def _create_linking_context_from_compilation_outputs(
         *,
-        actions,
+        ctx = None,
+        actions = None,
         name,
         feature_configuration,
         cc_toolchain,
@@ -362,6 +377,8 @@ def _create_linking_context_from_compilation_outputs(
         stamp = _UNBOUND,
         linked_dll_name_suffix = _UNBOUND,
         test_only_target = _UNBOUND):
+    ctx = _ctx_from_ctx_or_actions(ctx, actions)
+
     if stamp != _UNBOUND or \
        linked_dll_name_suffix != _UNBOUND or \
        test_only_target != _UNBOUND:
@@ -375,7 +392,7 @@ def _create_linking_context_from_compilation_outputs(
         test_only_target = False
 
     return create_linking_context_from_compilation_outputs(
-        actions = actions,
+        ctx = ctx,
         name = name,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
@@ -415,7 +432,8 @@ def _create_extra_link_time_library(*, build_library_func, **kwargs):
 
 def _register_linkstamp_compile_action(
         *,
-        actions,
+        ctx = None,
+        actions = None,
         cc_toolchain,
         feature_configuration,
         source_file,
@@ -426,6 +444,8 @@ def _register_linkstamp_compile_action(
         build_target = None,
         label_replacement = None,  # deprecated, use target_name
         output_replacement = None):  # deprecated, use build_target
+    ctx = _ctx_from_ctx_or_actions(ctx, actions)
+
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
 
     resolved_target_name = target_name if target_name != None else label_replacement
@@ -437,7 +457,7 @@ def _register_linkstamp_compile_action(
         fail("build_target must be specified.")
 
     return register_linkstamp_compile_action(
-        actions = actions,
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
         source_file = source_file,
@@ -450,7 +470,8 @@ def _register_linkstamp_compile_action(
 
 def _compile(
         *,
-        actions,
+        ctx = None,
+        actions = None,
         feature_configuration,
         cc_toolchain,
         name,
@@ -490,6 +511,8 @@ def _compile(
         separate_module_headers = _UNBOUND,
         module_interfaces = _UNBOUND,
         non_compilation_additional_inputs = _UNBOUND):
+    ctx = _ctx_from_ctx_or_actions(ctx, actions)
+
     if module_map != _UNBOUND or \
        additional_module_maps != _UNBOUND or \
        additional_exported_hdrs != _UNBOUND or \
@@ -532,7 +555,7 @@ def _compile(
         _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
 
     return compile(
-        actions = actions,
+        ctx = ctx,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         name = name,

--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -95,7 +95,7 @@ LTO_SOURCE_EXTENSIONS = set(extensions.CC_SOURCE + extensions.C_SOURCE)
 # LINT.IfChange(compile_api)
 def compile(
         *,
-        actions,
+        ctx,
         feature_configuration,
         cc_toolchain,
         srcs = [],
@@ -140,7 +140,7 @@ def compile(
     """Should be used for C++ compilation.
 
     Args:
-        actions: <code>actions</code> object.
+        ctx: The rule context.
         feature_configuration: <code>feature_configuration</code> to be queried."),
         cc_toolchain: <code>CcToolchainInfo</code> provider to be used."),
         srcs: The list of source files to be compiled.",
@@ -213,7 +213,7 @@ def compile(
     """
 
     # LINT.ThenChange(https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java:compile_api)
-    ctx = _cc_internal.actions2ctx_cheat(actions)
+    actions = ctx.actions
     _starlark_cc_semantics.validate_cc_compile_call(
         label = ctx.label,
         include_prefix = include_prefix,
@@ -225,7 +225,7 @@ def compile(
     if additional_module_maps == None:
         additional_module_maps = []
 
-    label = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name)
+    label = ctx.label.same_package_label(name)
     fdo_context = cc_toolchain._fdo_context
 
     use_pic_for_dynamic_libraries = _use_pic_for_dynamic_libs(cpp_configuration, feature_configuration)
@@ -248,7 +248,6 @@ def compile(
     language_normalized = "c++" if language == None else language
     language_normalized = language_normalized.replace("+", "p").upper()
     source_category = SOURCE_CATEGORY_CC if language_normalized == "CPP" else SOURCE_CATEGORY_CC_AND_OBJC
-    ctx = _cc_internal.actions2ctx_cheat(actions)
     if type(includes) == "depset":
         includes = includes.to_list()
     textual_hdrs_list = textual_hdrs.to_list() if type(textual_hdrs) == "depset" else textual_hdrs

--- a/cc/private/compile/linkstamp_compile.bzl
+++ b/cc/private/compile/linkstamp_compile.bzl
@@ -32,7 +32,7 @@ load(
 
 def register_linkstamp_compile_action(
         *,
-        actions,
+        ctx,
         cc_toolchain,
         feature_configuration,
         source_file,
@@ -47,7 +47,7 @@ def register_linkstamp_compile_action(
     """Registers a C++ compile action for linkstamps.
 
     Args:
-        actions: `actions` object.
+        ctx: The rule context.
         cc_toolchain: `CcToolchainInfo` provider to be used.
         feature_configuration: `feature_configuration` to be queried.
         source_file: The linkstamp source file to be compiled.
@@ -60,8 +60,6 @@ def register_linkstamp_compile_action(
         stamping: Whether stamping is enabled. If None, it's computed based on configuration.
         additional_linkstamp_defines: A list of additional defines for linkstamp compilation.
     """
-    ctx = _cc_internal.actions2ctx_cheat(actions)
-
     if stamping == None:
         stamping = should_stamp(ctx)
 

--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -42,7 +42,8 @@ load("//cc/private/link:target_types.bzl", "LINKING_MODE", "LINK_TARGET_TYPE", "
 # this can be done after removing Objc archives from cc_common.link.
 
 def create_cc_link_actions(
-        actions,
+        ctx,
+        link_actions,
         name,
         static_link_type,
         dynamic_link_type,
@@ -80,7 +81,8 @@ def create_cc_link_actions(
     behavior.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
+        link_actions: The wrapped action factory used to declare link artifacts.
         name: (str) This is used for naming the output artifacts of actions created by this method.
         static_link_type: (None|LINK_TARGET_TYPE) Type of static libraries to create.
         dynamic_link_type: (None|LINK_TARGET_TYPE) Type of dynamic libraries to create.
@@ -151,7 +153,8 @@ def create_cc_link_actions(
     use_pic_for_dynamic_libs = _use_pic_for_dynamic_libs(cpp_config, feature_configuration)
 
     link_action_kwargs = dict(
-        actions = actions,
+        ctx = ctx,
+        link_actions = link_actions,
         stamping = stamping,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
@@ -176,7 +179,7 @@ def create_cc_link_actions(
     static_library = {}
     if static_link_type:
         static_library = _create_no_pic_and_pic_static_libs_actions(
-            actions,
+            link_actions,
             name,
             static_link_type,
             cc_toolchain,
@@ -203,7 +206,7 @@ def create_cc_link_actions(
 
         dynamic_library, all_lto_artifacts, linker_output_artifact = \
             _create_dynamic_link_actions(
-                actions,
+                link_actions,
                 name,
                 dynamic_link_type,
                 linking_mode,

--- a/cc/private/link/cpp_link_action.bzl
+++ b/cc/private/link/cpp_link_action.bzl
@@ -24,7 +24,8 @@ load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "nati
 
 def link_action(
         *,
-        actions,
+        ctx,
+        link_actions,
         mnemonic,
         library_identifier,  # TODO(b/331164666): Set in the callee and remove
         link_type,
@@ -76,7 +77,8 @@ def link_action(
     and returned.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
+        link_actions: The wrapped action factory used to declare link artifacts.
         mnemonic: (str) The mnemonic used in the action.
         library_identifier: (str) Identifier of the library.
         link_type: (LINK_TARGET_TYPE) Type of libraries to create.
@@ -141,7 +143,7 @@ def link_action(
     if thinlto_param_file:
         non_code_inputs.append(thinlto_param_file)
 
-    linkstamp_map = _map_linkstamps_to_outputs(actions, linkstamps, output)
+    linkstamp_map = _map_linkstamps_to_outputs(link_actions, linkstamps, output)
     linkstamp_object_file_inputs = linkstamp_map.values()
     object_file_inputs = object_files
 
@@ -161,7 +163,7 @@ def link_action(
             object_files = combined_object_artifacts if use_archiver else [],
             lto_compilation_context = lto_compilation_context if use_archiver else [],
             shared_non_lto_backends = create_shared_non_lto_artifacts(
-                actions,
+                link_actions,
                 lto_compilation_context,
                 link_type.linker_or_archiver == USE_LINKER,
                 feature_configuration,
@@ -191,7 +193,7 @@ def link_action(
         feature_configuration,
         output,
         _cc_internal.dynamic_library_soname(
-            actions,
+            link_actions,
             # Must match https://github.com/bazelbuild/bazel/blob/795af54db5c348af5ca8b2961a982b399206ea20/src/main/java/com/google/devtools/build/lib/rules/cpp/SolibSymlinkAction.java#L169.
             root_relative_path(output),
             link_type != LINK_TARGET_TYPE.NODEPS_DYNAMIC_LIBRARY,
@@ -203,7 +205,7 @@ def link_action(
     user_link_flags = linkopts + cc_toolchain._cpp_configuration.linkopts
 
     finalize_link_action(
-        actions,
+        ctx,
         # TODO(b/331164666): use default value instead of an if
         mnemonic if mnemonic else "CppLink",
         link_type.action_name,
@@ -241,14 +243,14 @@ def link_action(
 
     return output_library, interface_output_library
 
-def _map_linkstamps_to_outputs(actions, linkstamps, output):
+def _map_linkstamps_to_outputs(link_actions, linkstamps, output):
     """ Translates a collection of Linkstamp instances to an immutable mapping from linkstamp to object files.
 
      In other words, given a set of source files, this method determines the output
      path to which each file should be compiled.
 
      Args:
-       actions: (Actions) `actions` object.
+       link_actions: The wrapped action factory used to declare link artifacts.
        linkstamps: (list[Linkstamp])
        output: the binary output path for this link
     Returns:
@@ -269,6 +271,6 @@ def _map_linkstamps_to_outputs(actions, linkstamps, output):
             stamp_output_dir,
             paths.replace_extension(linkstamp_file.short_path, ".o"),
         )
-        stamp_output_file = actions.declare_shareable_artifact(stamp_output_path)
+        stamp_output_file = link_actions.declare_shareable_artifact(stamp_output_path)
         map[linkstamp] = stamp_output_file
     return map

--- a/cc/private/link/create_linking_context_from_compilation_outputs.bzl
+++ b/cc/private/link/create_linking_context_from_compilation_outputs.bzl
@@ -27,7 +27,7 @@ load("//cc/private/link:target_types.bzl", "LINKING_MODE", "LINK_TARGET_TYPE")
 # IMPORTANT: This function is public API exposed on cc_common module!
 def create_linking_context_from_compilation_outputs(
         *,
-        actions,
+        ctx,
         name,
         feature_configuration,
         cc_toolchain,
@@ -68,7 +68,7 @@ def create_linking_context_from_compilation_outputs(
     those parameters need to be eventually removed or made public.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
         name: (str) This is used for naming the output artifacts of actions created by this method.
         feature_configuration: (FeatureConfiguration) `feature_configuration` to be queried.
         language: ("cpp") Only C++ supported for now. Do not use this parameter.
@@ -94,7 +94,7 @@ def create_linking_context_from_compilation_outputs(
 
     # LINT.ThenChange(https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/cpp/CcModuleApi.java)
     # TODO(b/202252560): Fix for swift_library's implicit output, remove rule_kind_cheat.
-    if alwayslink and _cc_internal.rule_class(_cc_internal.actions2ctx_cheat(actions)) != "swift_library":
+    if alwayslink and _cc_internal.rule_class(ctx) != "swift_library":
         static_link_type = LINK_TARGET_TYPE.ALWAYS_LINK_STATIC_LIBRARY
     else:
         static_link_type = LINK_TARGET_TYPE.STATIC_LIBRARY
@@ -102,7 +102,8 @@ def create_linking_context_from_compilation_outputs(
         additional_inputs = depset(additional_inputs)
 
     cc_linking_outputs = create_cc_link_actions(
-        _cc_internal.wrap_link_actions(actions),
+        ctx,
+        _cc_internal.wrap_link_actions(ctx.actions),
         name,
         None if disallow_static_libraries else static_link_type,
         None if disallow_dynamic_library else LINK_TARGET_TYPE.NODEPS_DYNAMIC_LIBRARY,
@@ -122,8 +123,7 @@ def create_linking_context_from_compilation_outputs(
     )
 
     linker_input = create_linker_input(
-        # TODO(b/331164666): remove cheat, we always produce a file, file.owner gives us a label
-        owner = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name),
+        owner = ctx.label.same_package_label(name),
         libraries = depset([cc_linking_outputs.library_to_link] if cc_linking_outputs.library_to_link else []),
         user_link_flags = user_link_flags,
         additional_inputs = additional_inputs,

--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -23,7 +23,7 @@ load("//cc/private/link:target_types.bzl", "LINKING_MODE", "LINK_TARGET_TYPE", "
 load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
 
 def finalize_link_action(
-        actions,
+        ctx,
         mnemonic,
         action_name,
         link_type,
@@ -65,7 +65,7 @@ def finalize_link_action(
     Creates the action, producing the `output` and maybe `interface_output`.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
         mnemonic: (str) The mnemonic used in the action.
         action_name: (str) action name.
         link_type: (LINK_TARGET_TYPE) Type of libraries to create.
@@ -179,8 +179,7 @@ def finalize_link_action(
         native_deps,
         solib_dir,
         toolchain_libraries_solib_dir,
-        # TODO(b/338618120): remove cheat using semantic or simplifying collect_libraries_to_link
-        _cc_internal.actions2ctx_cheat(actions).workspace_name,
+        ctx.workspace_name,
     )
 
     #  Add build variables necessary to template link args into the crosstool.
@@ -255,7 +254,7 @@ def finalize_link_action(
 
         for linkstamp, artifact in linkstamp_map.items():
             register_linkstamp_compile_action(
-                actions = actions,
+                ctx = ctx,
                 cc_toolchain = cc_toolchain,
                 feature_configuration = feature_configuration,
                 source_file = linkstamp.file(),
@@ -281,7 +280,7 @@ def finalize_link_action(
         )
 
     _create_action(
-        actions,
+        ctx,
         action_name,
         feature_configuration,
         cc_toolchain,
@@ -296,7 +295,7 @@ def finalize_link_action(
     )
 
 def _create_action(
-        actions,
+        ctx,
         action_name,
         feature_configuration,
         cc_toolchain,
@@ -312,7 +311,7 @@ def _create_action(
     Creates C++ linking or LTO indexing action.
 
     Args:
-      actions: (StarlarkActions) `actions` object
+      ctx: The rule context.
       action_name: (str) action name
       feature_configuration: (FeatureConfiguration) `feature_configuration` to be queried.
       cc_toolchain: (CcToolchainInfo) CcToolchainInfo provider to be used.
@@ -368,18 +367,16 @@ def _create_action(
     exec_group = None
     toolchain = None
 
-    if "cpp_link" in _cc_internal.actions2ctx_cheat(actions).exec_groups:
-        # TODO(b/338618120): ^ remove cheat, no idea how though, maybe always use cpp_link exec group?
+    if "cpp_link" in ctx.exec_groups:
         exec_group = "cpp_link"
-    elif "@@bazel_tools//tools/cpp:toolchain_type" in _cc_internal.actions2ctx_cheat(actions).toolchains:  # buildifier: disable=canonical-repository
-        # TODO(b/338618120): ^ remove cheat, needs depot cleanup, always use a toolchain
+    elif "@@bazel_tools//tools/cpp:toolchain_type" in ctx.toolchains:  # buildifier: disable=canonical-repository
         toolchain = semantics.toolchain
 
     execution_info = semantics.get_cc_link_memlimit(
         cc_toolchain._cpp_configuration.compilation_mode(),
         execution_info,
     )
-    actions.run(
+    ctx.actions.run(
         mnemonic = mnemonic,
         executable = tool_path,
         arguments = [link_args],

--- a/cc/private/link/link.bzl
+++ b/cc/private/link/link.bzl
@@ -36,7 +36,7 @@ _TARGET_TYPE = {
 # IMPORTANT: This function is public API exposed on cc_common module!
 def link(
         *,
-        actions,
+        ctx,
         name,
         feature_configuration,
         cc_toolchain,
@@ -91,7 +91,7 @@ def link(
     TODO(b/338618120): Migrate Objc to cc_common.create_linking_context_from_compilation_outputs.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
         name: (str) This is used for naming the output artifacts of actions created by this method.
         feature_configuration: (FeatureConfiguration) `feature_configuration` to be queried.
         cc_toolchain: (CcToolchainInfo) CcToolchainInfo provider to be used.
@@ -161,10 +161,11 @@ def link(
 
     # TODO(b/338618120): Migrate Apple and Android rules, so they don't need to use build_config
     # when calling link. This happens because they are using deps with split configuration
-    actions = _cc_internal.wrap_link_actions(actions, build_config, use_shareable_artifact_factory)
+    link_actions = _cc_internal.wrap_link_actions(ctx.actions, build_config, use_shareable_artifact_factory)
 
     return create_cc_link_actions(
-        actions,
+        ctx,
+        link_actions,
         name,
         static_link_type,
         dynamic_link_type,

--- a/cc/private/link/lto_indexing_action.bzl
+++ b/cc/private/link/lto_indexing_action.bzl
@@ -14,7 +14,6 @@
 """Functions that create LTO indexing action."""
 
 load("//cc/common:cc_helper_internal.bzl", "root_relative_path")
-load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 load("//cc/private/compile:lto_compilation_context.bzl", "get_minimized_bitcode_or_self")
 load("//cc/private/link:finalize_link_action.bzl", "finalize_link_action")
 load("//cc/private/link:link_build_variables.bzl", "setup_lto_indexing_variables")
@@ -22,7 +21,8 @@ load("//cc/private/link:lto_backends.bzl", "create_lto_backends")
 load("//cc/private/link:target_types.bzl", "LINKING_MODE", "LINK_TARGET_TYPE", "is_dynamic_library")
 
 def create_lto_artifacts_and_lto_indexing_action(
-        actions,
+        ctx,
+        link_actions,
         link_type,
         linking_mode,
         use_pic,
@@ -51,7 +51,8 @@ def create_lto_artifacts_and_lto_indexing_action(
     Both of the files are later passed into C++ linking action.
 
     Args:
-        actions: (Actions) `actions` object.
+        ctx: The rule context.
+        link_actions: The wrapped action factory used to declare link artifacts.
         link_type: (LINK_TARGET_TYPE) Type of libraries to create.
         linking_mode: (LINKING_MODE) Linking mode used for dynamic libraries.
         use_pic: (bool) Whether to use PIC.
@@ -96,7 +97,7 @@ def create_lto_artifacts_and_lto_indexing_action(
     object_file_inputs = compilation_outputs.pic_objects if use_pic else compilation_outputs.objects
 
     all_lto_artifacts = create_lto_backends(
-        actions,
+        link_actions,
         lto_compilation_context,
         feature_configuration,
         cc_toolchain,
@@ -111,7 +112,8 @@ def create_lto_artifacts_and_lto_indexing_action(
     )
     if allow_lto_indexing:
         thinlto_param_file, thinlto_merged_object_file = _lto_indexing_action(
-            actions = actions,
+            ctx = ctx,
+            link_actions = link_actions,
             cc_toolchain = cc_toolchain,
             compilation_outputs = compilation_outputs,
             feature_configuration = feature_configuration,
@@ -136,7 +138,8 @@ def create_lto_artifacts_and_lto_indexing_action(
     return all_lto_artifacts, allow_lto_indexing, thinlto_param_file, thinlto_merged_object_file
 
 def _lto_indexing_action(
-        actions,
+        ctx,
+        link_actions,
         linking_mode,
         cc_toolchain,
         all_lto_artifacts,
@@ -217,12 +220,12 @@ def _lto_indexing_action(
     # replaced with the final output directory, so they will be the paths
     # of the native object files not the input bitcode files.
     thinlto_param_file = \
-        actions.declare_shareable_artifact(root_relative_path(output) + "-lto-final.params")
+        link_actions.declare_shareable_artifact(root_relative_path(output) + "-lto-final.params")
 
     # Create artifact for the merged object file, which is an object file that is created
     # during the LTO indexing step and needs to be passed to the final link.
     thinlto_merged_object_file = \
-        actions.declare_shareable_artifact(root_relative_path(output) + ".lto.merged.o")
+        link_actions.declare_shareable_artifact(root_relative_path(output) + ".lto.merged.o")
 
     action_outputs = \
         ([lto_artifact.imports for lto_artifact in all_lto_artifacts if lto_artifact.index] +
@@ -232,8 +235,7 @@ def _lto_indexing_action(
     build_variables = variables_extensions | setup_lto_indexing_variables(
         cc_toolchain,
         feature_configuration,
-        # TODO(b/338618120): remove cheat using the root of one of the created outputs
-        _cc_internal.actions2ctx_cheat(actions).bin_dir.path,
+        ctx.bin_dir.path,
         thinlto_param_file.path,
         thinlto_merged_object_file.path,
         lto_output_root_prefix,
@@ -256,7 +258,7 @@ def _lto_indexing_action(
         action_name = "lto-index-for-nodeps-dynamic-library"
 
     finalize_link_action(
-        actions,
+        ctx,
         "CppLTOIndexing",  # mnemonic
         action_name,
         link_type,

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -380,7 +380,7 @@ def _create_transitive_linking_actions(
         link_deps_statically = False
 
     cc_linking_outputs = cc_common.link(
-        actions = ctx.actions,
+        ctx = ctx,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         compilation_outputs = cc_compilation_outputs_with_only_objects,
@@ -522,7 +522,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
 
     (compilation_context, compilation_outputs) = cc_common.compile(
         name = ctx.label.name,
-        actions = ctx.actions,
+        ctx = ctx,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         user_compile_flags = runtimes_copts + cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts"),
@@ -569,7 +569,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     cc_linking_outputs = None
     if link_compile_output_separately and not cc_helper.is_compilation_outputs_empty(cc_compilation_outputs):
         (_, cc_linking_outputs) = cc_common.create_linking_context_from_compilation_outputs(
-            actions = ctx.actions,
+            ctx = ctx,
             feature_configuration = feature_configuration,
             cc_toolchain = cc_toolchain,
             compilation_outputs = cc_compilation_outputs,

--- a/cc/private/rules_impl/cc_import.bzl
+++ b/cc/private/rules_impl/cc_import.bzl
@@ -168,7 +168,7 @@ def _cc_import_impl(ctx):
     runtimes_copts = semantics.get_cc_runtimes_copts(ctx)
     compilation_contexts = cc_helper.get_compilation_contexts_from_deps(runtimes_deps)
     (compilation_context, _) = cc_common.compile(
-        actions = ctx.actions,
+        ctx = ctx,
         feature_configuration = feature_configuration,
         user_compile_flags = runtimes_copts,
         cc_toolchain = cc_toolchain,

--- a/cc/private/rules_impl/cc_library_impl.bzl
+++ b/cc/private/rules_impl/cc_library_impl.bzl
@@ -54,7 +54,7 @@ def _cc_library_impl(ctx):
     additional_make_variable_substitutions.update(cc_helper.get_cc_flags_make_variable(ctx, feature_configuration, cc_toolchain))
 
     (compilation_context, srcs_compilation_outputs) = cc_common.compile(
-        actions = ctx.actions,
+        ctx = ctx,
         name = ctx.label.name,
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
@@ -156,7 +156,7 @@ def _cc_library_impl(ctx):
             linking_context,
             linking_outputs,
         ) = cc_common.create_linking_context_from_compilation_outputs(
-            actions = ctx.actions,
+            ctx = ctx,
             name = ctx.label.name,
             compilation_outputs = compilation_outputs,
             cc_toolchain = cc_toolchain,

--- a/cc/private/rules_impl/cc_shared_library_impl.bzl
+++ b/cc/private/rules_impl/cc_shared_library_impl.bzl
@@ -709,7 +709,7 @@ def _cc_shared_library_impl(ctx):
 
     additional_inputs.extend(ctx.files.additional_linker_inputs)
     linking_outputs = cc_common.link(
-        actions = ctx.actions,
+        ctx = ctx,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         linking_contexts = [linking_context] + runtimes_linking_contexts,

--- a/cc/private/rules_impl/objc_compilation_support.bzl
+++ b/cc/private/rules_impl/objc_compilation_support.bzl
@@ -178,7 +178,7 @@ def _compile(
     runtimes_copts = cc_semantics.get_cc_runtimes_copts(common_variables.ctx)
 
     return cc_common.compile(
-        actions = common_variables.ctx.actions,
+        ctx = common_variables.ctx,
         feature_configuration = feature_configuration,
         cc_toolchain = common_variables.toolchain,
         name = common_variables.ctx.label.name,
@@ -371,7 +371,7 @@ def _cc_compile_and_link(
     objc_linking_context = common_variables.objc_linking_context
     if len(compilation_outputs.objects) != 0 or len(compilation_outputs.pic_objects) != 0:
         (linking_context, _) = cc_common.create_linking_context_from_compilation_outputs(
-            actions = ctx.actions,
+            ctx = ctx,
             feature_configuration = feature_configuration,
             cc_toolchain = common_variables.toolchain,
             compilation_outputs = compilation_outputs,


### PR DESCRIPTION
## Summary

Change the `cc_common.compile`, `cc_common.link`, `cc_common.create_linking_context_from_compilation_outputs`, and `cc_common.register_linkstamp_compile_action` boundaries to accept `ctx`. The boundaries convert an `actions` value supplied as `ctx` once for migration compatibility, while compile, link, LTO, and linkstamp implementations receive the rule context directly. Wrapped `link_actions` remain separate only where shareable or alternate-configuration link artifacts require them.

## Rationale

The action-only parameters forced implementation code to recover the rule context repeatedly through `actions2ctx_cheat`. Passing `ctx` from rules_cc callers removes those downstream conversions and gives each implementation direct access to the exact rule context fields it uses.
