### PR TITLE
Skip Java interning for empty ThinLTO backend flags

### DIFF
--- a/cc/private/link/lto_backends.bzl
+++ b/cc/private/link/lto_backends.bzl
@@ -343,7 +343,7 @@ def create_lto_backend_artifacts(
     build_variables = _cc_internal.combine_cc_toolchain_variables(
         build_variables,
         _cc_internal.cc_toolchain_variables(vars = {
-            "user_compile_flags": _cc_internal.intern_string_sequence_variable_value(argv),
+            "user_compile_flags": _cc_internal.intern_string_sequence_variable_value(argv) if argv else (),
         }),
     )
 


### PR DESCRIPTION
Use the immutable empty Starlark tuple for ThinLTO user_compile_flags when the backend argv is empty. Nonempty ThinLTO backend options retain the existing Java weak interning.

Validation: 26 remote ThinLTO tests passed, including per-file backend options and shared backend actions.
