### PR TITLE
Starlarkify cc_common.empty_variables

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -172,7 +172,7 @@ def _get_environment_variables(*, feature_configuration, action_name, variables)
     return _cc_common_internal.get_environment_variables(feature_configuration = feature_configuration, action_name = action_name, variables = variables)
 
 def _empty_variables():
-    return _cc_common_internal.empty_variables()
+    return _cc_internal.cc_toolchain_variables(vars = {})
 
 def _create_library_to_link(
         *,


### PR DESCRIPTION
Replace the Java-backed `cc_common.empty_variables()` call with `_cc_internal.cc_toolchain_variables(vars = {})`. Both implementations construct the same empty `CcToolchainVariables` representation, preserving compile, link, FDO, and toolchain feature expansion.

Validation: `buildifier -mode=check cc/private/cc_common.bzl` and 66 passing C++ common, compile-variable, link-variable, and FDO analysis tests.
