### PR TITLE
Pass use_pic when creating module codegen actions

### DIFF
--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -2080,6 +2080,7 @@ def _create_module_codegen_action(
         needs_include_validation = _starlark_cc_semantics.needs_include_validation(language),
         toolchain_type = _starlark_cc_semantics.toolchain,
         progress_message_prefix = progress_message_prefix,
+        use_pic = use_pic,
     )
     if use_pic:
         outputs["pic_objects"].append(object_file)


### PR DESCRIPTION
Module codegen actions (`header_module_codegen`) compile a module file into an object file. `_create_module_codegen_action` computes `use_pic` from the module file's name but didn't forward it to `_create_compile_action`, so Bazel's `CppCompileActionBuilder` treats the action as non-PIC even for PIC module files — and e.g. looks up the non-PIC transitive modules as mandatory inputs, which are empty in PIC-only builds.

