### PR TITLE
Skip Java interning for empty user compiler flags

### DIFF
--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -323,7 +323,9 @@ def get_specific_compile_build_variables(
         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
 
-    result[_VARS.USER_COMPILE_FLAGS] = _cc_internal.intern_string_sequence_variable_value(user_compile_flags)
+    result[_VARS.USER_COMPILE_FLAGS] = (
+        _cc_internal.intern_string_sequence_variable_value(user_compile_flags) if user_compile_flags else ()
+    )
     if source_file:
         result[_VARS.SOURCE_FILE] = source_file
     if output_file:


### PR DESCRIPTION
Represent empty user_compile_flags with the immutable empty Starlark tuple instead of invoking intern_string_sequence_variable_value. Nonempty compiler flags continue to use Java weak interning and preserve existing command-line expansion.

Validation: 37 remote compiler-variable and C++ common tests passed.
