### PR TITLE
Starlarkify declare_compile_output_file and declare_other_output_file

### DIFF
--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -1581,10 +1581,9 @@ def _create_compile_source_action(
     if generate_dwo and not bitcode_output:
         dwo_file_name = paths.replace_extension(paths.basename(object_file.path), ".dwo")
 
-        dwo_file = _cc_internal.declare_other_output_file(
-            ctx = action_construction_context,
-            output_name = dwo_file_name,
-            object_file = object_file,
+        dwo_file = action_construction_context.actions.declare_file(
+            dwo_file_name,
+            sibling = object_file,
         )
 
     lto_indexing_file = None
@@ -1593,10 +1592,9 @@ def _create_compile_source_action(
             paths.basename(object_file.path),
             extensions.LTO_INDEXING_OBJECT_FILE[0],
         )
-        lto_indexing_file = _cc_internal.declare_other_output_file(
-            ctx = action_construction_context,
-            output_name = lto_indexing_file_name,
-            object_file = object_file,
+        lto_indexing_file = action_construction_context.actions.declare_file(
+            lto_indexing_file_name,
+            sibling = object_file,
         )
 
     complete_copts = get_copts(

--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -25,6 +25,8 @@ load(
     "CPP_SOURCE_TYPE_HEADER",
     "CPP_SOURCE_TYPE_SOURCE",
     "extensions",
+    "output_subdirectories",
+    "package_source_root",
     "should_create_per_object_debug_info",
     _use_pic_for_binaries = "use_pic_for_binaries",
     _use_pic_for_dynamic_libs = "use_pic_for_dynamic_libs",
@@ -535,7 +537,6 @@ def _create_scan_deps_action(
         dotd_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.INCLUDED_FILE_LIST,
@@ -675,7 +676,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
     modules_info_file = _get_compile_output_file(
         action_construction_context,
         label,
-        configuration = configuration,
         output_name = _cc_internal.get_artifact_name_for_category(
             cc_toolchain = cc_toolchain,
             category = artifact_category.CPP_MODULES_INFO,
@@ -705,7 +705,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
         module_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = output_category,
@@ -725,7 +724,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
         ddi_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = ddi_output_name,
         )
         _create_scan_deps_action(
@@ -784,7 +782,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
         modmap_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.CPP_MODULES_MODMAP,
@@ -794,7 +791,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
         modmap_input_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.CPP_MODULES_MODMAP_INPUT,
@@ -882,7 +878,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
             modmap_file = _get_compile_output_file(
                 action_construction_context,
                 label,
-                configuration = configuration,
                 output_name = _cc_internal.get_artifact_name_for_category(
                     cc_toolchain = cc_toolchain,
                     category = artifact_category.CPP_MODULES_MODMAP,
@@ -892,7 +887,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
             modmap_input_file = _get_compile_output_file(
                 action_construction_context,
                 label,
-                configuration = configuration,
                 output_name = _cc_internal.get_artifact_name_for_category(
                     cc_toolchain = cc_toolchain,
                     category = artifact_category.CPP_MODULES_MODMAP_INPUT,
@@ -908,7 +902,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
             ddi_file = _get_compile_output_file(
                 action_construction_context,
                 label,
-                configuration = configuration,
                 output_name = ddi_output_name,
             )
             _create_scan_deps_action(
@@ -936,7 +929,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
             modmap_file = _get_compile_output_file(
                 action_construction_context,
                 label,
-                configuration = configuration,
                 output_name = _cc_internal.get_artifact_name_for_category(
                     cc_toolchain = cc_toolchain,
                     category = artifact_category.CPP_MODULES_MODMAP,
@@ -946,7 +938,6 @@ def _create_cc_compile_actions_with_cpp20_module_helper(
             modmap_input_file = _get_compile_output_file(
                 action_construction_context,
                 label,
-                configuration = configuration,
                 output_name = _cc_internal.get_artifact_name_for_category(
                     cc_toolchain = cc_toolchain,
                     category = artifact_category.CPP_MODULES_MODMAP_INPUT,
@@ -1321,7 +1312,6 @@ def _create_cc_compile_actions(
         output_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.PROCESSED_HEADER,
@@ -1331,7 +1321,6 @@ def _create_cc_compile_actions(
         dotd_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.INCLUDED_FILE_LIST,
@@ -1344,7 +1333,6 @@ def _create_cc_compile_actions(
         diagnostics_file = _get_compile_output_file(
             action_construction_context,
             label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.SERIALIZED_DIAGNOSTICS_FILE,
@@ -1557,7 +1545,6 @@ def _create_compile_source_action(
     object_file = _get_compile_output_file(
         ctx = action_construction_context,
         label = label,
-        configuration = configuration,
         output_name = _cc_internal.get_artifact_name_for_category(
             cc_toolchain = cc_toolchain,
             category = output_category,
@@ -1571,7 +1558,6 @@ def _create_compile_source_action(
         category = output_category,
         output_name = output_pic_nopic_name,
         cc_toolchain = cc_toolchain,
-        configuration = configuration,
         feature_configuration = feature_configuration,
     ) if enable_dotd_files else None
     diagnostics_file = _maybe_declare_diagnostics_file(
@@ -1580,7 +1566,6 @@ def _create_compile_source_action(
         category = output_category,
         output_name = output_pic_nopic_name,
         cc_toolchain = cc_toolchain,
-        configuration = configuration,
         feature_configuration = feature_configuration,
     )
     gcno_file = _maybe_declare_gcno_file(
@@ -1589,7 +1574,6 @@ def _create_compile_source_action(
         output_name = output_pic_nopic_name,
         cc_toolchain = cc_toolchain,
         cpp_configuration = cpp_configuration,
-        configuration = configuration,
         enable_coverage = enable_coverage,
     )
 
@@ -1784,7 +1768,6 @@ def _create_temps_action(
     preprocess_object_file = _get_compile_output_file(
         ctx = action_construction_context,
         label = label,
-        configuration = configuration,
         output_name = _cc_internal.get_artifact_name_for_category(
             cc_toolchain = cc_toolchain,
             category = category,
@@ -1794,7 +1777,6 @@ def _create_temps_action(
     assembly_object_file = _get_compile_output_file(
         ctx = action_construction_context,
         label = label,
-        configuration = configuration,
         output_name = _cc_internal.get_artifact_name_for_category(
             cc_toolchain = cc_toolchain,
             category = artifact_category.GENERATED_ASSEMBLY,
@@ -1808,7 +1790,6 @@ def _create_temps_action(
         source_artifact = source_artifact,
         category = category,
         cc_toolchain = cc_toolchain,
-        configuration = configuration,
         feature_configuration = feature_configuration,
     ) if enable_dotd_files else None
     assembly_dotd_file = _maybe_declare_dotd_file(
@@ -1818,7 +1799,6 @@ def _create_temps_action(
         source_artifact = source_artifact,
         category = artifact_category.GENERATED_ASSEMBLY,
         cc_toolchain = cc_toolchain,
-        configuration = configuration,
         feature_configuration = feature_configuration,
     ) if enable_dotd_files else None
 
@@ -1828,7 +1808,6 @@ def _create_temps_action(
         category = category,
         output_name = output_name,
         cc_toolchain = cc_toolchain,
-        configuration = configuration,
         feature_configuration = feature_configuration,
     )
     assembly_diagnostics_file = _maybe_declare_diagnostics_file(
@@ -1838,7 +1817,6 @@ def _create_temps_action(
         output_name = output_name,
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
-        configuration = configuration,
     )
     preprocess_compile_variables = get_specific_compile_build_variables(
         source_file = source_artifact,
@@ -1952,7 +1930,6 @@ def _create_module_codegen_action(
         gcno_file = _get_compile_output_file(
             ctx = action_construction_context,
             label = label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.COVERAGE_DATA_FILE,
@@ -1980,7 +1957,6 @@ def _create_module_codegen_action(
     object_file = _get_compile_output_file(
         ctx = action_construction_context,
         label = label,
-        configuration = configuration,
         output_name = _cc_internal.get_artifact_name_for_category(
             cc_toolchain = cc_toolchain,
             category = artifact_category.OBJECT_FILE,
@@ -1994,7 +1970,6 @@ def _create_module_codegen_action(
         dotd_file = _get_compile_output_file(
             ctx = action_construction_context,
             label = label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.INCLUDED_FILE_LIST,
@@ -2007,7 +1982,6 @@ def _create_module_codegen_action(
         diagnostics_file = _get_compile_output_file(
             ctx = action_construction_context,
             label = label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.SERIALIZED_DIAGNOSTICS_FILE,
@@ -2144,14 +2118,18 @@ def _create_module_action(
         progress_message_prefix = progress_message_prefix,
     )
 
-def _get_compile_output_file(ctx, label, *, output_name, configuration):
-    file = _cc_internal.declare_compile_output_file(
-        ctx = ctx,
-        label = label,
-        output_name = output_name,
-        configuration = configuration,
+def _get_compile_output_file(ctx, label, *, output_name):
+    output_path = paths.join(
+        package_source_root(
+            label.workspace_name,
+            label.package,
+            ctx.configuration.is_sibling_repository_layout(),
+        ),
+        output_subdirectories.OBJS,
+        label.name,
+        output_name,
     )
-    return file
+    return ctx.actions.declare_shareable_artifact(output_path)
 
 def _use_dotd_file(feature_configuration, source_file):
     extension = "." + source_file.extension if source_file.extension else ""
@@ -2221,7 +2199,6 @@ def _maybe_declare_dotd_file(
         category,
         output_name,
         cc_toolchain,
-        configuration,
         feature_configuration):
     dotd_file = None
     if (_use_dotd_file(feature_configuration, source_artifact)):
@@ -2240,7 +2217,6 @@ def _maybe_declare_dotd_file(
         dotd_file = _get_compile_output_file(
             ctx = ctx,
             label = label,
-            configuration = configuration,
             output_name = dotd_name,
         )
     return dotd_file
@@ -2251,8 +2227,7 @@ def _maybe_declare_diagnostics_file(
         category,
         output_name,
         cc_toolchain,
-        feature_configuration,
-        configuration):
+        feature_configuration):
     diagnostics_file = None
     if feature_configuration.is_enabled("serialized_diagnostics_file"):
         base_name = output_name
@@ -2270,7 +2245,6 @@ def _maybe_declare_diagnostics_file(
         diagnostics_file = _get_compile_output_file(
             ctx = ctx,
             label = label,
-            configuration = configuration,
             output_name = diagnostics_file_name,
         )
     return diagnostics_file
@@ -2281,14 +2255,12 @@ def _maybe_declare_gcno_file(
         output_name,
         cc_toolchain,
         cpp_configuration,
-        configuration,
         enable_coverage):
     gcno_file = None
     if enable_coverage and not cpp_configuration.use_llvm_coverage_map_format():
         gcno_file = _get_compile_output_file(
             ctx = ctx,
             label = label,
-            configuration = configuration,
             output_name = _cc_internal.get_artifact_name_for_category(
                 cc_toolchain = cc_toolchain,
                 category = artifact_category.COVERAGE_DATA_FILE,


### PR DESCRIPTION
## Summary

Replace `_cc_internal.declare_compile_output_file` and `_cc_internal.declare_other_output_file` with Starlark output declarations. Compile outputs are declared as shareable artifacts at `<package>/_objs/<label.name>/<output_name>`, while `.dwo` and ThinLTO indexing outputs are declared beside their object files with `actions.declare_file(..., sibling = object_file)`.

The rule context already provides the configuration used by every caller, so this also removes redundant `configuration` arguments from `_get_compile_output_file`, `_maybe_declare_dotd_file`, `_maybe_declare_diagnostics_file`, `_maybe_declare_gcno_file`, and their callers.
