### PR TITLE
Remove deprecated macOS install-name fragment lookup

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -940,7 +940,7 @@ def _impl(ctx):
         )
         set_install_name_feature = feature(
             name = "set_install_name",
-            enabled = getattr(ctx.fragments.cpp, "do_not_use_macos_set_install_name", True),
+            enabled = True,
             flag_sets = [
                 flag_set(
                     actions = [


### PR DESCRIPTION
## Summary

Enable the Darwin `set_install_name` toolchain feature unconditionally and stop reading the private `ctx.fragments.cpp.do_not_use_macos_set_install_name` field.

The field lookup entered rules_cc in October 2024 in c2549f6 when the Unix C++ toolchain configuration moved from Bazel. Bazel enabled `--incompatible_macos_set_install_name` by default in Bazel 8 and moved the option to the graveyard in March 2025 in bazelbuild/bazel@b9db4602affe5a45d776eb78f215e11a86ab3b24. This change adopts that behavior for rules_cc users on Bazel 7 as well, including users that explicitly set the old flag to false, and removes the last dependency that prevents Bazel from deleting the private field.

## Validation

- `buildifier -mode=check cc/private/toolchain/unix_cc_toolchain_config.bzl`
- `bazel test //tests/cc/common:cc_binary_configured_target_tests` (57 tests passed)
