### PR TITLE
Move the cc_runtimes toolchain type into rules_cc

### DIFF
--- a/cc/BUILD
+++ b/cc/BUILD
@@ -49,6 +49,15 @@ alias(
     actual = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
+# The toolchain type for C++ runtimes toolchains, which provide libraries
+# (such as the C++ standard library) that are implicitly depended on by all
+# C++ targets. Lives in rules_cc rather than @bazel_tools so that it is
+# available independently of the Bazel version.
+toolchain_type(
+    name = "cc_runtimes_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "action_names_test_files",
     testonly = True,

--- a/cc/common/cc_helper_internal.bzl
+++ b/cc/common/cc_helper_internal.bzl
@@ -43,7 +43,7 @@ def wrap_with_check_private_api(symbol):
 CPP_SOURCE_TYPE_HEADER = "HEADER"
 CPP_SOURCE_TYPE_SOURCE = "SOURCE"
 CPP_SOURCE_TYPE_CLIF_INPUT_PROTO = "CLIF_INPUT_PROTO"
-CC_RUNTIMES_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:cc_runtimes_toolchain_type")
+CC_RUNTIMES_TOOLCHAIN_TYPE = Label("//cc:cc_runtimes_toolchain_type")
 
 def get_cc_runtimes(ctx, is_library):
     """Returns the list of C++ runtime dependency targets for the rule.
@@ -70,12 +70,13 @@ def get_cc_runtimes(ctx, is_library):
 
     cc_runtimes_toolchain = ctx.toolchains[CC_RUNTIMES_TOOLCHAIN_TYPE]
 
-    # All builds include the runtimes from the cc_runtimes_toolchain.
-    if cc_runtimes_toolchain:
-        runtimes += cc_runtimes_toolchain.cc_runtimes_info.runtimes
-    elif hasattr(ctx.attr, "tags") and "__CC_STL__" in ctx.attr.tags:
+    if hasattr(ctx.attr, "tags") and "__CC_STL__" in ctx.attr.tags:
+        # Targets that are part of the runtimes must not depend on them.
         # TODO(b/141613846): Remove this workaround.
         pass
+    elif cc_runtimes_toolchain:
+        # All other builds include the runtimes from the cc_runtimes_toolchain.
+        runtimes += cc_runtimes_toolchain.cc_runtimes_info.runtimes
     elif getattr(ctx.attr, "_stl", None) != None:
         runtimes.append(ctx.attr._stl)
 


### PR DESCRIPTION
The `cc_runtimes` toolchain allows a C++ toolchain to provide libraries (such as the C++ standard library) that all C++ targets implicitly depend on — the open-sourced version of the internal `_stl` mechanism. Two changes to make it usable outside of Google:

1. **Define the toolchain type in rules_cc**: `get_cc_runtimes` references `@bazel_tools//tools/cpp:cc_runtimes_toolchain_type`, which ties its availability to the Bazel version — with Bazel versions whose `bazel_tools` doesn't define that target, the C++ rules fail to load outright. The toolchain type now lives in rules_cc (`//cc:cc_runtimes_toolchain_type`), independent of the Bazel version.
2. **Honor `__CC_STL__` also when a runtimes toolchain is registered**: the runtimes provided by the toolchain are added to every C++ target, including the runtime libraries themselves, which creates a dependency cycle. The existing `__CC_STL__` tag escape hatch previously only applied when no runtimes toolchain was registered.

Remaining gap (out of scope here, happy to follow up): there is no public rule for the toolchain side yet — providing `ToolchainInfo(cc_runtimes_info = ...)` currently requires a hand-written rule, and the internal `cc_runtimes_library`/`cc_runtimes_toolchain` counterparts aren't open-sourced.

Context: I maintain a hermetic LLVM toolchain that exposes libc++ as a header-modules-enabled `cc_library` (matching Google's setup) and would like to attach it via a `cc_runtimes` toolchain instead of explicit deps once this mechanism works in OSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NHAZPGN2yMMnKAwZaQAem
