### PR TITLE
Remove unused Go exec-group flag helper

### DIFF
--- a/cc/private/cc_common.bzl
+++ b/cc/private/cc_common.bzl
@@ -404,10 +404,6 @@ def _incompatible_disable_objc_library_transition():
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return _cc_common_internal.incompatible_disable_objc_library_transition()
 
-def _add_go_exec_groups_to_binary_rules():
-    _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
-    return _cc_common_internal.add_go_exec_groups_to_binary_rules()
-
 def _get_tool_requirement_for_action(*, feature_configuration, action_name):
     _cc_internal.check_private_api(allowlist = _PRIVATE_STARLARKIFICATION_ALLOWLIST)
     return _get_execution_requirements(
@@ -751,7 +747,6 @@ cc_common = struct(
     merge_compilation_contexts = merge_compilation_contexts,
     legacy_cc_flags_make_variable_do_not_use = _legacy_cc_flags_make_variable_do_not_use,
     incompatible_disable_objc_library_transition = _incompatible_disable_objc_library_transition,
-    add_go_exec_groups_to_binary_rules = _add_go_exec_groups_to_binary_rules,
     is_cc_toolchain_resolution_enabled_do_not_use = _is_cc_toolchain_resolution_enabled_do_not_use,
     create_cc_toolchain_config_info = create_cc_toolchain_config_info,
     create_linking_context_from_compilation_outputs = _create_linking_context_from_compilation_outputs,


### PR DESCRIPTION
Remove the unused `cc_common.add_go_exec_groups_to_binary_rules` compatibility export and its only `_cc_common_internal.add_go_exec_groups_to_binary_rules` call. Existing `semantics.extra_exec_groups` behavior remains unchanged, and the unused Bazel built-in wrapper can be removed separately.

Validation: 88 C++ common, C++ binary, and Objective-C analysis tests passed.
