### PR TITLE
Skip Java interning for empty preprocessor definitions

### DIFF
--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -248,7 +248,7 @@ def _setup_common_compile_build_variables_internal(
     all_defines = defines.to_list() + local_defines.to_list() + (
         ["BUILD_FDO_TYPE=\"" + fdo_build_stamp + "\""] if fdo_build_stamp else []
     )
-    result[_VARS.PREPROCESSOR_DEFINES] = _cc_internal.intern_string_sequence_variable_value(all_defines)
+    result[_VARS.PREPROCESSOR_DEFINES] = _cc_internal.intern_string_sequence_variable_value(all_defines) if all_defines else ()
     result = result | additional_build_variables
 
     for key, value in variables_extension.items():


### PR DESCRIPTION
Represent empty PREPROCESSOR_DEFINES with the immutable empty Starlark tuple instead of calling intern_string_sequence_variable_value. Nonempty definitions, including FDO definitions, retain the existing Java weak interning.

Validation: 15 remote compiler-variable and FDO tests passed.
