### PR TITLE
[codex] Remove the legacy whole-archive heuristic

### DIFF
--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -98,13 +98,7 @@ def finalize_link_action(
     Returns:
       None
     """
-    need_whole_archive = whole_archive or _need_whole_archive(
-        feature_configuration,
-        linking_mode,
-        link_type,
-        user_link_flags,
-        cc_toolchain._cpp_configuration,
-    )
+    need_whole_archive = whole_archive
 
     must_keep_debug = any([lib._must_keep_debug for lib in libraries_to_link])
 
@@ -417,43 +411,6 @@ def _can_split_command_line(
         return feature_configuration.is_enabled("archive_param_file")
 
     # This should be unreachable:
-    return False
-
-def _need_whole_archive(feature_configuration, linking_mode, link_type, linkopts, cpp_config):
-    """The default heuristic on whether we need to use whole-archive for the link."""
-    shared_linkopts = is_dynamic_library(link_type) or "-shared" in linkopts or "-shared" in cpp_config.linkopts
-
-    # Fasten your seat belt, the logic below doesn't make perfect sense and it's full of obviously
-    # missed corner cases. The world still stands and depends on this behavior, so ¯\_(ツ)_/¯.
-    if not shared_linkopts:
-        # We are not producing shared library, there is no reason to use --whole-archive with
-        # executable (if the executable doesn't use the symbols, nobody else will, so --whole-archive
-        # is not needed).
-        return False
-
-    if feature_configuration.is_requested("force_no_whole_archive"):
-        return False
-
-    if cpp_config.incompatible_remove_legacy_whole_archive():
-        # --incompatible_remove_legacy_whole_archive has been flipped, no --whole-archive for the
-        # entire build.
-        return False
-
-    if linking_mode != LINKING_MODE.STATIC:
-        # legacy whole archive only applies to static linking mode.
-        return False
-
-    if feature_configuration.is_requested("legacy_whole_archive"):
-        # --incompatible_remove_legacy_whole_archive has not been flipped, and this target requested
-        # --whole-archive using features.
-        return True
-
-    if cpp_config.legacy_whole_archive():
-        # --incompatible_remove_legacy_whole_archive has not been flipped, so whether to
-        # use --whole-archive depends on --legacy_whole_archive.
-        return True
-
-    # Hopefully future default.
     return False
 
 def _quote_replacement(s):

--- a/tests/integration/cc_shared_library_tests.sh
+++ b/tests/integration/cc_shared_library_tests.sh
@@ -100,7 +100,6 @@ cc_shared_library(
 EOF
 
   bazel build \
-    --noincompatible_remove_legacy_whole_archive \
     --experimental_cc_shared_library \
     //foo:foo_shared >& "${TEST_log}" || fail "Expected build to succeed"
 


### PR DESCRIPTION
`--incompatible_remove_legacy_whole_archive` was introduced disabled in Bazel in February 2019 by [e5735fd27d](https://github.com/bazelbuild/bazel/commit/e5735fd27d7ab72ef1793a10977316b4bdf52020) and enabled by default in September 2019 by [799328f8e0](https://github.com/bazelbuild/bazel/commit/799328f8e02c891376853c31129ac723a7914c51). The legacy rules_cc heuristic has therefore been disabled by default since Bazel 1.0.

This removes `_need_whole_archive` and uses the explicit `whole_archive` request directly. Explicit `whole_archive` requests and `alwayslink` libraries continue to set `is_whole_archive`.

The Bazel option cleanup is [bazelbuild/bazel#29939](https://github.com/bazelbuild/bazel/pull/29939).

Validation: `buildifier -mode=check cc/private/link/finalize_link_action.bzl`, `bash -n tests/integration/cc_shared_library_tests.sh`, and `bazel test --jobs=3 --disk_cache=/private/tmp/bazel-pr-disk-cache //tests/cc/common:cc_common_tests //tests/alwayslink_srcs:alwayslink_test`. The edited `cc_shared_library_tests` target is Linux-only and is intentionally incompatible with the macOS host platform.
