### PR TITLE
Pass fission flags to ThinLTO backend actions

### DIFF
--- a/cc/private/toolchain/unix_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/unix_cc_toolchain_config.bzl
@@ -781,6 +781,7 @@ def _impl(ctx):
                     ACTION_NAMES.cpp_compile,
                     ACTION_NAMES.cpp_module_codegen,
                     ACTION_NAMES.cpp20_module_codegen,
+                    ACTION_NAMES.lto_backend,
                 ],
                 flag_groups = [
                     flag_group(

--- a/cc/private/toolchain_config/legacy_features.bzl
+++ b/cc/private/toolchain_config/legacy_features.bzl
@@ -158,6 +158,7 @@ def get_legacy_features(ctx, platform, existing_feature_names, linker_tool_path)
                     ACTION_NAMES.c_compile,
                     ACTION_NAMES.cpp_compile,
                     ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
                     ACTION_NAMES.preprocess_assemble,
                 ],
                 flag_groups = [flag_group(

--- a/tests/default_unix_toolchain/BUILD.bazel
+++ b/tests/default_unix_toolchain/BUILD.bazel
@@ -1,11 +1,18 @@
+load("//cc:cc_binary.bzl", "cc_binary")
 load("//cc:cc_library.bzl", "cc_library")
 load("//cc/private/toolchain:unix_cc_toolchain_config.bzl", "cc_toolchain_config")  # buildifier: disable=bzl-visibility
 load("//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
 load(":unix_archiver_test.bzl", "unix_archiver_tests")
+load(":unix_fission_test.bzl", "unix_fission_tests")
 
 platform(
     name = "macos",
     constraint_values = ["@platforms//os:macos"],
+)
+
+platform(
+    name = "linux",
+    constraint_values = ["@platforms//os:linux"],
 )
 
 filegroup(
@@ -64,4 +71,59 @@ cc_library(
 unix_archiver_tests(
     name = "unix_archiver_tests",
     target = ":archive",
+)
+
+cc_toolchain_config(
+    name = "linux_config",
+    abi_libc_version = "local",
+    abi_version = "local",
+    compiler = "compiler",
+    cpu = "k8",
+    host_system_name = "local",
+    supports_start_end_lib = True,
+    target_libc = "local",
+    target_system_name = "local",
+    tool_paths = {
+        "ar": "/usr/bin/ar",
+        "cpp": "/usr/bin/cpp",
+        "dwp": "/usr/bin/dwp",
+        "gcc": "/usr/bin/clang",
+        "ld": "/usr/bin/ld",
+        "nm": "/usr/bin/nm",
+        "objcopy": "/usr/bin/objcopy",
+        "objdump": "/usr/bin/objdump",
+        "strip": "/usr/bin/strip",
+    },
+    toolchain_identifier = "default-unix-linux-toolchain-test",
+)
+
+cc_toolchain(
+    name = "linux_cc_toolchain",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    toolchain_config = ":linux_config",
+    toolchain_identifier = "default-unix-linux-toolchain-test",
+)
+
+toolchain(
+    name = "linux_cc_toolchain_registration",
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":linux_cc_toolchain",
+    toolchain_type = "//cc:toolchain_type",
+)
+
+cc_binary(
+    name = "fission",
+    srcs = ["fission.cc"],
+)
+
+unix_fission_tests(
+    name = "unix_fission_tests",
+    target = ":fission",
 )

--- a/tests/default_unix_toolchain/fission.cc
+++ b/tests/default_unix_toolchain/fission.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/tests/default_unix_toolchain/unix_fission_test.bzl
+++ b/tests/default_unix_toolchain/unix_fission_test.bzl
@@ -1,0 +1,53 @@
+"""Tests for fission flags on ThinLTO backend actions in the default Unix toolchain."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+
+_LINUX_PLATFORM = str(Label("//tests/default_unix_toolchain:linux"))
+_LINUX_TOOLCHAIN = str(Label("//tests/default_unix_toolchain:linux_cc_toolchain_registration"))
+
+def _lto_backend_action(env, target):
+    backend_actions = [
+        action
+        for action in target.actions
+        if action.mnemonic == "CcLtoBackendCompile"
+    ]
+    env.expect.that_collection(backend_actions).has_size(1)
+    return backend_actions[0]
+
+def _fission_on_lto_backend_test_impl(env, target):
+    action = _lto_backend_action(env, target)
+
+    # Fission is enabled, so a .dwo output is declared for the backend action.
+    dwo_outputs = [
+        file.path
+        for file in action.outputs.to_list()
+        if file.path.endswith(".dwo")
+    ]
+    env.expect.that_collection(dwo_outputs).has_size(1)
+
+    # BUG: the backend action is the one that emits the object file, so it is
+    # the action that has to be told to split the debug info out of it -- but
+    # per_object_debug_info does not cover ACTION_NAMES.lto_backend, so the
+    # flag is absent and the .dwo declared above can never be written.
+    env.expect.that_collection(action.argv).not_contains("-gsplit-dwarf")
+
+def unix_fission_tests(name, target):
+    analysis_test(
+        name = name + "_lto_backend_fission_flags",
+        target = target,
+        impl = _fission_on_lto_backend_test_impl,
+        config_settings = {
+            "//command_line_option:extra_toolchains": [_LINUX_TOOLCHAIN],
+            "//command_line_option:features": [
+                "thin_lto",
+                "per_object_debug_info",
+            ],
+            "//command_line_option:fission": ["yes"],
+            "//command_line_option:platforms": [_LINUX_PLATFORM],
+        },
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [name + "_lto_backend_fission_flags"],
+    )

--- a/tests/default_unix_toolchain/unix_fission_test.bzl
+++ b/tests/default_unix_toolchain/unix_fission_test.bzl
@@ -25,11 +25,9 @@ def _fission_on_lto_backend_test_impl(env, target):
     ]
     env.expect.that_collection(dwo_outputs).has_size(1)
 
-    # BUG: the backend action is the one that emits the object file, so it is
-    # the action that has to be told to split the debug info out of it -- but
-    # per_object_debug_info does not cover ACTION_NAMES.lto_backend, so the
-    # flag is absent and the .dwo declared above can never be written.
-    env.expect.that_collection(action.argv).not_contains("-gsplit-dwarf")
+    # The backend action is the one that emits the object file, so it is the
+    # action that has to be told to split the debug info out of it.
+    env.expect.that_collection(action.argv).contains("-gsplit-dwarf")
 
 def unix_fission_tests(name, target):
     analysis_test(


### PR DESCRIPTION
Fix interaction between `--fission` and `--features=thin_lto`. Without this, every LTO backend action fails:

```
ERROR: output 'prog.lto/bazel-out/k8-opt/bin/_objs/prog/a.dwo' was not created
ERROR: LTO Backend Compile prog.lto/bazel-out/k8-opt/bin/_objs/prog/a.o failed:
       not all outputs were created or valid
```

Fixed by adding `ACTION_NAMES.lto_backend` to the `per_object_debug_info` flag_set in
`cc/private/toolchain/unix_cc_toolchain_config.bzl` and `cc/private/toolchain_config/legacy_features.bzl`.

Adds a test that uses the real Linux `cc_toolchain_config` since that wasn't covered by the existing test, and was broken.