### PR TITLE
Fix local_includes with implementation_deps

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -677,6 +677,7 @@ def _init_cc_compilation_context(
             external_includes = depset(external_include_dirs),
             system_includes = depset(system_include_dirs_for_context),
             includes = depset(include_dirs_for_context),
+            local_includes = depset(local_includes),
             virtual_to_original_headers = depset(virtual_to_original_headers),
             dependent_cc_compilation_contexts = dependent_cc_compilation_contexts + implementation_deps,
             non_code_inputs = additional_inputs,

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -689,6 +689,7 @@ def _init_cc_compilation_context(
             external_includes = depset(external_include_dirs),
             system_includes = depset(system_include_dirs_for_context),
             includes = depset(include_dirs_for_context),
+            local_includes = depset(local_includes),
             virtual_to_original_headers = depset(virtual_to_original_headers),
             dependent_cc_compilation_contexts = dependent_cc_compilation_contexts + implementation_deps,
             non_code_inputs = additional_inputs,

--- a/tests/local_includes/local_includes_test.bzl
+++ b/tests/local_includes/local_includes_test.bzl
@@ -36,3 +36,21 @@ def local_includes_test(name):
         ],
         deps = [":" + name + "_lib"],
     )
+
+    cc_library(
+        name = name + "_implementation_deps_lib",
+        srcs = [
+            "binary.c",
+            "binary_helper.c",
+            "private/binary_helper.h",
+        ],
+        local_includes = [
+            "private",
+        ],
+        implementation_deps = [":" + name + "_lib"],
+    )
+
+    cc_test(
+        name = name + "_implementation_deps",
+        deps = [":" + name + "_implementation_deps_lib"],
+    )

--- a/tests/local_includes/local_includes_test.bzl
+++ b/tests/local_includes/local_includes_test.bzl
@@ -5,6 +5,11 @@ load("//cc:cc_library.bzl", "cc_library")
 load("//cc:cc_test.bzl", "cc_test")
 
 def local_includes_test(name):
+    """Tests for the local_includes attribute.
+
+    Args:
+        name: The prefix of the test targets.
+    """
     if not bazel_features.cc.cc_common_is_in_rules_cc:
         return
 


### PR DESCRIPTION
This separate codepath was missing this attr

https://github.com/bazelbuild/rules_cc/commit/ab84bd3287a17631bd6c534d85c517e58d84cb3b
