### PR TITLE
Enable set_soname by default

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -923,6 +923,7 @@ def _impl(ctx):
         )
         set_install_name_feature = feature(
             name = "set_soname",
+            enabled = True,
             flag_sets = [
                 flag_set(
                     actions = [

--- a/cc/toolchains/args/soname_flags/BUILD
+++ b/cc/toolchains/args/soname_flags/BUILD
@@ -3,36 +3,19 @@ load("//cc/toolchains:feature.bzl", "cc_feature")
 
 cc_feature(
     name = "feature",
+    args = [":set_soname_args"],
+    feature_name = "set_soname",  # Feature name is important and read by rules_cc
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "set_soname_args",
+    actions = ["//cc/toolchains/actions:dynamic_library_link_actions"],
     args = select({
-        "//cc/settings:apple_constraint": [":apple_set_install_name"],
+        "//cc/settings:apple_constraint": ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
+        "@platforms//os:linux": ["-Wl,-soname,{runtime_solib_name}"],
         "//conditions:default": [],
     }),
-    feature_name = "_soname_flags",  # Doesn't override legacy feature, but shouldn't be disabled
-    visibility = ["//visibility:public"],
-)
-
-cc_args(
-    name = "apple_set_install_name",
-    actions = ["//cc/toolchains/actions:dynamic_library_link_actions"],
-    args = ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
     format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
-    target_compatible_with = ["//cc/settings:apple_constraint"],
-)
-
-cc_feature(
-    name = "set_soname_feature",
-    args = [":set_soname"],
-    feature_name = "set_soname",
-    visibility = ["//visibility:public"],
-)
-
-cc_args(
-    name = "set_soname",
-    actions = ["//cc/toolchains/actions:dynamic_library_link_actions"],
-    args = ["-Wl,-soname,{runtime_solib_name}"],
-    format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
-    requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
-    target_compatible_with = ["@platforms//os:linux"],
-    visibility = ["//visibility:public"],
 )

--- a/cc/toolchains/args/soname_flags/BUILD
+++ b/cc/toolchains/args/soname_flags/BUILD
@@ -1,21 +1,45 @@
 load("//cc/toolchains:args.bzl", "cc_args")
 load("//cc/toolchains:feature.bzl", "cc_feature")
+load("//cc/toolchains:feature_set.bzl", "cc_feature_set")
+
+cc_feature_set(
+    name = "feature",
+    all_of = select({
+        "//cc/settings:apple_constraint": [":set_install_name_feature"],
+        "@platforms//os:linux": [":set_soname_feature"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+)
 
 cc_feature(
-    name = "feature",
-    args = [":set_soname_args"],
+    name = "set_install_name_feature",
+    args = [":apple_set_install_name"],
+    feature_name = "set_install_name",  # Doesn't override legacy feature, but shouldn't be disabled, mirrors default toolchain name
+)
+
+cc_args(
+    name = "apple_set_install_name",
+    actions = ["//cc/toolchains/actions:dynamic_library_link_actions"],
+    args = ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
+    format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
+    requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
+    target_compatible_with = ["//cc/settings:apple_constraint"],
+)
+
+cc_feature(
+    name = "set_soname_feature",
+    args = [":set_soname"],
     feature_name = "set_soname",  # Feature name is important and read by rules_cc
     visibility = ["//visibility:public"],
 )
 
 cc_args(
-    name = "set_soname_args",
+    name = "set_soname",
     actions = ["//cc/toolchains/actions:dynamic_library_link_actions"],
-    args = select({
-        "//cc/settings:apple_constraint": ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
-        "@platforms//os:linux": ["-Wl,-soname,{runtime_solib_name}"],
-        "//conditions:default": [],
-    }),
+    args = ["-Wl,-soname,{runtime_solib_name}"],
     format = {"runtime_solib_name": "//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "//cc/toolchains/variables:runtime_solib_name",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
 )

--- a/tests/builtins_bzl/cc/cc_shared_library/test/BUILD
+++ b/tests/builtins_bzl/cc/cc_shared_library/test/BUILD
@@ -410,7 +410,11 @@ filegroup(
 
 cc_shared_library(
     name = "renamed_so_file",
-    features = ["windows_export_all_symbols"],
+    features = [
+        # This library is copied to a different basename above.
+        "-set_soname",
+        "windows_export_all_symbols",
+    ],
     shared_lib_name = "renamed_so_file.so",
     deps = [
         ":direct_so_file_cc_lib2",


### PR DESCRIPTION
This was already the case for macOS, and doesn't always matter for
Linux, but when it does, this being not set is always wrong. If users
are overwriting this today with linkopts or post processing, this
shouldn't affect them.
