### PR TITLE
Remove unnecessary transition flag that fails @ HEAD

### DIFF
--- a/tests/cc/common/cc_binary_thin_lto_tests.bzl
+++ b/tests/cc/common/cc_binary_thin_lto_tests.bzl
@@ -1099,7 +1099,6 @@ def _test_lto_standalone_command_lines(name, **kwargs):
         test_features = ["thin_lto", "supports_pic", "supports_start_end_lib"],
         config_settings = {
             "//command_line_option:ltoindexopt": ["anltoindexopt"],
-            "//command_line_option:incompatible_make_thinlto_command_lines_standalone": "true",
         },
         **kwargs
     )


### PR DESCRIPTION
Added in a7a6249dccf0f8427c117f6a02e3752f379e19a4 which fails on public CI

```
(17:41:52) ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/rules_testing+/lib/private/analysis_test.bzl:259:57: transition outputs [//command_line_option:incompatible_make_thinlto_command_lines_standalone] do not correspond to valid settings
(17:41:52) ERROR: /workdir/tests/cc/common/BUILD:13:25: on dependency edge //tests/cc/common:test_lto_standalone_command_lines (8c20d50) -|target|-> //tests/cc/common:test_lto_standalone_command_lines/bin: Errors encountered while applying Starlark transition
```

https://github.com/bazelbuild/bazel/commit/1e15e28708810397ca73742905616d34e70a3227
