### PR TITLE
Cache rule feature lists

### DIFF
--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -928,11 +928,13 @@ def _expand_make_variables_for_copts(ctx, tokenization, unexpanded_tokens, addit
                 tokens.append(_expand(ctx, token, additional_make_variable_substitutions, targets = targets))
     return tokens
 
-def _get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts"):
+def _get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts", requested_features = None):
     if not hasattr(ctx.attr, attr):
         fail("could not find rule attribute named: '{}'".format(attr))
+    if requested_features == None:
+        requested_features = ctx.features
     attribute_copts = getattr(ctx.attr, attr)
-    tokenization = not (cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_copts_tokenization") or "no_copts_tokenization" in ctx.features)
+    tokenization = not (cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "no_copts_tokenization") or "no_copts_tokenization" in requested_features)
     expanded_attribute_copts = _expand_make_variables_for_copts(ctx, tokenization, attribute_copts, additional_make_variable_substitutions)
     return expanded_attribute_copts
 

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -525,9 +525,9 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
-        user_compile_flags = runtimes_copts + cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts"),
-        conly_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "conlyopts"),
-        cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts"),
+        user_compile_flags = runtimes_copts + cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts", requested_features = features),
+        conly_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "conlyopts", requested_features = features),
+        cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts", requested_features = features),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
         local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps),
         includes = cc_helper.include_dirs(ctx, additional_make_variable_substitutions),
@@ -550,7 +550,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
     link_variables = {}
 
     # Allows the dynamic library generated for code of test targets to be linked separately.
-    link_compile_output_separately = ctx.attr._is_test and linking_mode == linker_mode.LINKING_DYNAMIC and cpp_config.dynamic_mode() == "DEFAULT" and ("dynamic_link_test_srcs" in ctx.features)
+    link_compile_output_separately = ctx.attr._is_test and linking_mode == linker_mode.LINKING_DYNAMIC and cpp_config.dynamic_mode() == "DEFAULT" and ("dynamic_link_test_srcs" in features)
 
     is_windows_enabled = cc_common.is_enabled(feature_configuration = feature_configuration, feature_name = "targets_windows")
 

--- a/cc/private/rules_impl/cc_library_impl.bzl
+++ b/cc/private/rules_impl/cc_library_impl.bzl
@@ -30,10 +30,11 @@ def _cc_library_impl(ctx):
     cc_toolchain = find_cc_toolchain(ctx)
     cc_helper.report_invalid_options(cc_toolchain, ctx.fragments.cpp)
 
+    features = ctx.features
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        requested_features = ctx.features,
+        requested_features = features,
         unsupported_features = ctx.disabled_features,
     )
 
@@ -58,9 +59,9 @@ def _cc_library_impl(ctx):
         name = ctx.label.name,
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
-        user_compile_flags = runtimes_copts + cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts"),
-        conly_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "conlyopts"),
-        cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts"),
+        user_compile_flags = runtimes_copts + cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "copts", requested_features = features),
+        conly_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "conlyopts", requested_features = features),
+        cxx_flags = cc_helper.get_copts(ctx, feature_configuration, additional_make_variable_substitutions, attr = "cxxopts", requested_features = features),
         defines = cc_helper.defines(ctx, additional_make_variable_substitutions),
         local_defines = cc_helper.local_defines(ctx, additional_make_variable_substitutions) + cc_helper.get_local_defines_for_runfiles_lookup(ctx, ctx.attr.deps + ctx.attr.implementation_deps),
         includes = cc_helper.include_dirs(ctx, additional_make_variable_substitutions),

--- a/cc/private/rules_impl/objc_compilation_support.bzl
+++ b/cc/private/rules_impl/objc_compilation_support.bzl
@@ -77,7 +77,13 @@ def _build_common_variables(
         extra_enabled_features = [],
         attr_linkopts = [],
         alwayslink = False,
-        direct_cc_compilation_contexts = []):
+        direct_cc_compilation_contexts = [],
+        requested_features = None,
+        unsupported_features = None):
+    if requested_features == None:
+        requested_features = ctx.features
+    if unsupported_features == None:
+        unsupported_features = ctx.disabled_features
     compilation_attributes = _create_compilation_attributes(ctx = ctx)
     intermediate_artifacts = create_intermediate_artifacts(ctx = ctx)
     if empty_compilation_artifacts:
