### PR TITLE
Starlarkify legacy_cc_flags_make_variable_do_not_use

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -336,6 +336,8 @@ def _create_compilation_context(
     )
 
 def _legacy_cc_flags_make_variable_do_not_use(*, cc_toolchain):
+    if hasattr(cc_toolchain, "_legacy_cc_flags_make_variable"):
+        return cc_toolchain._legacy_cc_flags_make_variable
     return _cc_common_internal.legacy_cc_flags_make_variable_do_not_use(cc_toolchain = cc_toolchain)
 
 # buildifier: disable=unused-variable


### PR DESCRIPTION
`legacy_cc_flags_make_variable_do_not_use` now reads `CcToolchainInfo._legacy_cc_flags_make_variable` directly when the Starlark provider exposes that field. Bazel 7 uses a native `CcToolchainInfo` without the private field, so the wrapper retains the native implementation as a compatibility fallback.
