### PR TITLE
Use Starlark tuples for extra link-time libraries

### DIFF
--- a/cc/private/link/create_extra_link_time_library.bzl
+++ b/cc/private/link/create_extra_link_time_library.bzl
@@ -70,9 +70,9 @@ def create_extra_link_time_library(*, build_library_func, **kwargs):
         # the split between depset and non-depset parameters to determine equality.
         _key = _KeyInfo(
             build_library_func = build_library_func,
-            # _KeyInfo is used in a dict, so all of its fields must be frozen/hashable.
-            constant_fields = _cc_internal.freeze([k for k, v in kwargs.items() if type(v) != "depset"]),
-            depset_fields = _cc_internal.freeze([k for k, v in kwargs.items() if type(v) == "depset"]),
+            # _KeyInfo is used in a dict, so all of its fields must be hashable.
+            constant_fields = tuple([k for k, v in kwargs.items() if type(v) != "depset"]),
+            depset_fields = tuple([k for k, v in kwargs.items() if type(v) == "depset"]),
         ),
         **kwargs
     )
@@ -80,12 +80,12 @@ def create_extra_link_time_library(*, build_library_func, **kwargs):
 ExtraLinkTimeLibrariesInfo = provider(
     "ExtraLinkTimeLibrariesInfo",
     fields = {
-        "libraries": "A list of (ExtraLinkTimeLibraryInfo) extra libraries.",
+        "libraries": "A tuple of (ExtraLinkTimeLibraryInfo) extra libraries.",
     },
 )
 
 _EMPTY = ExtraLinkTimeLibrariesInfo(
-    libraries = [],
+    libraries = (),
 )
 
 def create_extra_link_time_libraries(library):
