### PR TITLE
Remove unused Objective-C transition flag helper

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -400,10 +400,6 @@ def _check_experimental_cc_shared_library():
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return _cc_common_internal.check_experimental_cc_shared_library()
 
-def _incompatible_disable_objc_library_transition():
-    _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
-    return _cc_common_internal.incompatible_disable_objc_library_transition()
-
 def _add_go_exec_groups_to_binary_rules():
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return _cc_common_internal.add_go_exec_groups_to_binary_rules()
@@ -750,7 +746,6 @@ cc_common = struct(
     create_compilation_context = _create_compilation_context,
     merge_compilation_contexts = merge_compilation_contexts,
     legacy_cc_flags_make_variable_do_not_use = _legacy_cc_flags_make_variable_do_not_use,
-    incompatible_disable_objc_library_transition = _incompatible_disable_objc_library_transition,
     add_go_exec_groups_to_binary_rules = _add_go_exec_groups_to_binary_rules,
     is_cc_toolchain_resolution_enabled_do_not_use = _is_cc_toolchain_resolution_enabled_do_not_use,
     create_cc_toolchain_config_info = create_cc_toolchain_config_info,


### PR DESCRIPTION
Remove the unused `cc_common.incompatible_disable_objc_library_transition` compatibility export and its only `_cc_common_internal.incompatible_disable_objc_library_transition` call. No C++, Objective-C, or external Starlark caller uses this private export; the Bazel built-in wrapper can be removed separately.

Validation: 91 C++ and Objective-C analysis tests passed, plus 26 Objective-C and C++ common tests with the transition flag explicitly enabled and 26 with it explicitly disabled.
