### PR TITLE
Avoid private API checks for internal ThinLTO contexts

### DIFF
--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -48,7 +48,7 @@ load(
     "get_specific_compile_build_variables",
     "setup_common_compile_build_variables",
 )
-load("//cc/private/compile:lto_compilation_context.bzl", "create_lto_compilation_context")
+load("//cc/private/compile:lto_compilation_context.bzl", "create_lto_compilation_context_internal")
 
 _VALID_CPP_SOURCE_TYPES = set([CPP_SOURCE_TYPE_SOURCE, CPP_SOURCE_TYPE_HEADER, CPP_SOURCE_TYPE_CLIF_INPUT_PROTO])
 
@@ -387,7 +387,7 @@ def compile(
         progress_message_prefix = progress_message_prefix,
     )
 
-    compilation_outputs_dict["lto_compilation_context"] = create_lto_compilation_context(
+    compilation_outputs_dict["lto_compilation_context"] = create_lto_compilation_context_internal(
         objects = compilation_outputs_dict["lto_compilation_context"],
     )
     compilation_outputs = create_compilation_outputs_internal(**compilation_outputs_dict)

--- a/cc/private/compile/lto_compilation_context.bzl
+++ b/cc/private/compile/lto_compilation_context.bzl
@@ -50,6 +50,10 @@ def create_lto_compilation_context(*, objects = {}):
         An LtoCompilationContextInfo provider.
     """
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
+    return create_lto_compilation_context_internal(objects = objects)
+
+def create_lto_compilation_context_internal(*, objects = {}):
+    """Creates an LtoCompilationContextInfo provider for internal C++ callers."""
     bitcode_infos = {}
     for k, (minimized_bitcode, copts) in objects.items():
         if type(minimized_bitcode) != "File" and minimized_bitcode != None:


### PR DESCRIPTION
Keep cc_common.create_lto_compilation_context as the checked public entry point and add create_lto_compilation_context_internal for C++ compilation. The internal constructor preserves all BitcodeInfo validation and provider construction while avoiding one Java-backed private-API check per compilation.

Validation: 56 remote C++ common, ThinLTO, and C++ module tests passed.
