### PR TITLE
Do not expose external repo source root as system include

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -458,7 +458,6 @@ def _init_cc_compilation_context(
     shorten_virtual_includes = _enabled(feature_configuration, "shorten_virtual_includes")
     skip_virtual_includes = _enabled(feature_configuration, "skip_virtual_includes")
     external_include_dirs = []
-    local_include_dirs_for_context = list(local_includes)
     declared_include_srcs = []
 
     if not external and feature_configuration.is_requested("system_include_paths"):
@@ -468,13 +467,13 @@ def _init_cc_compilation_context(
         system_include_dirs_for_context = list(system_include_dirs)
         include_dirs_for_context = list(include_dirs)
     else:
-        # Do not add include dirs directly to the regular compilation context; all public search
-        # paths for external repositories are reclassified as external includes.
-        quote_include_dirs_for_context = []
+        # Keep the repository root as a quote-only include so repository-relative quoted includes
+        # keep working without allowing the root to shadow angle-bracket system headers. Reclassify
+        # all other public search paths for external repositories as external includes.
+        quote_include_dirs_for_context = [repo_path]
         system_include_dirs_for_context = []
         include_dirs_for_context = []
 
-        local_include_dirs_for_context = [repo_path] + local_include_dirs_for_context
         external_include_dirs.append(gen_include_dir)
         external_include_dirs.append(bin_include_dir)
         external_include_dirs.extend(quote_include_dirs)
@@ -651,7 +650,7 @@ def _init_cc_compilation_context(
         external_includes = depset(external_include_dirs),
         system_includes = depset(system_include_dirs_for_context),
         includes = depset(include_dirs_for_context),
-        local_includes = depset(local_include_dirs_for_context),
+        local_includes = depset(local_includes),
         virtual_to_original_headers = depset(virtual_to_original_headers),
         dependent_cc_compilation_contexts = dependent_cc_compilation_contexts,
         non_code_inputs = additional_inputs,
@@ -678,7 +677,7 @@ def _init_cc_compilation_context(
             external_includes = depset(external_include_dirs),
             system_includes = depset(system_include_dirs_for_context),
             includes = depset(include_dirs_for_context),
-            local_includes = depset(local_include_dirs_for_context),
+            local_includes = depset(local_includes),
             virtual_to_original_headers = depset(virtual_to_original_headers),
             dependent_cc_compilation_contexts = dependent_cc_compilation_contexts + implementation_deps,
             non_code_inputs = additional_inputs,

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -458,6 +458,7 @@ def _init_cc_compilation_context(
     shorten_virtual_includes = _enabled(feature_configuration, "shorten_virtual_includes")
     skip_virtual_includes = _enabled(feature_configuration, "skip_virtual_includes")
     external_include_dirs = []
+    local_include_dirs_for_context = list(local_includes)
     declared_include_srcs = []
 
     if not external and feature_configuration.is_requested("system_include_paths"):
@@ -473,7 +474,7 @@ def _init_cc_compilation_context(
         system_include_dirs_for_context = []
         include_dirs_for_context = []
 
-        external_include_dirs.append(repo_path)
+        local_include_dirs_for_context = [repo_path] + local_include_dirs_for_context
         external_include_dirs.append(gen_include_dir)
         external_include_dirs.append(bin_include_dir)
         external_include_dirs.extend(quote_include_dirs)
@@ -650,7 +651,7 @@ def _init_cc_compilation_context(
         external_includes = depset(external_include_dirs),
         system_includes = depset(system_include_dirs_for_context),
         includes = depset(include_dirs_for_context),
-        local_includes = depset(local_includes),
+        local_includes = depset(local_include_dirs_for_context),
         virtual_to_original_headers = depset(virtual_to_original_headers),
         dependent_cc_compilation_contexts = dependent_cc_compilation_contexts,
         non_code_inputs = additional_inputs,
@@ -677,6 +678,7 @@ def _init_cc_compilation_context(
             external_includes = depset(external_include_dirs),
             system_includes = depset(system_include_dirs_for_context),
             includes = depset(include_dirs_for_context),
+            local_includes = depset(local_include_dirs_for_context),
             virtual_to_original_headers = depset(virtual_to_original_headers),
             dependent_cc_compilation_contexts = dependent_cc_compilation_contexts + implementation_deps,
             non_code_inputs = additional_inputs,

--- a/tests/cc/common/cc_binary_configured_target_tests.bzl
+++ b/tests/cc/common/cc_binary_configured_target_tests.bzl
@@ -497,9 +497,12 @@ def _test_sanitize_pwd_macos_no_pwd_impl(env, target):
 
 def _include_paths_from_argv(argv, flag):
     include_paths = []
-    for i in range(len(argv) - 1):
+    for i in range(len(argv)):
         if argv[i] == flag:
-            include_paths.append(argv[i + 1])
+            if i + 1 < len(argv):
+                include_paths.append(argv[i + 1])
+        elif argv[i].startswith(flag):
+            include_paths.append(argv[i][len(flag):])
     return include_paths
 
 def _system_include_paths_from_argv(argv):
@@ -621,6 +624,7 @@ def _test_external_include_paths_reclassifies_external_quote_includes_impl(env, 
 
     env.expect.that_collection(hello_obj_files).has_size(1)
     compile_action = env.expect.that_target(target).action_generating(hello_obj_files[0].short_path)
+    include_paths = _include_paths_from_argv(compile_action.actual.argv, "-I")
     quote_include_paths = _include_paths_from_argv(compile_action.actual.argv, "-iquote")
     system_include_paths = _system_include_paths_from_argv(compile_action.actual.argv)
 
@@ -632,9 +636,12 @@ def _test_external_include_paths_reclassifies_external_quote_includes_impl(env, 
     env.expect.that_collection(system_include_paths).contains_none_of([
         "external/googletest+",
     ])
-    env.expect.that_collection(quote_include_paths).transform(
+    env.expect.that_collection(include_paths).transform(
         filter = matching.contains("googletest"),
     ).contains_exactly([])
+    env.expect.that_collection(quote_include_paths).transform(
+        filter = matching.contains("googletest"),
+    ).contains_exactly(["external/googletest+"])
 
 def _test_linkopts_diamond(name, **kwargs):
     util.helper_target(

--- a/tests/cc/common/cc_binary_configured_target_tests.bzl
+++ b/tests/cc/common/cc_binary_configured_target_tests.bzl
@@ -629,6 +629,9 @@ def _test_external_include_paths_reclassifies_external_quote_includes_impl(env, 
     env.expect.that_collection(system_include_paths).contains_predicate(
         matching.contains("googletest"),
     )
+    env.expect.that_collection(system_include_paths).contains_none_of([
+        "external/googletest+",
+    ])
     env.expect.that_collection(quote_include_paths).transform(
         filter = matching.contains("googletest"),
     ).contains_exactly([])


### PR DESCRIPTION
Fixes #801.

When `external_include_paths` is enabled for a target in an external repository, `rules_cc` reclassifies public include paths as external/system includes. Including the external repository source root (`repo_path`) in that set emits `-isystem external/<repo>` on downstream compile actions and exposes unrelated root files to angle-bracket lookup.

On case-insensitive filesystems, a repository containing a root-level `VERSION` file can therefore break libc++’s `#include <version>`. The issue originally surfaced in [`DoDoENT/bazel-playground`](https://github.com/DoDoENT/bazel-playground) through its OpenCV/libtiff dependency graph.

Keep the external repository root propagated as a quote-only include (`-iquote`). This preserves repository-relative quoted includes for downstream dependents without making the root eligible for angle-bracket includes. Generated roots and explicit public include directories remain external/system includes.

The `external_include_paths` analysis regression inspects a downstream compile action and asserts that the exact external repository root:

- is absent from `-isystem` and `-I`, reproducing the original header-shadowing failure;
- remains present in `-iquote`, reproducing the downstream include failure caused by keeping the root target-local.

Other public paths from the external dependency are still required to appear as system includes.

Validation:

- `bazel test //tests/cc/common:cc_binary_configured_target_tests --test_output=errors`