### PR TITLE
Represent C++ string sequence variables with tuples

### DIFF
--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -210,6 +210,12 @@ def setup_common_compile_build_variables(
     )
     return _cc_internal.combine_cc_toolchain_variables(cc_toolchain._build_variables, common_vars)
 
+def _string_sequence_variable_value(values):
+    for index, value in enumerate(values):
+        if type(value) != "string":
+            fail("at index %d of string_sequence, got element of type %s, want string" % (index, type(value)))
+    return tuple(values)
+
 def _setup_common_compile_build_variables_internal(
         *,
         feature_configuration,
@@ -238,7 +244,7 @@ def _setup_common_compile_build_variables_internal(
         result[_VARS.SYSTEM_INCLUDE_PATHS] = system_include_dirs
     result[_VARS.QUOTE_INCLUDE_PATHS] = quote_include_dirs
     if includes:
-        result[_VARS.INCLUDES] = _cc_internal.intern_string_sequence_variable_value(includes)
+        result[_VARS.INCLUDES] = _string_sequence_variable_value(includes)
     result[_VARS.FRAMEWORK_PATHS] = framework_include_dirs
 
     if is_using_memprof:
@@ -248,12 +254,12 @@ def _setup_common_compile_build_variables_internal(
     all_defines = defines.to_list() + local_defines.to_list() + (
         ["BUILD_FDO_TYPE=\"" + fdo_build_stamp + "\""] if fdo_build_stamp else []
     )
-    result[_VARS.PREPROCESSOR_DEFINES] = _cc_internal.intern_string_sequence_variable_value(all_defines)
+    result[_VARS.PREPROCESSOR_DEFINES] = _string_sequence_variable_value(all_defines)
     result = result | additional_build_variables
 
     for key, value in variables_extension.items():
         if type(value) == type([]):
-            result[key] = _cc_internal.intern_string_sequence_variable_value(value)
+            result[key] = _string_sequence_variable_value(value)
         elif type(value) == type(""):
             result[key] = value
         elif type(value) == type(depset()):
@@ -323,7 +329,7 @@ def get_specific_compile_build_variables(
         result[_VARS.MODULE_MAP_FILE] = cpp_module_map.file
         result[_VARS.DEPENDENT_MODULE_MAP_FILES] = direct_module_maps
 
-    result[_VARS.USER_COMPILE_FLAGS] = _cc_internal.intern_string_sequence_variable_value(user_compile_flags)
+    result[_VARS.USER_COMPILE_FLAGS] = _string_sequence_variable_value(user_compile_flags)
     if source_file:
         result[_VARS.SOURCE_FILE] = source_file
     if output_file:

--- a/cc/private/link/lto_backends.bzl
+++ b/cc/private/link/lto_backends.bzl
@@ -343,7 +343,7 @@ def create_lto_backend_artifacts(
     build_variables = _cc_internal.combine_cc_toolchain_variables(
         build_variables,
         _cc_internal.cc_toolchain_variables(vars = {
-            "user_compile_flags": _cc_internal.intern_string_sequence_variable_value(argv),
+            "user_compile_flags": tuple(argv),
         }),
     )
 

--- a/tests/cc/common/compile_build_variables_tests.bzl
+++ b/tests/cc/common/compile_build_variables_tests.bzl
@@ -1,9 +1,12 @@
 """Tests for compile build variables."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_testing//lib:analysis_test.bzl", "test_suite")
 load("@rules_testing//lib:truth.bzl", "matching", "subjects")
 load("@rules_testing//lib:util.bzl", "TestingAspectInfo", "util")
 load("//cc:cc_binary.bzl", _actual_cc_binary = "cc_binary")
+load("//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "find_cc_toolchain", "use_cc_toolchain")
+load("//cc/common:cc_common.bzl", "cc_common")
 load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
 load("//tests/cc/testutil:link_action_subject.bzl", "link_action_subject")
 
@@ -92,6 +95,66 @@ def _test_presence_of_configuration_compile_flags(name, **kwargs):
 def _test_presence_of_configuration_compile_flags_impl(env, target):
     compile_action = _compile_action(env, target, "bin")
     _variable_list(compile_action, "user_compile_flags").contains_at_least(["-foo", "-bar"]).in_order()
+
+def _test_duplicate_compile_flags(name, **kwargs):
+    util.helper_target(
+        cc_binary,
+        name = name + "/bin",
+        srcs = ["bin.cc"],
+        copts = ["-duplicate", "-middle", "-duplicate"],
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_duplicate_compile_flags_impl,
+        target = name + "/bin",
+        **kwargs
+    )
+
+def _test_duplicate_compile_flags_impl(env, target):
+    compile_action = _compile_action(env, target, "bin")
+    _variable_list(compile_action, "user_compile_flags").contains_at_least([
+        "-duplicate",
+        "-middle",
+        "-duplicate",
+    ]).in_order()
+
+def _invalid_variables_extension_impl(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    cc_common.create_compile_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        variables_extension = {"invalid": ["valid", 42]},
+    )
+    return []
+
+_invalid_variables_extension = rule(
+    implementation = _invalid_variables_extension_impl,
+    attrs = CC_TOOLCHAIN_ATTRS,
+    fragments = ["cpp"],
+    toolchains = use_cc_toolchain(),
+)
+
+def _test_invalid_variables_extension(name, **kwargs):
+    util.helper_target(
+        _invalid_variables_extension,
+        name = name + "/invalid",
+    )
+    cc_analysis_test(
+        name = name,
+        impl = _test_invalid_variables_extension_impl,
+        target = name + "/invalid",
+        expect_failure = True,
+        **kwargs
+    )
+
+def _test_invalid_variables_extension_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("at index 1 of string_sequence, got element of type int, want string"),
+    )
 
 def _test_presence_of_conly_flags(name, **kwargs):
     target_label = "//tests/cc/common:" + name + "/bin"
@@ -406,5 +469,8 @@ def compile_build_variables_tests(name):
             _test_presence_of_is_using_fission_and_per_debug_object_file_variables_with_thinlto,
             _test_presence_of_per_object_debug_file_build_variable,
             _test_presence_of_min_os_version_build_variable,
-        ],
+        ] + ([
+            _test_duplicate_compile_flags,
+            _test_invalid_variables_extension,
+        ] if bazel_features.cc.cc_common_is_in_rules_cc else []),
     )


### PR DESCRIPTION
Replace all five `_cc_internal.intern_string_sequence_variable_value` calls with immutable Starlark tuples in C++ compile and ThinLTO build variables. Preserve element ordering, duplicate flags, and the existing error for non-string variable-extension elements.

Validation: 127 C++ common, binary, ThinLTO, and compile-variable analysis tests passed, including new duplicate-flag and invalid-variable-extension tests. Stable analysis heap changed by -0.13% on the 127-test workload.