@@ -112,7 +118,9 @@ def _build_common_variables(
         extra_enabled_features = extra_enabled_features,
         objc_compilation_context = objc_compilation_context,
         objc_linking_context = objc_linking_context,
+        requested_features = requested_features,
         toolchain = toolchain,
+        unsupported_features = unsupported_features,
         alwayslink = alwayslink,
         use_pch = use_pch,
         objc_config = ctx.fragments.objc,
@@ -120,14 +128,12 @@ def _build_common_variables(
     )
 
 def _build_feature_configuration(common_variables, support_parse_headers):
-    ctx = common_variables.ctx
-
     enabled_features = []
-    enabled_features.extend(ctx.features)
+    enabled_features.extend(common_variables.requested_features)
     enabled_features.extend(common_variables.extra_enabled_features)
 
     disabled_features = []
-    disabled_features.extend(ctx.disabled_features)
+    disabled_features.extend(common_variables.unsupported_features)
     disabled_features.extend(common_variables.extra_disabled_features)
 
     if not support_parse_headers:

--- a/cc/private/rules_impl/objc_library.bzl
+++ b/cc/private/rules_impl/objc_library.bzl
@@ -55,7 +55,14 @@ def _objc_library_impl(ctx):
     _validate_attributes(srcs = ctx.attr.srcs, non_arc_srcs = ctx.attr.non_arc_srcs, label = ctx.label)
 
     cc_toolchain = find_cc_toolchain(ctx)
-    semantics.check_toolchain_supports_objc_compile(ctx, cc_toolchain)
+    requested_features = ctx.features
+    unsupported_features = ctx.disabled_features
+    semantics.check_toolchain_supports_objc_compile(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
+    )
 
     common_variables = compilation_support.build_common_variables(
         ctx = ctx,
@@ -65,6 +72,8 @@ def _objc_library_impl(ctx):
         implementation_deps = ctx.attr.implementation_deps,
         attr_linkopts = ctx.attr.linkopts,
         alwayslink = cc.target_should_alwayslink(ctx),
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
     )
     files = []
     if common_variables.compilation_artifacts.archive != None:
@@ -90,8 +99,8 @@ def _objc_library_impl(ctx):
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
     )
     instrumented_files_info = coverage_common.instrumented_files_info(
         ctx = ctx,

--- a/cc/private/rules_impl/objc_semantics.bzl
+++ b/cc/private/rules_impl/objc_semantics.bzl
@@ -16,13 +16,17 @@
 
 load("//cc/common:cc_common.bzl", "cc_common")
 
-def _check_toolchain_supports_objc_compile(ctx, cc_toolchain):
+def _check_toolchain_supports_objc_compile(ctx, cc_toolchain, requested_features = None, unsupported_features = None):
+    if requested_features == None:
+        requested_features = ctx.features
+    if unsupported_features == None:
+        unsupported_features = ctx.disabled_features
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
         language = "objc",
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
+        requested_features = requested_features,
+        unsupported_features = unsupported_features,
     )
 
     if not cc_common.action_is_enabled(


### PR DESCRIPTION
## Summary

`ctx.features` and `ctx.disabled_features` allocate a new list on every access. Cache those lists in `cc_binary`, `cc_library`, `objc_library`, and `objc_import`, then pass the cached lists through the existing feature-configuration helpers.

This reduces `ctx.features` accesses from up to five to one for `cc_binary`/`cc_test`, from up to four to one for `cc_library`, and reduces both property accesses from four to one for `objc_library` and from two to one for `objc_import`. Optional helper arguments preserve behavior for existing external callers.

## Validation

- `buildifier -mode=check` on all changed Starlark files
- `bazel test --jobs=4 --test_output=errors //tests/cc/common:cc_common_tests //tests/cc/common:cc_binary_configured_target_tests //tests/cc/common:cc_objc_library_configured_target_tests`