@@ -99,9 +99,8 @@ def create_extra_link_time_libraries(library):
     """
     if library == None:
         return _EMPTY
-    libraries = _cc_internal.freeze([library])
     return ExtraLinkTimeLibrariesInfo(
-        libraries = libraries,
+        libraries = (library,),
     )
 
 def _merge_values(values):
@@ -150,7 +149,7 @@ def merge_extra_link_time_libraries(libraries):
 
         result.append(ExtraLinkTimeLibraryInfo(**merged_fields))
     return ExtraLinkTimeLibrariesInfo(
-        libraries = _cc_internal.freeze(result),
+        libraries = tuple(result),
     )
 
 def build_libraries(extra_libraries, ctx, static_mode, for_dynamic_library):

--- a/tests/cc/common/BUILD
+++ b/tests/cc/common/BUILD
@@ -10,6 +10,7 @@ load(":cc_objc_library_configured_target_tests.bzl", "cc_objc_library_configured
 load(":compile_build_variables_tests.bzl", "compile_build_variables_tests")
 load(":cpp_modules_test.bzl", "cpp_modules_tests")
 load(":debug_info_packaging_test.bzl", "debug_info_packaging_tests")
+load(":extra_link_time_library_test.bzl", "extra_link_time_library_tests")
 load(":link_build_variables_test.bzl", "link_build_variables_tests")
 
 cc_binary_configured_target_tests(name = "cc_binary_configured_target_tests")
@@ -29,6 +30,8 @@ cpp_modules_tests(name = "cpp_modules_tests")
 compile_build_variables_tests(name = "compile_build_variables_tests")
 
 debug_info_packaging_tests(name = "debug_info_packaging_tests")
+
+extra_link_time_library_tests(name = "extra_link_time_library_tests")
 
 cc_fdo_env_tests(name = "cc_fdo_env_tests")
 

--- a/tests/cc/common/extra_link_time_library_test.bzl
+++ b/tests/cc/common/extra_link_time_library_test.bzl
@@ -1,0 +1,105 @@
+"""Tests for extra link-time library creation and merging."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//cc/common:cc_common.bzl", "cc_common")
+
+def _build_extra_link_time_library(_ctx, _static_mode, _for_dynamic_library, **_kwargs):
+    return None
+
+def _library_key_collections_are_hashable_tuples_impl(ctx):
+    env = unittest.begin(ctx)
+    first_library = cc_common.create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+        first_constant = "first",
+        inputs = depset(["first-input"]),
+        second_constant = "second",
+    )
+    second_library = cc_common.create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+        first_constant = "first",
+        inputs = depset(["second-input"]),
+        second_constant = "second",
+    )
+
+    asserts.equals(env, "tuple", type(first_library._key.constant_fields))
+    asserts.equals(env, ("first_constant", "second_constant"), first_library._key.constant_fields)
+    asserts.equals(env, "tuple", type(first_library._key.depset_fields))
+    asserts.equals(env, ("inputs",), first_library._key.depset_fields)
+
+    values_by_key = {first_library._key: "value"}
+    asserts.equals(env, "value", values_by_key[second_library._key])
+    return unittest.end(env)
+
+_library_key_collections_are_hashable_tuples_test = unittest.make(
+    _library_key_collections_are_hashable_tuples_impl,
+)
+
+def _empty_and_singleton_libraries_are_tuples_impl(ctx):
+    env = unittest.begin(ctx)
+    empty_libraries = cc_common.create_linking_context(
+        linker_inputs = depset(),
+    )._extra_link_time_libraries
+    asserts.equals(env, "tuple", type(empty_libraries.libraries))
+    asserts.equals(env, (), empty_libraries.libraries)
+
+    library = cc_common.create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+    )
+    singleton_libraries = cc_common.create_linking_context(
+        linker_inputs = depset(),
+        extra_link_time_library = library,
+    )._extra_link_time_libraries
+    asserts.equals(env, "tuple", type(singleton_libraries.libraries))
+    asserts.equals(env, (library,), singleton_libraries.libraries)
+    return unittest.end(env)
+
+_empty_and_singleton_libraries_are_tuples_test = unittest.make(
+    _empty_and_singleton_libraries_are_tuples_impl,
+)
+
+def _merged_libraries_are_tuples_impl(ctx):
+    env = unittest.begin(ctx)
+    first_library = cc_common.create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+        inputs = depset(["first-input"]),
+        mode = "constant",
+    )
+    second_library = cc_common.create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+        inputs = depset(["second-input"]),
+        mode = "constant",
+    )
+
+    merged_libraries = cc_common.merge_linking_contexts(
+        linking_contexts = [
+            cc_common.create_linking_context(
+                linker_inputs = depset(),
+                extra_link_time_library = first_library,
+            ),
+            cc_common.create_linking_context(
+                linker_inputs = depset(),
+                extra_link_time_library = second_library,
+            ),
+        ],
+    )._extra_link_time_libraries
+
+    asserts.equals(env, "tuple", type(merged_libraries.libraries))
+    asserts.equals(env, 1, len(merged_libraries.libraries))
+    merged_library = merged_libraries.libraries[0]
+    asserts.equals(env, "constant", merged_library.mode)
+    asserts.equals(env, ["first-input", "second-input"], merged_library.inputs.to_list())
+    return unittest.end(env)
+
+_merged_libraries_are_tuples_test = unittest.make(_merged_libraries_are_tuples_impl)
+
+def extra_link_time_library_tests(name):
+    if bazel_features.cc.cc_common_is_in_rules_cc:
+        unittest.suite(
+            name,
+            _library_key_collections_are_hashable_tuples_test,
+            _empty_and_singleton_libraries_are_tuples_test,
+            _merged_libraries_are_tuples_test,
+        )
+    else:
+        native.test_suite(name = name)


### PR DESCRIPTION
Replace Java-backed `_cc_internal.freeze` calls in extra-link-time library grouping and collections with immutable Starlark tuples. Grouping keys remain hashable, constant and depset fields retain their ordering, and empty, singleton, and merged library collections preserve their existing behavior.

Add three focused regression tests covering grouping-key equality, tuple-valued collections, and merged depsets.

Validation: `buildifier -mode=check` and three passing `//tests/cc/common:extra_link_time_library_tests` cases.
