### PR TITLE
Automatically add supports-path-mapping where applicable

### DIFF
--- a/cc/private/compile/BUILD
+++ b/cc/private/compile/BUILD
@@ -23,6 +23,7 @@ bzl_library(
         "//cc/common:semantics_bzl",
         "//cc/private:cc_internal_bzl",
         "//cc/private/rules_impl:native_cc_common_bzl",
+        "@bazel_features//:features",
         "@bazel_skylib//lib:paths",
     ],
 )

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -402,7 +402,13 @@ def _create_module_map_action(
     tree_artifacts += [h for h in textual_headers if h.is_directory]
     content.add_all(tree_artifacts, map_each = lambda x: None, allow_closure = True)
 
-    actions.write(module_map.file, content = content, is_executable = True, mnemonic = "CppModuleMap")
+    actions.write(
+        module_map.file,
+        content = content,
+        is_executable = True,
+        mnemonic = "CppModuleMap",
+        execution_requirements = {"supports-path-mapping": ""},
+    )
 
 def _init_cc_compilation_context(
         # DO NOT use ctx, this is a temporary placeholder

--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Compilation helper for C++ rules."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//cc/common:cc_helper_internal.bzl",
@@ -402,12 +403,16 @@ def _create_module_map_action(
     tree_artifacts += [h for h in textual_headers if h.is_directory]
     content.add_all(tree_artifacts, map_each = lambda x: None, allow_closure = True)
 
+    write_kwargs = {}
+    if bazel_features.rules.write_action_has_execution_requirements:
+        write_kwargs["execution_requirements"] = {"supports-path-mapping": ""}
+
     actions.write(
         module_map.file,
         content = content,
         is_executable = True,
         mnemonic = "CppModuleMap",
-        execution_requirements = {"supports-path-mapping": ""},
+        **write_kwargs
     )
 
 def _init_cc_compilation_context(

--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -353,6 +353,9 @@ def _create_action(
     for req in _cc_common_internal.get_execution_requirements(feature_configuration = feature_configuration, action_name = action_name):
         execution_info[req] = ""
 
+    if mnemonic == "CppArchive":
+        execution_info["supports-path-mapping"] = ""
+
     # At the moment we do not believe that LTO builds are sufficiently cacheable or sufficiently
     # frequent to invest time in path mapping.
     # CppLink does significantly different work for LTO and non-LTO builds and there is an argument

--- a/tests/cc/common/cc_library_configured_target_tests.bzl
+++ b/tests/cc/common/cc_library_configured_target_tests.bzl
@@ -63,6 +63,7 @@ def _test_cc_library_data_in_runfiles(name, **kwargs):
         name = name,
         impl = _test_cc_library_data_in_runfiles_impl,
         target = name + "_lib_with_data",
+        test_features = ["module_maps"],
         **kwargs
     )
 


### PR DESCRIPTION
This way users don't have to pass:

```
--modify_execution_info=CppCompile=+supports-path-mapping,CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping
```

or know which mnemonics support it. This still does nothing unless the
overall path stripping feature is enabled
