### PR TITLE
Add action_command_line_test rule

### DIFF
--- a/tests/cc/common/BUILD
+++ b/tests/cc/common/BUILD
@@ -1,3 +1,5 @@
+load("//cc:defs.bzl", "cc_library")
+load(":action_command_line_test_test.bzl", "mock_toolchain_action_command_line_test")
 load(":cc_binary_configured_target_tests.bzl", "cc_binary_configured_target_tests")
 load(":cc_binary_thin_lto_tests.bzl", "cc_binary_thin_lto_tests")
 load(":cc_common_test.bzl", "cc_common_tests")
@@ -7,6 +9,27 @@ load(":cc_library_configured_target_tests.bzl", "cc_library_configured_target_te
 load(":cc_objc_library_configured_target_tests.bzl", "cc_objc_library_configured_target_tests")
 load(":debug_info_packaging_test.bzl", "debug_info_packaging_tests")
 load(":link_build_variables_test.bzl", "link_build_variables_tests")
+
+cc_library(
+    name = "action_command_line_test_subject",
+    testonly = True,
+    srcs = ["action_command_line_test_subject.cc"],
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+mock_toolchain_action_command_line_test(
+    name = "action_command_line_test_test",
+    expected_argv = [
+        "/usr/bin/mock-gcc",
+        "--default-compile-flag",
+        "<flag>",
+    ],
+    mnemonic = "CppCompile",
+    not_expected_argv = ["-ldefault-link-flag"],
+    target_under_test = ":action_command_line_test_subject",
+    visibility = ["//visibility:private"],
+)
 
 cc_binary_configured_target_tests(name = "cc_binary_configured_target_tests")
 

--- a/tests/cc/common/action_command_line_test_subject.cc
+++ b/tests/cc/common/action_command_line_test_subject.cc
@@ -1,0 +1,15 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int action_command_line_test_subject;

--- a/tests/cc/common/action_command_line_test_test.bzl
+++ b/tests/cc/common/action_command_line_test_test.bzl
@@ -1,0 +1,36 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for action_command_line_test."""
+
+load("//tests/cc/testutil:action_command_line_test.bzl", "make_action_command_line_test_rule")
+load("//tests/cc/testutil/toolchains:features.bzl", "FEATURE_NAMES")
+
+visibility("private")
+
+_MOCK_TOOLCHAINS = [
+    "//tests/cc/testutil/toolchains:cc-toolchain-k8-compiler",
+    "//tests/cc/testutil/toolchains:cc-toolchain-macos-compiler",
+]
+
+_WITH_FEATURES = str(Label("//tests/cc/testutil/toolchains:with_features"))
+
+mock_toolchain_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "fastbuild",
+        "//command_line_option:extra_toolchains": ",".join(_MOCK_TOOLCHAINS),
+        "//command_line_option:features": [FEATURE_NAMES.simple_compile_feature],
+        _WITH_FEATURES: [FEATURE_NAMES.simple_compile_feature],
+    },
+)

--- a/tests/cc/common/action_command_line_test_test.bzl
+++ b/tests/cc/common/action_command_line_test_test.bzl
@@ -28,6 +28,7 @@ _WITH_FEATURES = str(Label("//tests/cc/testutil/toolchains:with_features"))
 
 mock_toolchain_action_command_line_test = make_action_command_line_test_rule(
     config_settings = {
+        "//command_line_option:collect_code_coverage": "false",
         "//command_line_option:compilation_mode": "fastbuild",
         "//command_line_option:extra_toolchains": ",".join(_MOCK_TOOLCHAINS),
         "//command_line_option:features": [FEATURE_NAMES.simple_compile_feature],

--- a/tests/cc/testutil/action_command_line_test.bzl
+++ b/tests/cc/testutil/action_command_line_test.bzl
@@ -1,0 +1,159 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for testing the contents of action command lines."""
+
+load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "unittest")
+
+visibility("//tests/...")
+
+def _action_command_line_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    # Find the desired action and verify that there is exactly one.
+    actions = analysistest.target_actions(env)
+    mnemonic = ctx.attr.mnemonic
+    matching_actions = [
+        action
+        for action in actions
+        if action.mnemonic == mnemonic
+    ]
+    if not matching_actions:
+        actual_mnemonics = collections.uniq(
+            [action.mnemonic for action in actions],
+        )
+        unittest.fail(
+            env,
+            ("Target '{}' registered no actions with the mnemonic '{}' " +
+             "(it had {}).").format(
+                str(target_under_test.label),
+                mnemonic,
+                actual_mnemonics,
+            ),
+        )
+        return analysistest.end(env)
+    if len(matching_actions) != 1 and ctx.attr.argv_filter:
+        matching_actions = [
+            action
+            for action in matching_actions
+            if ctx.attr.argv_filter + " " in " ".join(action.argv) + " "
+        ]
+    if len(matching_actions) != 1:
+        unittest.fail(
+            env,
+            ("Expected exactly one action with the mnemonic '{}', " +
+             "but found {}.").format(
+                mnemonic,
+                len(matching_actions),
+            ),
+        )
+        return analysistest.end(env)
+
+    action = matching_actions[0]
+    message_prefix = "In {} action for target '{}', ".format(
+        mnemonic,
+        str(target_under_test.label),
+    )
+
+    # Concatenate the arguments into a single string so that we can easily look
+    # for subsequences of arguments. Note that we append an extra space to the
+    # end and look for arguments followed by a trailing space so that having
+    # `-foo` in the expected list doesn't match `-foobar`, for example.
+    concatenated_args = " ".join(action.argv) + " "
+    bin_dir = analysistest.target_bin_dir_path(env)
+    remaining = concatenated_args
+    for expected in ctx.attr.expected_argv:
+        expected = expected.replace("$(BIN_DIR)", bin_dir).replace("$(WORKSPACE_NAME)", ctx.workspace_name)
+        space_pos = remaining.find(expected + " ")
+        eq_pos = remaining.find(expected + "=")
+        if space_pos == -1 and eq_pos == -1:
+            unittest.fail(
+                env,
+                "{}expected argv to contain '{}' (in order), but it was not found in remaining args: {}\nFull args: {}".format(
+                    message_prefix,
+                    expected,
+                    remaining,
+                    concatenated_args,
+                ),
+            )
+        elif space_pos != -1 and (eq_pos == -1 or space_pos <= eq_pos):
+            remaining = remaining[space_pos + len(expected) + 1:]
+        else:
+            remaining = remaining[eq_pos + len(expected) + 1:]
+    for not_expected in ctx.attr.not_expected_argv:
+        not_expected = not_expected.replace("$(BIN_DIR)", bin_dir).replace("$(WORKSPACE_NAME)", ctx.workspace_name)
+        if not_expected + " " in concatenated_args or not_expected + "=" in concatenated_args:
+            unittest.fail(
+                env,
+                "{}expected argv to not contain '{}', but it did: {}".format(
+                    message_prefix,
+                    not_expected,
+                    concatenated_args,
+                ),
+            )
+
+    return analysistest.end(env)
+
+def make_action_command_line_test_rule(config_settings = {}):
+    """Returns a new `action_command_line_test`-like rule with custom configs.
+
+    Args:
+        config_settings: A dictionary of configuration settings and their values
+            that should be applied during tests.
+
+    Returns:
+        A rule returned by `analysistest.make` that has the
+        `action_command_line_test` interface and the given config settings.
+    """
+    return analysistest.make(
+        _action_command_line_test_impl,
+        attrs = {
+            "expected_argv": attr.string_list(
+                mandatory = False,
+                doc = """\
+A list of strings representing substrings expected to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+            ),
+            "not_expected_argv": attr.string_list(
+                mandatory = False,
+                doc = """\
+A list of strings representing substrings expected not to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+            ),
+            "mnemonic": attr.string(
+                mandatory = True,
+                doc = """\
+The mnemonic of the action to be inspected on the target under test. It is
+expected that there will be exactly one of these.
+""",
+            ),
+            "argv_filter": attr.string(
+                doc = """\
+If set, when multiple actions match the mnemonic, select the action whose
+argv contains this string. Useful when a config like --save_temps produces
+multiple actions with the same mnemonic.
+""",
+            ),
+        },
+        config_settings = config_settings,
+    )
+
+# A default instantiation of the rule when no custom config settings are needed.
+action_command_line_test = make_action_command_line_test_rule()


### PR DESCRIPTION
This is copied originally from rules_swift, it lets us write simple
tests asserting things about command line behavior of actions, which is
often a nice fit for making sure actions get the args we expect to be
threaded through.
