### PR TITLE
Validate extra link-time callbacks with Starlark Args

### DIFF
--- a/cc/private/link/create_extra_link_time_library.bzl
+++ b/cc/private/link/create_extra_link_time_library.bzl
@@ -63,7 +63,6 @@ def create_extra_link_time_library(*, build_library_func, **kwargs):
     Returns:
       ExtraLinkTimeLibraryInfo.
     """
-    _cc_internal.check_toplevel(build_library_func)
     return ExtraLinkTimeLibraryInfo(
         build_library_func = build_library_func,
         # Key to identify the "class" of a StarlarkDefinedLinkTimeLibrary. Uses the build function and
@@ -170,6 +169,7 @@ def build_libraries(extra_libraries, ctx, static_mode, for_dynamic_library):
     transitive_runtime_libraries = []
     additional_stamp_infos = []
     for library in extra_libraries:
+        ctx.actions.args().add_all([], map_each = library.build_library_func)
         kwargs = {}
         for key in dir(library):
             if key not in ["build_library_func", "_key"]:

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -7,6 +7,7 @@ load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:cc_binary.bzl", "cc_binary")
 load("//cc:cc_library.bzl", "cc_library")
 load("//cc/common:cc_info.bzl", "CcInfo")
+load("//cc/private/link:create_extra_link_time_library.bzl", "build_libraries", "create_extra_link_time_library")
 load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
 load("//tests/cc/testutil:cc_info_subject.bzl", "cc_info_subject")
 
@@ -659,6 +660,74 @@ def _test_alwayslink_yields_lo_impl(env, target):
     files = [f.basename for f in target[DefaultInfo].files.to_list()]
     env.expect.that_collection(files).contains("libalways_link.lo")
 
+def _build_extra_link_time_library(_ctx, _static_mode, _for_dynamic_library):
+    return struct(
+        linker_input = depset(),
+        runtime_library = depset(),
+    )
+
+def _top_level_extra_link_time_library_impl(ctx):
+    library = create_extra_link_time_library(
+        build_library_func = _build_extra_link_time_library,
+    )
+    build_libraries([library], ctx, False, False)
+    return []
+
+_top_level_extra_link_time_library = rule(
+    implementation = _top_level_extra_link_time_library_impl,
+)
+
+def _nested_extra_link_time_library_impl(ctx):
+    def nested_build_library(_ctx, _static_mode, _for_dynamic_library):
+        return struct(
+            linker_input = depset(),
+            runtime_library = depset(),
+        )
+
+    library = create_extra_link_time_library(
+        build_library_func = nested_build_library,
+    )
+    build_libraries([library], ctx, False, False)
+    return []
+
+_nested_extra_link_time_library = rule(
+    implementation = _nested_extra_link_time_library_impl,
+)
+
+def _test_top_level_extra_link_time_library(name):
+    util.helper_target(
+        _top_level_extra_link_time_library,
+        name = name + "/library",
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_top_level_extra_link_time_library_impl,
+        target = name + "/library",
+    )
+
+def _test_top_level_extra_link_time_library_impl(env, target):
+    env.expect.that_target(target).failures().contains_exactly([])
+
+def _test_nested_extra_link_time_library(name):
+    util.helper_target(
+        _nested_extra_link_time_library,
+        name = name + "/library",
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_nested_extra_link_time_library_impl,
+        target = name + "/library",
+        expect_failure = True,
+    )
+
+def _test_nested_extra_link_time_library_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.custom(
+            "contains 'must be declared by a top-level def statement'",
+            lambda message: "must be declared by a top-level def statement" in message,
+        ),
+    )
+
 def cc_common_tests(name):
     tests = [
         _test_same_cc_file_twice,
@@ -681,6 +750,8 @@ def cc_common_tests(name):
         _test_temps_for_c_without_pic,
         _test_library_in_hdrs,
         _test_alwayslink_yields_lo,
+        _test_top_level_extra_link_time_library,
+        _test_nested_extra_link_time_library,
     ]
     if bazel_features.cc.cc_common_is_in_rules_cc:
         tests.extend([

--- a/tests/cc/common/cc_common_test.bzl
+++ b/tests/cc/common/cc_common_test.bzl
@@ -750,11 +750,11 @@ def cc_common_tests(name):
         _test_temps_for_c_without_pic,
         _test_library_in_hdrs,
         _test_alwayslink_yields_lo,
-        _test_top_level_extra_link_time_library,
-        _test_nested_extra_link_time_library,
     ]
     if bazel_features.cc.cc_common_is_in_rules_cc:
         tests.extend([
+            _test_top_level_extra_link_time_library,
+            _test_nested_extra_link_time_library,
             _test_strip_include_prefix_uses_virtual_includes_by_default,
             _test_strip_include_prefix_no_virtual_includes_when_enabled,
             _test_strip_include_prefix_with_include_prefix_uses_virtual_includes,


### PR DESCRIPTION
Validate extra link-time library callbacks with `ctx.actions.args().add_all([], map_each = callback)` immediately before invocation. `Args.add_all` performs the same top-level-function check as `_cc_internal.check_toplevel`, so the C++ Java helper is no longer needed.

Validation: 88 C++ common and binary analysis tests passed, including new tests for top-level and nested callbacks.
