### PR TITLE
Use Starlark tuples for C++ module-map headers

### DIFF
--- a/cc/private/compile/cc_compilation_helper.bzl
+++ b/cc/private/compile/cc_compilation_helper.bzl
@@ -22,7 +22,6 @@ load(
 )
 load("//cc/common:semantics.bzl", "STRIP_INCLUDE_PREFIX_APPLIES_TO_TEXTUAL_HEADERS", "USE_EXEC_ROOT_FOR_VIRTUAL_INCLUDES_SYMLINKS")
 load("//cc/private:cc_info.bzl", "create_compilation_context", "create_module_map")
-load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 
 _VIRTUAL_INCLUDES_DIR = "_virtual_includes"
 
@@ -372,11 +371,11 @@ def _create_module_map_action(
     content.set_param_file_format("multiline")
     segments_to_exec_path = module_map.file.path.count("/")
     leading_periods = "" if module_map_home_is_cwd else "../" * segments_to_exec_path
-    public_headers = _cc_internal.freeze(public_headers)
-    private_headers = _cc_internal.freeze(private_headers)
-    public_textual_headers = _cc_internal.freeze(public_textual_headers)
-    additional_exported_headers = _cc_internal.freeze(additional_exported_headers)
-    separate_module_headers = _cc_internal.freeze(separate_module_headers)
+    public_headers = tuple(public_headers)
+    private_headers = tuple(private_headers)
+    public_textual_headers = tuple(public_textual_headers)
+    additional_exported_headers = tuple(additional_exported_headers)
+    separate_module_headers = tuple(separate_module_headers)
     data_struct = _ModuleMapInfo(
         module_map = module_map,
         public_headers = public_headers,

--- a/tests/cc/common/cpp_modules_test.bzl
+++ b/tests/cc/common/cpp_modules_test.bzl
@@ -116,6 +116,51 @@ def _test_cpp_modules_no_features_impl(env, target):
         matching.contains("requires --experimental_cpp_modules"),
     )
 
+def _generated_module_map_headers_impl(ctx):
+    headers = ctx.actions.declare_directory(ctx.label.name + ".h")
+    ctx.actions.run_shell(
+        outputs = [headers],
+        arguments = [headers.path],
+        command = "mkdir -p \"$1\" && touch \"$1/generated.h\"",
+    )
+    return [DefaultInfo(files = depset([headers]))]
+
+_generated_module_map_headers = rule(implementation = _generated_module_map_headers_impl)
+
+def _test_module_map_action_with_tree_artifact_headers(name):
+    util.empty_file(name + "/public.h")
+    util.empty_file(name + "/private.h")
+    util.empty_file(name + "/textual.h")
+    util.helper_target(
+        _generated_module_map_headers,
+        name = name + "_generated_headers",
+    )
+    util.helper_target(
+        cc_library,
+        name = name + "_lib",
+        srcs = [name + "/private.h"],
+        hdrs = [
+            name + "/public.h",
+            name + "_generated_headers",
+        ],
+        textual_hdrs = [name + "/textual.h"],
+    )
+    cc_analysis_test(
+        name = name,
+        target = name + "_lib",
+        impl = _test_module_map_action_with_tree_artifact_headers_impl,
+        test_features = ["module_maps"],
+    )
+
+def _test_module_map_action_with_tree_artifact_headers_impl(env, target):
+    generated_headers = "{}/{}_generated_headers.h".format(
+        target.label.package,
+        env.ctx.label.name,
+    )
+    env.expect.that_target(target).action_named("CppModuleMap").inputs().contains(
+        generated_headers,
+    )
+
 def cpp_modules_tests(name):
     tests = []
     if bazel_features.cc.cc_common_is_in_rules_cc:
@@ -126,6 +171,7 @@ def cpp_modules_tests(name):
             _test_cpp_modules_cc_library_configuration_no_features,
             _test_cpp_modules_cc_binary_configuration_no_features,
             _test_cpp_modules_cc_test_configuration_no_features,
+            _test_module_map_action_with_tree_artifact_headers,
         ])
 
     test_suite(


### PR DESCRIPTION
Store private module-map callback sequences as immutable Starlark tuples instead of calling `_cc_internal.freeze`. The `_ModuleMapInfo` callback preserves header ordering, tree-artifact expansion, and `Args.map_each` behavior while eliminating the module's Java-backed `cc_internal` dependency.

Add a configured-target regression test verifying that generated header directories are included in the `CppModuleMap` action.

Validation: `buildifier -mode=check` and seven passing C++ module-analysis tests, including the new generated-tree-header test.
