### PR TITLE
Replace confusing is_dynamic_link_type parameter

### DIFF
--- a/cc/common/cc_helper.bzl
+++ b/cc/common/cc_helper.bzl
@@ -86,18 +86,13 @@ def _get_base_name(name):
         return name
     return name[last_slash + 1:]
 
-def _get_artifact_name_for_category(cc_toolchain, is_dynamic_link_type, output_name):
-    linked_artifact_category = None
-    if is_dynamic_link_type:
-        linked_artifact_category = artifact_category.DYNAMIC_LIBRARY
-    else:
-        linked_artifact_category = artifact_category.EXECUTABLE
-
-    return cc_common.get_artifact_name_for_category(cc_toolchain = cc_toolchain, category = linked_artifact_category, output_name = output_name)
-
-def _get_linked_artifact(ctx, cc_toolchain, is_dynamic_link_type):
+def _get_linked_artifact(ctx, cc_toolchain, linked_artifact_category):
     name = ctx.label.name
-    new_name = _get_artifact_name_for_category(cc_toolchain, is_dynamic_link_type, _get_base_name(name))
+    new_name = cc_common.get_artifact_name_for_category(
+        cc_toolchain = cc_toolchain,
+        category = linked_artifact_category,
+        output_name = _get_base_name(name),
+    )
     name = _replace_name(name, new_name)
 
     return ctx.actions.declare_file(name)

--- a/cc/private/rules_impl/cc_binary_impl.bzl
+++ b/cc/private/rules_impl/cc_binary_impl.bzl
@@ -18,7 +18,7 @@ load("//cc:cc_postmark.bzl", "postmark")
 load("//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("//cc/common:cc_common.bzl", "cc_common")
 load("//cc/common:cc_debug_helper.bzl", "create_debug_packager_actions")
-load("//cc/common:cc_helper.bzl", "cc_helper", "linker_mode")
+load("//cc/common:cc_helper.bzl", "artifact_category", "cc_helper", "linker_mode")
 load("//cc/common:cc_info.bzl", "CcInfo")
 load("//cc/common:debug_package_info.bzl", "DebugPackageInfo")
 load("//cc/common:semantics.bzl", "semantics")
@@ -466,11 +466,10 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
 
     precompiled_files = cc_helper.build_precompiled_files(ctx)
     link_target_type = _EXECUTABLE
+    linked_artifact_category = artifact_category.EXECUTABLE
     if _is_link_shared(ctx):
         link_target_type = _DYNAMIC_LIBRARY
-    is_dynamic_link_type = True
-    if link_target_type == _EXECUTABLE:
-        is_dynamic_link_type = False
+        linked_artifact_category = artifact_category.DYNAMIC_LIBRARY
     semantics.validate_attributes(ctx)
 
     # TODO(b/198254254): Fill in empty providers if needed.
@@ -491,7 +490,7 @@ def cc_binary_impl(ctx, additional_linkopts, force_linkstatic = False):
         binary = cc_helper.get_linked_artifact(
             ctx = ctx,
             cc_toolchain = cc_toolchain,
-            is_dynamic_link_type = is_dynamic_link_type,
+            linked_artifact_category = linked_artifact_category,
         )
     linking_mode = _get_link_staticness(
         ctx,


### PR DESCRIPTION
This was ambiguous for if the binary was being linked dynamically vs
statically or if it was creating a shared library. Really all this
function cares about is the artifact_category so we can just pass that
ourselves.
