### PR TITLE
Reuse frozen empty ThinLTO backend mappings

### DIFF
--- a/cc/private/link/create_library_to_link.bzl
+++ b/cc/private/link/create_library_to_link.bzl
@@ -22,6 +22,8 @@ load("//cc/private/compile:lto_compilation_context.bzl", _EMPTY_LTO = "EMPTY_LTO
 load("//cc/private/link:dynamic_library_symlink.bzl", "dynamic_library_symlink", "dynamic_library_symlink2")
 load("//cc/private/link:lto_backends.bzl", "create_shared_non_lto_artifacts")
 
+_EMPTY_SHARED_NON_LTO_BACKENDS = {}
+
 _warning = """ Don't use this field. It's intended for internal use and will be changed or removed
     without warning."""
 
@@ -111,8 +113,12 @@ def make_library_to_link(
         _disable_whole_archive = _disable_whole_archive,
         _lto_compilation_context = _lto_compilation_context,
         _pic_lto_compilation_context = _pic_lto_compilation_context,
-        _shared_non_lto_backends = _cc_internal.freeze(_shared_non_lto_backends),
-        _pic_shared_non_lto_backends = _cc_internal.freeze(_pic_shared_non_lto_backends),
+        _shared_non_lto_backends = (
+            _EMPTY_SHARED_NON_LTO_BACKENDS if _shared_non_lto_backends == {} else _cc_internal.freeze(_shared_non_lto_backends)
+        ),
+        _pic_shared_non_lto_backends = (
+            _EMPTY_SHARED_NON_LTO_BACKENDS if _pic_shared_non_lto_backends == {} else _cc_internal.freeze(_pic_shared_non_lto_backends)
+        ),
     )
 
 def create_library_to_link(

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -236,6 +236,11 @@ def _test_empty_library_impl(env, target):
     linker_inputs = target[CcInfo].linking_context.linker_inputs.to_list()
     for input in linker_inputs:
         for lib in input.libraries:
+            if bazel_features.cc.cc_common_is_in_rules_cc:
+                for backends in (lib._shared_non_lto_backends, lib._pic_shared_non_lto_backends):
+                    if backends != None:
+                        env.expect.that_str(type(backends)).equals("dict")
+                        env.expect.that_collection(backends.keys()).contains_exactly([])
             if lib.dynamic_library != None:
                 env.expect.meta.add_failure(
                     "expected no dynamic library for empty library at runtime",


### PR DESCRIPTION
Reuse one module-frozen empty dictionary for empty PIC and non-PIC shared ThinLTO backend mappings. Nonempty mappings retain Java-backed freezing, None remains unchanged, and both private provider fields continue to contain dictionaries. Extend the empty-library regression to verify mapping types and contents.

Validation: 50 remote C++ common and ThinLTO tests passed.
