### PR TITLE
Use Starlark tuples for C++ object-file groups

### DIFF
--- a/cc/private/link/create_libraries_to_link_values.bzl
+++ b/cc/private/link/create_libraries_to_link_values.bzl
@@ -14,7 +14,6 @@
 """Goes over LibraryToLinks and produces LibraryToLinkValue-s."""
 
 load("//cc/common:cc_helper_internal.bzl", "is_shared_library", "is_versioned_shared_library", "root_relative_path")
-load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 
 # Types of LibraryToLinkValues
 _TYPE = struct(
@@ -59,7 +58,7 @@ def add_object_files_to_link(object_files, libraries_to_link_values):
             libraries_to_link_values.append(
                 _ObjectFileGroupInfo(
                     type = _TYPE.OBJECT_FILE_GROUP,
-                    object_files = _cc_internal.freeze([object_file]),
+                    object_files = (object_file,),
                     is_whole_archive = False,
                 ),
             )
@@ -226,7 +225,7 @@ def _add_static_library_to_link(
                     libraries_to_link_values.append(
                         _ObjectFileGroupInfo(
                             type = _TYPE.OBJECT_FILE_GROUP,
-                            object_files = _cc_internal.freeze([object]),
+                            object_files = (object,),
                             is_whole_archive = True,
                         ),
                     )
@@ -245,7 +244,7 @@ def _add_static_library_to_link(
             libraries_to_link_values.append(
                 _ObjectFileGroupInfo(
                     type = _TYPE.OBJECT_FILE_GROUP,
-                    object_files = _cc_internal.freeze(objects),
+                    object_files = tuple(objects),
                     is_whole_archive = False,
                 ),
             )


### PR DESCRIPTION
Store private `_ObjectFileGroupInfo.object_files` collections as immutable Starlark tuples instead of Java-backed `_cc_internal.freeze` lists. Tuple iteration preserves object order, generated-directory expansion, and whole-archive grouping while removing the module's remaining `cc_internal` dependency.

Validation: `buildifier -mode=check` and 30 passing link-variable and Linux, macOS, and Windows toolchain-feature analysis tests.
