### PR TITLE
Avoid duplicate cc_common.compile private API checks

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -496,18 +496,21 @@ def _compile(
         separate_module_headers = _UNBOUND,
         module_interfaces = _UNBOUND,
         non_compilation_additional_inputs = _UNBOUND):
-    if module_map != _UNBOUND or \
-       additional_module_maps != _UNBOUND or \
-       additional_exported_hdrs != _UNBOUND or \
-       propagate_module_map_to_compile_action != _UNBOUND or \
-       do_not_generate_module_map != _UNBOUND or \
-       code_coverage_enabled != _UNBOUND or \
-       purpose != _UNBOUND or \
-       hdrs_checking_mode != _UNBOUND or \
-       implementation_compilation_contexts != _UNBOUND or \
-       separate_module_headers != _UNBOUND or \
-       module_interfaces != _UNBOUND or \
-       non_compilation_additional_inputs != _UNBOUND:
+    private_api_checked = (
+        module_map != _UNBOUND or
+        additional_module_maps != _UNBOUND or
+        additional_exported_hdrs != _UNBOUND or
+        propagate_module_map_to_compile_action != _UNBOUND or
+        do_not_generate_module_map != _UNBOUND or
+        code_coverage_enabled != _UNBOUND or
+        purpose != _UNBOUND or
+        hdrs_checking_mode != _UNBOUND or
+        implementation_compilation_contexts != _UNBOUND or
+        separate_module_headers != _UNBOUND or
+        module_interfaces != _UNBOUND or
+        non_compilation_additional_inputs != _UNBOUND
+    )
+    if private_api_checked:
         _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
 
     if module_map == _UNBOUND:
@@ -534,7 +537,7 @@ def _compile(
         non_compilation_additional_inputs = []
 
     has_tuple = _check_all_sources_contain_tuples_or_none_of_them([srcs, module_interfaces, private_hdrs, public_hdrs])
-    if has_tuple:
+    if has_tuple and not private_api_checked:
         _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
 
     return compile(


### PR DESCRIPTION
Record when cc_common.compile has already authorized private arguments and avoid repeating check_private_api for tuple-valued sources. Preserve private-argument validation order, mixed-source diagnostics, allowlist behavior, and caller-stack depth.

Validation: 29 remote C++ common, C++ library, and Objective-C configured-target tests passed.
