### PR TITLE
Starlarkify compute_output_name_prefix_dir

### DIFF
--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -1033,7 +1033,7 @@ def _create_cc_compile_actions_with_cpp20_module(
         progress_message_prefix):
     """Constructs the C++ compiler actions with C++20 modules support.
     """
-    output_name_prefix_dir = _cc_internal.compute_output_name_prefix_dir(configuration = configuration, purpose = purpose)
+    output_name_prefix_dir = _compute_output_name_prefix_dir(purpose)
     output_name_map = _calculate_output_name_map_by_type(compilation_unit_sources | module_interfaces_sources, output_name_prefix_dir)
     use_pic_values = []
     if generate_no_pic_action:
@@ -1230,7 +1230,7 @@ def _create_cc_compile_actions(
                     progress_message_prefix = progress_message_prefix,
                 )
 
-    output_name_prefix_dir = _cc_internal.compute_output_name_prefix_dir(configuration = configuration, purpose = purpose)
+    output_name_prefix_dir = _compute_output_name_prefix_dir(purpose)
     output_name_map = _calculate_output_name_map_by_type(compilation_unit_sources, output_name_prefix_dir)
 
     compiled_basenames = set()
@@ -2186,6 +2186,13 @@ def _calculate_output_name_map_by_type(sources, prefix_dir):
             prefix_dir,
         )
     )
+
+def _compute_output_name_prefix_dir(purpose):
+    if purpose.endswith("_non_objc_arc"):
+        return "non_arc"
+    if purpose.endswith("_objc_arc"):
+        return "arc"
+    return ""
 
 def _calculate_output_name_map(source_artifacts, prefix_dir):
     """Calculates the output names for object file paths from a set of source files."""

--- a/tests/cc/common/cc_objc_library_configured_target_tests.bzl
+++ b/tests/cc/common/cc_objc_library_configured_target_tests.bzl
@@ -32,10 +32,38 @@ def _test_data_in_runfiles_impl(env, target):
     target.runfiles().not_contains_predicate(matching.str_endswith(".a"))
     target.data_runfiles().not_contains_predicate(matching.str_endswith(".a"))
 
+def _test_arc_output_directories(name, **kwargs):
+    util.helper_target(
+        objc_library,
+        name = name + "_lib",
+        srcs = ["arc_source.m"],
+        non_arc_srcs = ["non_arc_source.m"],
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_arc_output_directories_impl,
+        target = name + "_lib",
+        with_action_configs = [ACTION_NAMES.objc_compile],
+        **kwargs
+    )
+
+def _test_arc_output_directories_impl(env, target):
+    outputs = [file.short_path for file in target[OutputGroupInfo].compilation_outputs.to_list()]
+    env.expect.that_collection(outputs).contains_predicate(matching.custom(
+        "contains '/arc/'",
+        lambda output: "/arc/" in output,
+    ))
+    env.expect.that_collection(outputs).contains_predicate(matching.custom(
+        "contains '/non_arc/'",
+        lambda output: "/non_arc/" in output,
+    ))
+
 def cc_objc_library_configured_target_tests(name):
     test_suite(
         name = name,
         tests = [
+            _test_arc_output_directories,
             _test_objc_data_in_runfiles,
         ] if bazel_features.cc.cc_common_is_in_rules_cc else [],
     )


### PR DESCRIPTION
## Summary

Replace both `_cc_internal.compute_output_name_prefix_dir` calls with a private Starlark helper. The helper returns `non_arc` for purposes ending in `_non_objc_arc`, `arc` for purposes ending in `_objc_arc`, and an empty prefix otherwise.

`compile()` normalizes an unset purpose to an empty string before these calls, so the native helper's configuration-mnemonic fallback was not reachable from either rules_cc caller.

Configured-target coverage verifies that Objective-C ARC and non-ARC sources retain separate output directories.