### PR TITLE
Validate variables_extension passed to the linking APIs

### DIFF
--- a/cc/common/cc_helper_internal.bzl
+++ b/cc/common/cc_helper_internal.bzl
@@ -93,6 +93,35 @@ def get_cc_runtimes_copts(ctx):
     cc_runtimes_toolchain = ctx.toolchains[CC_RUNTIMES_TOOLCHAIN_TYPE]
     return cc_runtimes_toolchain.cc_runtimes_info.copts if cc_runtimes_toolchain else []
 
+def validate_variables_extension(variables_extension):
+    """Validates a user-provided variables_extension and normalizes its values.
+
+    Build variable values are stored as opaque objects and are only converted when the toolchain
+    expands them, so unsupported types have to be rejected here, next to the API call that supplied
+    them.
+
+    Args:
+      variables_extension: (dict[str, str|list[str]|depset[str]]) Additional variables as passed to
+        a public cc_common API.
+
+    Returns:
+      A dict of build variables with string sequences interned.
+    """
+    result = {}
+    for key, value in variables_extension.items():
+        if type(value) == type([]):
+            result[key] = _cc_internal.intern_string_sequence_variable_value(value)
+        elif type(value) == type(""):
+            result[key] = value
+        elif type(value) == type(depset()):
+            for e in value.to_list():
+                if type(e) != type(""):
+                    fail("for string_sequence_variables_extension, got element of type " + type(e) + ", want string")
+            result[key] = value
+        else:
+            fail("for variable extension key:" + key + ", got element of type " + type(value) + ", want string")
+    return result
+
 def get_fdo_build_stamp(cpp_configuration, fdo_context, feature_configuration):
     """Returns the FDO build stamp.
 

--- a/cc/private/compile/compile_build_variables.bzl
+++ b/cc/private/compile/compile_build_variables.bzl
@@ -15,7 +15,7 @@
 All build variables we create for various `CppCompileAction`s
 """
 
-load("//cc/common:cc_helper_internal.bzl", "extensions", "get_fdo_build_stamp", "get_linkstamp_stamps", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
+load("//cc/common:cc_helper_internal.bzl", "extensions", "get_fdo_build_stamp", "get_linkstamp_stamps", "validate_variables_extension", _PRIVATE_STARLARKIFICATION_ALLOWLIST = "PRIVATE_STARLARKIFICATION_ALLOWLIST")
 load("//cc/private:cc_info.bzl", "get_module_map_name")
 load("//cc/private:cc_internal.bzl", _cc_internal = "cc_internal")
 load("//cc/private/rules_impl:native_cc_common.bzl", _cc_common_internal = "native_cc_common")
@@ -259,19 +259,7 @@ def _setup_common_compile_build_variables_internal(
     )
     result[_VARS.PREPROCESSOR_DEFINES] = _cc_internal.intern_string_sequence_variable_value(all_defines)
     result = result | additional_build_variables
-
-    for key, value in variables_extension.items():
-        if type(value) == type([]):
-            result[key] = _cc_internal.intern_string_sequence_variable_value(value)
-        elif type(value) == type(""):
-            result[key] = value
-        elif type(value) == type(depset()):
-            for e in value.to_list():
-                if type(e) != type(""):
-                    fail("for string_sequence_variables_extension, got element of type " + type(e) + ", want string")
-            result[key] = value
-        else:
-            fail("for variable extension key:" + key + ", got element of type " + type(value) + ", want string")
+    result = result | validate_variables_extension(variables_extension)
 
     if external_include_dirs:
         result[_VARS.EXTERNAL_INCLUDE_PATHS] = external_include_dirs

--- a/cc/private/link/cc_linking_helper.bzl
+++ b/cc/private/link/cc_linking_helper.bzl
@@ -19,6 +19,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//cc/common:cc_helper_internal.bzl",
     "root_relative_path",
+    "validate_variables_extension",
     "wrap_with_check_private_api",
     _use_pic_for_binaries = "use_pic_for_binaries",
     _use_pic_for_dynamic_libs = "use_pic_for_dynamic_libs",
@@ -150,6 +151,7 @@ def create_cc_link_actions(
     if not compilation_outputs:
         compilation_outputs = EMPTY_COMPILATION_OUTPUTS
     linkopts = list(linkopts)
+    variables_extension = validate_variables_extension(variables_extension)
 
     cpp_config = cc_toolchain._cpp_configuration
     use_pic_for_binaries = _use_pic_for_binaries(cpp_config, feature_configuration)


### PR DESCRIPTION
The compile APIs reject `variables_extension` values that are not strings, string lists or string depsets, but `cc_common.link` and `cc_common.create_linking_context_from_compilation_outputs` merged the dict into the link build variables unchecked, which could cause a Bazel crash on an unsupported value type.