### PR TITLE
Use Starlark dynamic-library symlinks in C++ linking

### DIFF
--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -491,7 +491,7 @@ def _construct_dynamic_library_to_link(
 
         else:
             if dynamic_link_type == LINK_TARGET_TYPE.NODEPS_DYNAMIC_LIBRARY:
-                impl_library_link_artifact = _cc_internal.dynamic_library_symlink(
+                impl_library_link_artifact = dynamic_library_symlink(
                     actions,
                     dynamic_library.file,
                     cc_toolchain._solib_dir,
@@ -502,7 +502,7 @@ def _construct_dynamic_library_to_link(
             library_to_link["resolved_symlink_dynamic_library"] = dynamic_library.file
 
             if interface_library:
-                library_link_artifact = _cc_internal.dynamic_library_symlink(
+                library_link_artifact = dynamic_library_symlink(
                     actions,
                     interface_library.file,
                     cc_toolchain._solib_dir,

--- a/tests/cc/common/cc_binary_thin_lto_tests.bzl
+++ b/tests/cc/common/cc_binary_thin_lto_tests.bzl
@@ -273,9 +273,9 @@ def _test_thin_lto_no_linkstatic_impl(env, targets):
 
     lib_target_subject = env.expect.that_target(lib_target)
     solib_action = lib_target_subject.action_generating(solib_file.short_path)
-    solib_action.mnemonic().equals("SolibSymlink")
+    solib_action.mnemonic().is_in(["SolibSymlink", "Symlink"])
 
-    # The input to SolibSymlink is the library itself
+    # The input to the solib symlink action is the library itself.
     solib_action_inputs = solib_action.actual.inputs.to_list()
     lib_file = solib_action_inputs[0]
 


### PR DESCRIPTION
Route both remaining direct `_cc_internal.dynamic_library_symlink` calls in `cc_linking_helper.bzl` through the existing Starlark `dynamic_library_symlink` implementation. The existing implementation preserves artifact naming, symlink registration, and its compatibility fallback for older Bazel versions.

Update the ThinLTO symlink regression to accept the Starlark `Symlink` action mnemonic and the native `SolibSymlink` compatibility fallback.

Validation: `buildifier -mode=check` and 89 passing ThinLTO, C++ binary, and import analysis tests.
