### PR TITLE
Remove easy instances of actions2ctx_cheat

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -405,10 +405,7 @@ def _create_module_map_action(
     actions.write(module_map.file, content = content, is_executable = True, mnemonic = "CppModuleMap")
 
 def _init_cc_compilation_context(
-        # DO NOT use ctx, this is a temporary placeholder
-        # to avoid adding a new field to CcCompilationHelper.
-        # Once compile is in Starlark we can directly pass in actions here.
-        ctx,
+        actions,
         binfiles_dir,
         genfiles_dir,
         label,
@@ -438,9 +435,6 @@ def _init_cc_compilation_context(
         deps,
         implementation_deps,
         additional_cpp_module_maps):
-    # Single usage of ctx.
-    actions = ctx.actions
-
     # Setup the include path; local include directories come before those inherited from deps or
     # from the toolchain; in case of aliasing (same include file found on different entries),
     # prefer the local include rather than the inherited one.

--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -225,7 +225,7 @@ def compile(
     if additional_module_maps == None:
         additional_module_maps = []
 
-    label = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name)
+    label = ctx.label.same_package_label(name)
     fdo_context = cc_toolchain._fdo_context
 
     use_pic_for_dynamic_libraries = _use_pic_for_dynamic_libs(cpp_configuration, feature_configuration)
@@ -248,7 +248,6 @@ def compile(
     language_normalized = "c++" if language == None else language
     language_normalized = language_normalized.replace("+", "p").upper()
     source_category = SOURCE_CATEGORY_CC if language_normalized == "CPP" else SOURCE_CATEGORY_CC_AND_OBJC
-    ctx = _cc_internal.actions2ctx_cheat(actions)
     if type(includes) == "depset":
         includes = includes.to_list()
     textual_hdrs_list = textual_hdrs.to_list() if type(textual_hdrs) == "depset" else textual_hdrs
@@ -283,7 +282,7 @@ def compile(
     private_hdrs_artifacts = _to_file_list(private_hdrs)
 
     public_compilation_context, implementation_deps_context = cc_compilation_helper.init_cc_compilation_context(
-        ctx = ctx,
+        actions = actions,
         binfiles_dir = ctx.bin_dir.path,
         genfiles_dir = ctx.genfiles_dir.path,
         label = label,

--- a/cc/private/link/create_linking_context_from_compilation_outputs.bzl
+++ b/cc/private/link/create_linking_context_from_compilation_outputs.bzl
@@ -121,10 +121,21 @@ def create_linking_context_from_compilation_outputs(
         linked_dll_name_suffix = linked_dll_name_suffix,
     )
 
+    library_to_link = cc_linking_outputs.library_to_link
+    if library_to_link:
+        # All library files are declared by the target calling this function, so their owner label
+        # is the label of that target and can be used to recover the package.
+        produced_file = (library_to_link.static_library or library_to_link.pic_static_library or
+                         library_to_link.dynamic_library or library_to_link.interface_library)
+        owner = produced_file.owner.same_package_label(name)
+    else:
+        # TODO(b/331164666): remove cheat; no file is produced only if both
+        # disallow_static_libraries and disallow_dynamic_library are set.
+        owner = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name)
+
     linker_input = create_linker_input(
-        # TODO(b/331164666): remove cheat, we always produce a file, file.owner gives us a label
-        owner = _cc_internal.actions2ctx_cheat(actions).label.same_package_label(name),
-        libraries = depset([cc_linking_outputs.library_to_link] if cc_linking_outputs.library_to_link else []),
+        owner = owner,
+        libraries = depset([library_to_link] if library_to_link else []),
         user_link_flags = user_link_flags,
         additional_inputs = additional_inputs,
     )

--- a/cc/private/link/lto_indexing_action.bzl
+++ b/cc/private/link/lto_indexing_action.bzl
@@ -15,7 +15,6 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc/common:cc_helper_internal.bzl", "root_relative_path")
-load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 load("//cc/private/compile:lto_compilation_context.bzl", "get_minimized_bitcode_or_self")
 load("//cc/private/link:finalize_link_action.bzl", "finalize_link_action")
 load("//cc/private/link:link_build_variables.bzl", "setup_lto_indexing_variables")
@@ -233,8 +232,9 @@ def _lto_indexing_action(
     build_variables = variables_extensions | setup_lto_indexing_variables(
         cc_toolchain,
         feature_configuration,
-        # TODO(b/338618120): remove cheat using the root of one of the created outputs
-        _cc_internal.actions2ctx_cheat(actions).bin_dir.path,
+        # The param file is rooted in the bin directory of the configuration that link outputs
+        # are created in, which is also the root of the paths prefix-matched via these variables.
+        thinlto_param_file.root.path,
         thinlto_param_file.path,
         thinlto_merged_object_file.path,
         lto_output_root_prefix,


### PR DESCRIPTION
Removes the `actions2ctx_cheat` call sites that don't require Bazel-side changes or behavior decisions, going from 13 call sites to 8:

* **`compile.bzl`** (3 → 1): The rule context is now recovered once and reused; the two redundant `actions2ctx_cheat` calls are dropped. `init_cc_compilation_context` now takes `actions` directly — its `ctx` parameter was only ever used for `ctx.actions`, and the comment on it ("Once compile is in Starlark we can directly pass in actions here") already anticipated this change.

* **`create_linking_context_from_compilation_outputs.bzl`** (per the TODO for b/331164666): The owner label of the linker input is now recovered from the produced library artifact. All library artifacts are declared by the calling target, so `artifact.owner` is that target's label and `artifact.owner.same_package_label(name)` yields exactly the label the cheat produced — including when `name != ctx.label.name`, so there is no behavior change. `make_library_to_link` guarantees at least one of `static_library`/`pic_static_library`/`dynamic_library`/`interface_library` is set whenever `library_to_link` is non-`None`. The cheat remains only on the path where both `disallow_static_libraries` and `disallow_dynamic_library` are set: no file is produced there, but the linker input is still needed to propagate `user_link_flags`.

* **`lto_indexing_action.bzl`** (per the TODO for b/338618120): The bin directory prefix for the LTO indexing variables is now taken from `thinlto_param_file.root.path` instead of `ctx.bin_dir.path`. These only differ when link outputs are rooted in a configuration passed via `cc_common.link`'s private `build_config` parameter (Apple/Android split-configuration links); in that case the param file's own root is the prefix that actually matches the object paths these variables are prefix-replaced against, so this is a strict improvement.

**Deliberately not changed:**

* `dynamic_library_symlink.bzl` / `dynamic_library_soname`: These look like they only round-trip `actions2ctx_cheat(actions).actions`, but the `actions` object flowing through the link code is the `WrappedStarlarkActionFactory` from `cc_internal.wrap_link_actions`, whose `declare_shareable_artifact` routes through `LinkActionConstruction` (potentially a different configuration root and non-shareable artifacts). The cheat there is a deliberate unwrap to reach the real `ctx.actions`; replacing it crashes with "Output artifact `_solib_...` not under package directory" (verified against `//tests/builtins_bzl/cc/cc_shared_library/...`). Removing it needs a Bazel-side change first.
* The remaining sites (exec group/toolchain sniffing and `workspace_name` in `finalize_link_action.bzl`, `rule_class` swift_library special case, `should_stamp`/`version_file` in `linkstamp_compile.bzl`, and the `action_construction_context` arguments to `cc_internal` methods) need either Bazel-side API changes or caller-facing decisions and are left for follow-ups.

Tested with Bazel `last_green` on macOS arm64: `//tests/builtins_bzl/...` (32 pass, 2 skipped) and the CI target set `//:all //cc/... //examples/... //tests/...` minus the standard exclusions (261 pass, 8 skipped; two `legacy_features_as_args` timeouts under full parallel load pass in isolation and are unrelated).
