### PR TITLE
Add -mmacosx-version-min back to default toolchain

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -35,6 +35,11 @@ load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")
 load("@rules_cc//cc/toolchains:feature_injection.bzl", "FeatureInfo", "convert_feature")
 
+def _target_os_version(ctx):
+    platform_type = ctx.fragments.apple.single_arch_platform.platform_type
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    return xcode_config.minimum_os_for_platform_type(platform_type)
+
 def layering_check_features(compiler, extra_flags_per_feature, is_macos):
     if compiler != "clang":
         return []
@@ -1780,6 +1785,19 @@ def _impl(ctx):
         ],
     )
 
+    # If you have Xcode + the CLT installed the version defaults can be
+    # too old for some standard C apis such as thread locals
+    macos_minimum_os_feature = feature(
+        name = "macos_minimum_os",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions + all_link_actions,
+                flag_groups = [flag_group(flags = ["-mmacosx-version-min={}".format(_target_os_version(ctx))])],
+            ),
+        ],
+    )
+
     macos_reproducible_feature = feature(
         name = "macos_reproducible",
         enabled = "macos_reproducible" in ctx.features,
@@ -1961,6 +1979,7 @@ def _impl(ctx):
             cpp_modules_feature,
             cpp_module_modmap_file_feature,
             cpp20_module_compile_flags_feature,
+            macos_minimum_os_feature,
             macos_reproducible_feature,
             macos_default_link_flags_feature,
             dependency_file_feature,
@@ -2083,7 +2102,11 @@ This is only offered as a migration bridge for projects transitioning to rule-ba
         "_use_libtool_on_macos": attr.label(
             default = "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos",
         ),
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
     },
-    fragments = ["cpp"],
+    fragments = ["apple", "cpp"],
     provides = [CcToolchainConfigInfo],
 )

--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -36,9 +36,8 @@ load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfig
 load("@rules_cc//cc/toolchains:feature_injection.bzl", "FeatureInfo", "convert_feature")
 
 def _target_os_version(ctx):
-    platform_type = ctx.fragments.apple.single_arch_platform.platform_type
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
-    return xcode_config.minimum_os_for_platform_type(platform_type)
+    return xcode_config.minimum_os_for_platform_type(apple_common.platform_type.macos)
 
 def layering_check_features(compiler, extra_flags_per_feature, is_macos):
     if compiler != "clang":
@@ -2107,6 +2106,6 @@ This is only offered as a migration bridge for projects transitioning to rule-ba
             name = "xcode_config_label",
         )),
     },
-    fragments = ["apple", "cpp"],
+    fragments = ["cpp"],
     provides = [CcToolchainConfigInfo],
 )


### PR DESCRIPTION
Without this compiler behavior is non-heremetic based on the host OS
version

This reverts commit 2d10ebab2b9d40ecdff973921709d5986c33f728.
