### PR TITLE
Replace the deprecated C++ compiler marker with None

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -732,7 +732,7 @@ cc_common = struct(
     # Ideally we would like to get rid of this Java symbol and replace it with Starlark one.
     # And also deprecate this public API.
     CcToolchainInfo = CcToolchainInfo,
-    do_not_use_tools_cpp_compiler_present = _cc_common_internal.do_not_use_tools_cpp_compiler_present,
+    do_not_use_tools_cpp_compiler_present = None,
     configure_features = configure_features,
     get_tool_for_action = _get_tool_for_action,
     get_execution_requirements = _get_execution_requirements,

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -6,26 +6,9 @@ load("@rules_testing//lib:truth.bzl", "matching")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:cc_binary.bzl", "cc_binary")
 load("//cc:cc_library.bzl", "cc_library")
-load("//cc/common:cc_common.bzl", "cc_common")
 load("//cc/common:cc_info.bzl", "CcInfo")
 load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
 load("//tests/cc/testutil:cc_info_subject.bzl", "cc_info_subject")
-
-def _test_compiler_presence_marker(name):
-    util.helper_target(
-        cc_library,
-        name = name + "/lib",
-    )
-
-    cc_analysis_test(
-        name = name,
-        impl = _test_compiler_presence_marker_impl,
-        target = name + "/lib",
-    )
-
-def _test_compiler_presence_marker_impl(env, _target):
-    env.expect.that_bool(hasattr(cc_common, "do_not_use_tools_cpp_compiler_present")).equals(True)
-    env.expect.that_bool(cc_common.do_not_use_tools_cpp_compiler_present == None).equals(True)
 
 def _test_same_cc_file_twice(name):
     util.helper_target(
@@ -678,7 +661,6 @@ def _test_alwayslink_yields_lo_impl(env, target):
 
 def cc_common_tests(name):
     tests = [
-        _test_compiler_presence_marker,
         _test_same_cc_file_twice,
         _test_same_header_file_twice,
         _test_isolated_includes,

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -6,9 +6,26 @@ load("@rules_testing//lib:truth.bzl", "matching")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:cc_binary.bzl", "cc_binary")
 load("//cc:cc_library.bzl", "cc_library")
+load("//cc/common:cc_common.bzl", "cc_common")
 load("//cc/common:cc_info.bzl", "CcInfo")
 load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
 load("//tests/cc/testutil:cc_info_subject.bzl", "cc_info_subject")
+
+def _test_compiler_presence_marker(name):
+    util.helper_target(
+        cc_library,
+        name = name + "/lib",
+    )
+
+    cc_analysis_test(
+        name = name,
+        impl = _test_compiler_presence_marker_impl,
+        target = name + "/lib",
+    )
+
+def _test_compiler_presence_marker_impl(env, _target):
+    env.expect.that_bool(hasattr(cc_common, "do_not_use_tools_cpp_compiler_present")).equals(True)
+    env.expect.that_bool(cc_common.do_not_use_tools_cpp_compiler_present == None).equals(True)
 
 def _test_same_cc_file_twice(name):
     util.helper_target(
@@ -661,6 +678,7 @@ def _test_alwayslink_yields_lo_impl(env, target):
 
 def cc_common_tests(name):
     tests = [
+        _test_compiler_presence_marker,
         _test_same_cc_file_twice,
         _test_same_header_file_twice,
         _test_isolated_includes,


### PR DESCRIPTION
Replace the Java-backed cc_common.do_not_use_tools_cpp_compiler_present marker with its existing Starlark value, None. Bazel declares the deprecated marker as a Java void struct field, so preserving the exported field with None removes the Java dependency without changing compatibility.

Validation: buildifier -mode=check and 24 passing //tests/cc/common:cc_common_tests cases.
