### PR TITLE
Check private cc_common.link arguments once

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -89,10 +89,8 @@ def _link(
         use_shareable_artifact_factory = _UNBOUND,
         build_config = _UNBOUND,
         emit_interface_shared_library = _UNBOUND):
-    if output_type == "archive":
-        _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
-
-    if use_test_only_flags != _UNBOUND or \
+    if output_type == "archive" or \
+       use_test_only_flags != _UNBOUND or \
        never_link != _UNBOUND or \
        test_only_target != _UNBOUND or \
        native_deps != _UNBOUND or \


### PR DESCRIPTION
Combine the archive-output predicate with the existing cc_common.link private-argument predicates so callers receive one check_private_api invocation. Preserve existing allowlist behavior, argument normalization, and caller-stack depth.

Validation: 51 remote C++ common and link-build-variable tests passed.
