### PR TITLE
Read the ThinLTO output root from its declared artifact

### DIFF
--- a/cc/private/link/lto_indexing_action.bzl
+++ b/cc/private/link/lto_indexing_action.bzl
@@ -15,7 +15,6 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//cc/common:cc_helper_internal.bzl", "root_relative_path")
-load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 load("//cc/private/compile:lto_compilation_context.bzl", "get_minimized_bitcode_or_self")
 load("//cc/private/link:finalize_link_action.bzl", "finalize_link_action")
 load("//cc/private/link:link_build_variables.bzl", "setup_lto_indexing_variables")
@@ -233,8 +232,7 @@ def _lto_indexing_action(
     build_variables = variables_extensions | setup_lto_indexing_variables(
         cc_toolchain,
         feature_configuration,
-        # TODO(b/338618120): remove cheat using the root of one of the created outputs
-        _cc_internal.actions2ctx_cheat(actions).bin_dir.path,
+        thinlto_param_file.root.path,
         thinlto_param_file.path,
         thinlto_merged_object_file.path,
         lto_output_root_prefix,


### PR DESCRIPTION
Read the ThinLTO indexing output directory from `thinlto_param_file.root.path` instead of recovering the rule context through `_cc_internal.actions2ctx_cheat`. The declared parameter file carries the actual selected output root, including alternate or transitioned configurations, and removing the obsolete call also eliminates `cc_internal` from `lto_indexing_action.bzl`.

Validation: `buildifier -mode=check cc/private/link/lto_indexing_action.bzl` and 88 passing ThinLTO and C++ binary analysis tests.
