### PR TITLE
Starlarkify default_features_and_action_configs

### DIFF
--- a/cc/private/rules_impl/cc_toolchain_info.bzl
+++ b/cc/private/rules_impl/cc_toolchain_info.bzl
@@ -137,6 +137,7 @@ def _create_cc_toolchain_info(
         _build_info_files = build_info_files,
         _supports_header_parsing = supports_header_parsing,
         _supports_param_files = supports_param_files,
+        _default_features_and_action_configs = toolchain_config_info._default_features_and_action_configs,
         _toolchain_features = toolchain_features,
         _toolchain_label = toolchain_label,
         _cpp_configuration = cpp_configuration,
@@ -232,6 +233,7 @@ CcToolchainInfo, _ = provider(
         # Fields still used by native code - will be used by Starlark in the future.
         "_supports_header_parsing": "INTERNAL API, DO NOT USE!",
         "_supports_param_files": "INTERNAL API, DO NOT USE!",
+        "_default_features_and_action_configs": "INTERNAL API, DO NOT USE!",
         "_toolchain_features": "INTERNAL API, DO NOT USE!",
         "_toolchain_label": "INTERNAL API, DO NOT USE!",
         "_cpp_configuration": "INTERNAL API, DO NOT USE!",

--- a/cc/private/toolchain_config/cc_toolchain_config_info.bzl
+++ b/cc/private/toolchain_config/cc_toolchain_config_info.bzl
@@ -33,6 +33,7 @@ CcToolchainConfigInfo, _new_cc_toolchain_config_info = provider(
     fields = [
         "_action_configs_DO_NOT_USE",
         "_artifact_name_patterns_DO_NOT_USE",
+        "_default_features_and_action_configs",
         "_exec_os_DO_NOT_USE",
         "_features_DO_NOT_USE",
         "abi_libc_version",
@@ -124,9 +125,20 @@ def create_cc_toolchain_config_info(
         features = legacy_features
         action_configs = legacy_action_configs
 
+    default_features_and_action_configs = [
+        feature.name
+        for feature in features
+        if feature.enabled
+    ] + [
+        action_config.action_name
+        for action_config in action_configs
+        if action_config.enabled
+    ]
+
     return _new_cc_toolchain_config_info(
         _action_configs_DO_NOT_USE = action_configs,
         _artifact_name_patterns_DO_NOT_USE = artifact_name_patterns,
+        _default_features_and_action_configs = default_features_and_action_configs,
         _features_DO_NOT_USE = features,
         _exec_os_DO_NOT_USE = _cc_internal.exec_os(ctx),
         abi_libc_version = abi_libc_version or "",

--- a/cc/private/toolchain_config/configure_features.bzl
+++ b/cc/private/toolchain_config/configure_features.bzl
@@ -142,7 +142,7 @@ def configure_features(
     all_features = [cpp_configuration.compilation_mode()]
     all_features.extend(DEFAULT_ACTION_CONFIGS)
     all_features.extend(requested_features)
-    all_features.extend(cc_toolchain._toolchain_features.default_features_and_action_configs())
+    all_features.extend(cc_toolchain._default_features_and_action_configs)
 
     if language == "objc" or language == "objcpp":
         all_features.extend(OBJC_ACTIONS)


### PR DESCRIPTION
Compute `CcToolchainConfigInfo._default_features_and_action_configs` in `create_cc_toolchain_config_info` after legacy feature and action-config injection, preserving the native feature-before-action-config order. `CcToolchainInfo` exposes the same list to `configure_features`, which removes the call to `CcToolchainFeatures.default_features_and_action_configs()`.