### PR TITLE
Reuse Starlark default features in CcToolchainInfo

### DIFF
--- a/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
+++ b/cc/private/rules_impl/cc_toolchain_provider_helper.bzl
@@ -158,7 +158,7 @@ def get_cc_toolchain_provider(ctx, attributes):
     # we fall back to below so the guard in tool_path returns true
     # when those action_configs are declared.
     feature_configuration = toolchain_features.configure_features(
-        requested_features = toolchain_features.default_features_and_action_configs() + [
+        requested_features = toolchain_config_info._default_features_and_action_configs + [
             ACTION_NAMES.c_compile,
             ACTION_NAMES.cpp_link_static_library,
             ACTION_NAMES.cpp_link_executable,


### PR DESCRIPTION
Use `CcToolchainConfigInfo._default_features_and_action_configs` when initializing the C++ toolchain provider. `create_cc_toolchain_config_info` already computes this ordered list in Starlark, so the remaining `CcToolchainFeatures.default_features_and_action_configs()` Java call is unnecessary.

Validation: `buildifier -mode=check cc/private/rules_impl/cc_toolchain_provider_helper.bzl` and 89 passing C++ common, binary, and library analysis tests.
