### PR TITLE
Remove supports-path-mapping from CppLink by default

### DIFF
--- a/cc/private/link/finalize_link_action.bzl
+++ b/cc/private/link/finalize_link_action.bzl
@@ -358,8 +358,8 @@ def _create_action(
     # CppLink does significantly different work for LTO and non-LTO builds and there is an argument
     # for using separate mnemonic for the two different activities, but that would require a lot
     # of updates to configurations and rules that reference the CppLink mnemonic.
-    if mnemonic == "CppLink" and not feature_configuration.is_enabled("thin_lto"):
-        execution_info["supports-path-mapping"] = ""
+    if mnemonic == "CppLink" and feature_configuration.is_enabled("thin_lto"):
+        execution_info.pop("supports-path-mapping", None)
 
     build_variables = _cc_internal.cc_toolchain_variables(vars = build_variables)
     get_link_args_kwargs = {}


### PR DESCRIPTION
There are 2 major known issues with this today:

1. When targeting macOS the debug info paths stored in the binaries are
   invalid, since they encode the literal `bazel-out/cfg`
2. Paths in environment variables configured in the toolchain are not
   path mapped today. They should be in a future bazel release, but the
   current fix will also only fix direct File objects not more complex
   cases

If users are ok with these 2 limitations they should enable this
manually with `--modify_execution_info=CppLink=+supports-path-mapping`
