### PR TITLE
Added pure C runfiles implementation

### DIFF
--- a/cc/runfiles/BUILD
+++ b/cc/runfiles/BUILD
@@ -6,6 +6,19 @@ cc_library(
     name = "runfiles",
     srcs = ["runfiles.cc"],
     hdrs = ["runfiles.h"],
+    implementation_deps = [":runfiles_c"],
+    include_prefix = "rules_cc/cc/runfiles",
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "runfiles_c",
+    srcs = ["runfiles_c.c"],
+    hdrs = [
+        "runfiles_c.h",
+        "runfiles_c_internal.h",
+    ],
     include_prefix = "rules_cc/cc/runfiles",
     strip_include_prefix = ".",
     visibility = ["//visibility:public"],
@@ -14,6 +27,7 @@ cc_library(
 filegroup(
     name = "srcs",
     srcs = glob([
+        "*.c",
         "*.cc",
         "*.h",
     ]) + [

--- a/cc/runfiles/BUILD
+++ b/cc/runfiles/BUILD
@@ -6,7 +6,10 @@ cc_library(
     name = "runfiles",
     srcs = ["runfiles.cc"],
     hdrs = ["runfiles.h"],
-    implementation_deps = [":runfiles_c"],
+    implementation_deps = [
+        ":runfiles_c",
+        ":runfiles_c_internal",
+    ],
     include_prefix = "rules_cc/cc/runfiles",
     strip_include_prefix = ".",
     visibility = ["//visibility:public"],
@@ -15,13 +18,19 @@ cc_library(
 cc_library(
     name = "runfiles_c",
     srcs = ["runfiles_c.c"],
-    hdrs = [
-        "runfiles_c.h",
-        "runfiles_c_internal.h",
-    ],
+    hdrs = ["runfiles_c.h"],
+    implementation_deps = [":runfiles_c_internal"],
     include_prefix = "rules_cc/cc/runfiles",
     strip_include_prefix = ".",
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "runfiles_c_internal",
+    hdrs = ["runfiles_c_internal.h"],
+    include_prefix = "rules_cc/cc/runfiles",
+    strip_include_prefix = ".",
+    visibility = ["//cc/runfiles:__pkg__"],
 )
 
 filegroup(

--- a/cc/runfiles/README.md
+++ b/cc/runfiles/README.md
@@ -1,0 +1,3 @@
+# runfiles
+
+For details see [//docs:runfiles.md](../../docs/runfiles.md).

--- a/cc/runfiles/README.md
+++ b/cc/runfiles/README.md
@@ -1,3 +1,18 @@
 # runfiles
 
 For details see [//docs:runfiles.md](../../docs/runfiles.md).
+
+## Testing
+
+The test suites in `//tests/runfiles/` cover manifest parsing (both
+forms + escapes), envvar / argv0 / directory discovery, and
+`_repo_mapping` in all its variants (exact match, wildcard, per-call
+source-repo override). The pure-C tests additionally exercise the
+custom allocator hook and verify that `rf_rlocation` outputs route
+through it.
+
+```bash
+bazel test //tests/runfiles:runfiles_test       # C++ API
+bazel test //tests/runfiles:runfiles_c_test     # C API from C++
+bazel test //tests/runfiles:runfiles_c_pure_test # C API from C
+```

--- a/cc/runfiles/runfiles.cc
+++ b/cc/runfiles/runfiles.cc
@@ -14,182 +14,121 @@
 
 #include "rules_cc/cc/runfiles/runfiles.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#else  // not _WIN32
-#include <stdlib.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif  // _WIN32
+extern "C" {
+#include "rules_cc/cc/runfiles/runfiles_c.h"
+#include "rules_cc/cc/runfiles/runfiles_c_internal.h"
+}
 
-#include <fstream>
+#include <cstdlib>
 #include <functional>
-#include <map>
-#include <sstream>
-#include <vector>
+#include <string>
 #include <utility>
-
-#ifdef _WIN32
-#include <memory>
-#endif  // _WIN32
+#include <vector>
 
 namespace rules_cc {
 namespace cc {
 namespace runfiles {
 
 using std::function;
-using std::map;
 using std::pair;
 using std::string;
 using std::vector;
 
 namespace {
 
-bool starts_with(const string& s, const string& prefix) {
-  return s.compare(0, prefix.size(), prefix) == 0;
+// Read an env-var as a UTF-8 std::string via the C library's
+// rf_getenv_alloc, so Windows Unicode env-var handling lives in one
+// place across both languages.
+string GetEnv(const string& key) {
+  char* raw = rf_getenv_alloc(key.c_str());
+  if (!raw) return string();
+  string out(raw);
+  std::free(raw);
+  return out;
 }
 
-bool contains(const string& s, const string& substr) {
-  return s.find(substr) != string::npos;
+// Populate the EnvVars() vector once at construction. Buffers sized to
+// cover any real filesystem path (rf_paths_from itself caps at 4096;
+// 8192 gives headroom for the JAVA_RUNFILES / RUNFILES_DIR keys).
+vector<pair<string, string> > BuildEnvVars(rf_runfiles* rf) {
+  int n = rf_env_vars_count(rf);
+  vector<pair<string, string> > out;
+  out.reserve(static_cast<size_t>(n));
+  char k[128];
+  char v[8192];
+  for (int i = 0; i < n; i++) {
+    if (rf_env_var(rf, i, k, sizeof(k), v, sizeof(v))) {
+      out.emplace_back(k, v);
+    }
+  }
+  return out;
 }
 
-bool ends_with(const string& s, const string& suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+// Bridge the std::function predicates from TestOnly_PathsFrom down to
+// the C #rf_predicate function-pointer shape. Not on the production
+// code path.
+using PredicatePair =
+    pair<function<bool(const string&)>, function<bool(const string&)> >;
+int PredicateTrampolineIsMf(void* userdata, const char* path) {
+  auto* p = static_cast<PredicatePair*>(userdata);
+  return p->first(path) ? 1 : 0;
 }
-
-bool IsReadableFile(const string& path) {
-  return std::ifstream(path).is_open();
+int PredicateTrampolineIsDir(void* userdata, const char* path) {
+  auto* p = static_cast<PredicatePair*>(userdata);
+  return p->second(path) ? 1 : 0;
 }
-
-bool IsDirectory(const string& path) {
-#ifdef _WIN32
-  DWORD attrs = GetFileAttributesA(path.c_str());
-  return (attrs != INVALID_FILE_ATTRIBUTES) &&
-         (attrs & FILE_ATTRIBUTE_DIRECTORY);
-#else
-  struct stat buf;
-  return stat(path.c_str(), &buf) == 0 && S_ISDIR(buf.st_mode);
-#endif
-}
-
-bool PathsFrom(const std::string& argv0, std::string runfiles_manifest_file,
-               std::string runfiles_dir, std::string* out_manifest,
-               std::string* out_directory);
-
-bool PathsFrom(const std::string& argv0, std::string runfiles_manifest_file,
-               std::string runfiles_dir,
-               std::function<bool(const std::string&)> is_runfiles_manifest,
-               std::function<bool(const std::string&)> is_runfiles_directory,
-               std::string* out_manifest, std::string* out_directory);
-
-bool ParseManifest(const string& path, map<string, string>* result,
-                   string* error);
-bool ParseRepoMapping(const string& path,
-                      map<pair<string, string>, string>* result, string* error);
 
 }  // namespace
 
+Runfiles::~Runfiles() { rf_free(handle_); }
+
+// Full-parameter constructor — every other Create overload eventually
+// forwards here.
 Runfiles* Runfiles::Create(const string& argv0,
                            const string& runfiles_manifest_file,
                            const string& runfiles_dir,
                            const string& source_repository, string* error) {
-  string manifest, directory;
-  if (!PathsFrom(argv0, runfiles_manifest_file, runfiles_dir, &manifest,
-                 &directory)) {
-    if (error) {
-      std::ostringstream err;
-      err << "ERROR: " << __FILE__ << "(" << __LINE__
-          << "): cannot find runfiles (argv0=\"" << argv0 << "\")";
-      *error = err.str();
-    }
+  char err[512] = {0};
+  rf_runfiles* handle = rf_create_ex(
+      /*alloc=*/nullptr, argv0.c_str(), runfiles_manifest_file.c_str(),
+      runfiles_dir.c_str(), source_repository.c_str(), err, sizeof(err));
+  if (!handle) {
+    if (error) *error = err;
     return nullptr;
   }
+  return new Runfiles(handle, source_repository, BuildEnvVars(handle));
+}
 
-  vector<pair<string, string> > envvars = {
-      {"RUNFILES_MANIFEST_FILE", manifest},
-      {"RUNFILES_DIR", directory},
-      // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can
-      // pick up RUNFILES_DIR.
-      {"JAVA_RUNFILES", directory}};
+Runfiles* Runfiles::Create(const string& argv0,
+                           const string& runfiles_manifest_file,
+                           const string& runfiles_dir, string* error) {
+  return Create(argv0, runfiles_manifest_file, runfiles_dir, "", error);
+}
 
-  map<string, string> runfiles;
-  if (!manifest.empty()) {
-    if (!ParseManifest(manifest, &runfiles, error)) {
-      return nullptr;
-    }
-  }
+Runfiles* Runfiles::Create(const string& argv0, const string& source_repository,
+                           string* error) {
+  return Create(argv0, GetEnv("RUNFILES_MANIFEST_FILE"), GetEnv("RUNFILES_DIR"),
+                source_repository, error);
+}
 
-  map<pair<string, string>, string> mapping;
-  if (!ParseRepoMapping(
-          RlocationUnchecked("_repo_mapping", runfiles, directory), &mapping,
-          error)) {
+Runfiles* Runfiles::Create(const string& argv0, string* error) {
+  return Create(argv0, "", error);
+}
+
+Runfiles* Runfiles::CreateForTest(const string& source_repository,
+                                  string* error) {
+  char err[512] = {0};
+  rf_runfiles* handle = rf_create_for_test_ex(
+      /*alloc=*/nullptr, source_repository.c_str(), err, sizeof(err));
+  if (!handle) {
+    if (error) *error = err;
     return nullptr;
   }
-
-  return new Runfiles(std::move(runfiles), std::move(directory),
-                      std::move(mapping), std::move(envvars),
-                      string(source_repository));
+  return new Runfiles(handle, source_repository, BuildEnvVars(handle));
 }
 
-bool IsAbsolute(const string& path) {
-  if (path.empty()) {
-    return false;
-  }
-  char c = path.front();
-  return (c == '/' && (path.size() < 2 || path[1] != '/')) ||
-         (path.size() >= 3 &&
-          ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) &&
-          path[1] == ':' && (path[2] == '\\' || path[2] == '/'));
-}
-
-string GetEnv(const string& key) {
-#ifdef _WIN32
-  DWORD size = ::GetEnvironmentVariableA(key.c_str(), nullptr, 0);
-  if (size == 0) {
-    return string();  // unset or empty envvar
-  }
-  std::unique_ptr<char[]> value(new char[size]);
-  ::GetEnvironmentVariableA(key.c_str(), value.get(), size);
-  return value.get();
-#else
-  char* result = getenv(key.c_str());
-  return (result == nullptr) ? string() : string(result);
-#endif
-}
-
-// Replaces \s, \n, and \b with their respective characters.
-string Unescape(const string& path) {
-  string result;
-  result.reserve(path.size());
-  for (size_t i = 0; i < path.size(); ++i) {
-    if (path[i] == '\\' && i + 1 < path.size()) {
-      switch (path[i + 1]) {
-        case 's': {
-          result.push_back(' ');
-          break;
-        }
-        case 'n': {
-          result.push_back('\n');
-          break;
-        }
-        case 'b': {
-          result.push_back('\\');
-          break;
-        }
-        default: {
-          result.push_back(path[i]);
-          result.push_back(path[i + 1]);
-          break;
-        }
-      }
-      ++i;
-    } else {
-      result.push_back(path[i]);
-    }
-  }
-  return result;
+Runfiles* Runfiles::CreateForTest(string* error) {
+  return CreateForTest("", error);
 }
 
 string Runfiles::Rlocation(const string& path) const {
@@ -198,185 +137,16 @@ string Runfiles::Rlocation(const string& path) const {
 
 string Runfiles::Rlocation(const string& path,
                            const string& source_repo) const {
-  if (path.empty() || starts_with(path, "../") || contains(path, "/..") ||
-      starts_with(path, "./") || contains(path, "/./") ||
-      ends_with(path, "/.") || contains(path, "//")) {
-    return string();
-  }
-  if (IsAbsolute(path)) {
-    return path;
-  }
-
-  string::size_type first_slash = path.find_first_of('/');
-  if (first_slash == string::npos) {
-    return RlocationUnchecked(path, runfiles_map_, directory_);
-  }
-  string target_apparent = path.substr(0, first_slash);
-  auto lookup_key = std::make_pair(target_apparent, source_repo);
-  // The smallest entry that is greater than lookup_key.
-  auto upper_bound = repo_mapping_.upper_bound(lookup_key);
-  // The largest entry that is less than or equal to lookup_key.
-  auto floor = upper_bound == repo_mapping_.begin() ? upper_bound
-                                                    : std::prev(upper_bound);
-  if (floor == repo_mapping_.end()) {
-    return RlocationUnchecked(path, runfiles_map_, directory_);
-  }
-  if (floor->first == lookup_key) {
-    return RlocationUnchecked(floor->second + path.substr(first_slash),
-                              runfiles_map_, directory_);
-  }
-  // Since the asterisk sorts before any other valid character in a repo name,
-  // the floor element may be a prefix match.
-  std::pair<string, string> key;
-  string value;
-  std::tie(key, value) = *floor;
-  if (key.first == target_apparent &&
-      ends_with(key.second, "*") &&
-      starts_with(
-        source_repo, key.second.substr( 0, key.second.size() - 1))) {
-    return RlocationUnchecked(
-      value + path.substr(first_slash), runfiles_map_, directory_);
-  }
-  return RlocationUnchecked(path, runfiles_map_, directory_);
+  // 8 KB output buffer covers any real filesystem path. rf_rlocation
+  // returns <=0 for invalid paths, unknown runfiles, or buffer-too-
+  // small; all of those legitimately produce the empty string on the
+  // C++ side.
+  char buf[8192];
+  int n = rf_rlocation_from(handle_, path.c_str(), source_repo.c_str(), buf,
+                            sizeof(buf));
+  if (n <= 0) return string();
+  return string(buf, static_cast<size_t>(n));
 }
-
-string Runfiles::RlocationUnchecked(const string& path,
-                                    const map<string, string>& runfiles_map,
-                                    const string& directory) {
-  const auto exact_match = runfiles_map.find(path);
-  if (exact_match != runfiles_map.end()) {
-    return exact_match->second;
-  }
-  if (!runfiles_map.empty()) {
-    // If path references a runfile that lies under a directory that itself is a
-    // runfile, then only the directory is listed in the manifest. Look up all
-    // prefixes of path in the manifest and append the relative path from the
-    // prefix to the looked up path.
-    std::size_t prefix_end = path.size();
-    while ((prefix_end = path.find_last_of('/', prefix_end - 1)) !=
-           string::npos) {
-      const string prefix = path.substr(0, prefix_end);
-      const auto prefix_match = runfiles_map.find(prefix);
-      if (prefix_match != runfiles_map.end()) {
-        return prefix_match->second + "/" + path.substr(prefix_end + 1);
-      }
-    }
-  }
-  if (!directory.empty()) {
-    return directory + "/" + path;
-  }
-  return "";
-}
-
-namespace {
-
-bool ParseManifest(const string& path, map<string, string>* result,
-                   string* error) {
-  std::ifstream stm(path);
-  if (!stm.is_open()) {
-    if (error) {
-      std::ostringstream err;
-      err << "ERROR: " << __FILE__ << "(" << __LINE__
-          << "): cannot open runfiles manifest \"" << path << "\"";
-      *error = err.str();
-    }
-    return false;
-  }
-  string line;
-  std::getline(stm, line);
-  size_t line_count = 1;
-  while (!line.empty()) {
-    std::string source;
-    std::string target;
-    if (line[0] == ' ') {
-      // The link path contains escape sequences for spaces and backslashes.
-      string::size_type idx = line.find(' ', 1);
-      if (idx == string::npos) {
-        if (error) {
-          std::ostringstream err;
-          err << "ERROR: " << __FILE__ << "(" << __LINE__
-              << "): bad runfiles manifest entry in \"" << path << "\" line #"
-              << line_count << ": \"" << line << "\"";
-          *error = err.str();
-        }
-        return false;
-      }
-      source = Unescape(line.substr(1, idx - 1));
-      target = Unescape(line.substr(idx + 1));
-    } else {
-      string::size_type idx = line.find(' ');
-      if (idx == string::npos) {
-        if (error) {
-          std::ostringstream err;
-          err << "ERROR: " << __FILE__ << "(" << __LINE__
-              << "): bad runfiles manifest entry in \"" << path << "\" line #"
-              << line_count << ": \"" << line << "\"";
-          *error = err.str();
-        }
-        return false;
-      }
-      source = line.substr(0, idx);
-      target = line.substr(idx + 1);
-    }
-    (*result)[source] = target;
-    std::getline(stm, line);
-    ++line_count;
-  }
-  return true;
-}
-
-bool ParseRepoMapping(const string& path,
-                      map<pair<string, string>, string>* result,
-                      string* error) {
-  std::ifstream stm(path);
-  if (!stm.is_open()) {
-    return true;
-  }
-  string line;
-  std::getline(stm, line);
-  size_t line_count = 1;
-  while (!line.empty()) {
-    string::size_type first_comma = line.find_first_of(',');
-    if (first_comma == string::npos) {
-      if (error) {
-        std::ostringstream err;
-        err << "ERROR: " << __FILE__ << "(" << __LINE__
-            << "): bad repository mapping entry in \"" << path << "\" line #"
-            << line_count << ": \"" << line << "\"";
-        *error = err.str();
-      }
-      return false;
-    }
-    string::size_type second_comma = line.find_first_of(',', first_comma + 1);
-    if (second_comma == string::npos) {
-      if (error) {
-        std::ostringstream err;
-        err << "ERROR: " << __FILE__ << "(" << __LINE__
-            << "): bad repository mapping entry in \"" << path << "\" line #"
-            << line_count << ": \"" << line << "\"";
-        *error = err.str();
-      }
-      return false;
-    }
-
-    // If the source repo ends with an asterisk, the line is supposed to match
-    // any name that starts with the prefix up to the asterisk. Since an
-    // asterisk sorts before any other valid character in a repo name, we can
-    // insert the line as is and search for a lower bound if we store the
-    // apparent target repo name first in the map key.
-    string source = line.substr(0, first_comma);
-    string target_apparent =
-        line.substr(first_comma + 1, second_comma - (first_comma + 1));
-    string target = line.substr(second_comma + 1);
-
-    (*result)[std::make_pair(target_apparent, source)] = target;
-    std::getline(stm, line);
-    ++line_count;
-  }
-  return true;
-}
-
-}  // namespace
 
 namespace testing {
 
@@ -384,106 +154,24 @@ bool TestOnly_PathsFrom(const string& argv0, string mf, string dir,
                         function<bool(const string&)> is_runfiles_manifest,
                         function<bool(const string&)> is_runfiles_directory,
                         string* out_manifest, string* out_directory) {
-  return PathsFrom(argv0, mf, dir, is_runfiles_manifest, is_runfiles_directory,
-                   out_manifest, out_directory);
+  PredicatePair ctx(std::move(is_runfiles_manifest),
+                    std::move(is_runfiles_directory));
+  char mf_buf[4096] = {0};
+  char dir_buf[4096] = {0};
+  int ok =
+      rf_paths_from(argv0.c_str(), mf.c_str(), dir.c_str(),
+                    &PredicateTrampolineIsMf, &PredicateTrampolineIsDir, &ctx,
+                    mf_buf, sizeof(mf_buf), dir_buf, sizeof(dir_buf));
+  *out_manifest = mf_buf;
+  *out_directory = dir_buf;
+  return ok != 0;
 }
 
-bool TestOnly_IsAbsolute(const string& path) { return IsAbsolute(path); }
+bool TestOnly_IsAbsolute(const string& path) {
+  return rf_is_absolute(path.c_str()) != 0;
+}
 
 }  // namespace testing
-
-Runfiles* Runfiles::Create(const std::string& argv0,
-                           const std::string& runfiles_manifest_file,
-                           const std::string& runfiles_dir,
-                           std::string* error) {
-  return Runfiles::Create(argv0, runfiles_manifest_file, runfiles_dir, "",
-                          error);
-}
-
-Runfiles* Runfiles::Create(const string& argv0, const string& source_repository,
-                           string* error) {
-  return Runfiles::Create(argv0, GetEnv("RUNFILES_MANIFEST_FILE"),
-                          GetEnv("RUNFILES_DIR"), source_repository, error);
-}
-
-Runfiles* Runfiles::Create(const string& argv0, string* error) {
-  return Runfiles::Create(argv0, "", error);
-}
-
-Runfiles* Runfiles::CreateForTest(const string& source_repository,
-                                  std::string* error) {
-  return Runfiles::Create(std::string(), GetEnv("RUNFILES_MANIFEST_FILE"),
-                          GetEnv("TEST_SRCDIR"), source_repository, error);
-}
-
-Runfiles* Runfiles::CreateForTest(std::string* error) {
-  return Runfiles::CreateForTest("", error);
-}
-
-namespace {
-
-bool PathsFrom(const string& argv0, string mf, string dir, string* out_manifest,
-               string* out_directory) {
-  return PathsFrom(
-      argv0, mf, dir, [](const string& path) { return IsReadableFile(path); },
-      [](const string& path) { return IsDirectory(path); }, out_manifest,
-      out_directory);
-}
-
-bool PathsFrom(const string& argv0, string mf, string dir,
-               function<bool(const string&)> is_runfiles_manifest,
-               function<bool(const string&)> is_runfiles_directory,
-               string* out_manifest, string* out_directory) {
-  out_manifest->clear();
-  out_directory->clear();
-
-  bool mfValid = is_runfiles_manifest(mf);
-  bool dirValid = is_runfiles_directory(dir);
-
-  if (!argv0.empty() && !mfValid && !dirValid) {
-    mf = argv0 + ".runfiles/MANIFEST";
-    dir = argv0 + ".runfiles";
-    mfValid = is_runfiles_manifest(mf);
-    dirValid = is_runfiles_directory(dir);
-    if (!mfValid) {
-      mf = argv0 + ".runfiles_manifest";
-      mfValid = is_runfiles_manifest(mf);
-    }
-  }
-
-  if (!mfValid && !dirValid) {
-    return false;
-  }
-
-  if (!mfValid) {
-    mf = dir + "/MANIFEST";
-    mfValid = is_runfiles_manifest(mf);
-    if (!mfValid) {
-      mf = dir + "_manifest";
-      mfValid = is_runfiles_manifest(mf);
-    }
-  }
-
-  if (!dirValid &&
-      (ends_with(mf, ".runfiles_manifest") || ends_with(mf, "/MANIFEST"))) {
-    static const size_t kSubstrLen = 9;  // "_manifest" or "/MANIFEST"
-    dir = mf.substr(0, mf.size() - kSubstrLen);
-    dirValid = is_runfiles_directory(dir);
-  }
-
-  if (mfValid) {
-    *out_manifest = mf;
-  }
-
-  if (dirValid) {
-    *out_directory = dir;
-  }
-
-  return true;
-}
-
-}  // namespace
-
 }  // namespace runfiles
 }  // namespace cc
 }  // namespace rules_cc

--- a/cc/runfiles/runfiles.cc
+++ b/cc/runfiles/runfiles.cc
@@ -36,37 +36,30 @@ using std::vector;
 
 namespace {
 
-// Read an env-var as a UTF-8 std::string via the C library's
-// rf_getenv_alloc, so Windows Unicode env-var handling lives in one
-// place across both languages.
+// Route env-var reads through the C library so Windows Unicode env-var
+// handling (GetEnvironmentVariableW) lives in one place across both
+// languages. NULL allocator -> libc malloc, paired with the std::free
+// below.
 string GetEnv(const string& key) {
-  char* raw = rf_getenv_alloc(key.c_str());
+  char* raw = rf_getenv_alloc(/*alloc=*/nullptr, key.c_str());
   if (!raw) return string();
   string out(raw);
   std::free(raw);
   return out;
 }
 
-// Populate the EnvVars() vector once at construction. Buffers sized to
-// cover any real filesystem path (rf_paths_from itself caps at 4096;
-// 8192 gives headroom for the JAVA_RUNFILES / RUNFILES_DIR keys).
 vector<pair<string, string> > BuildEnvVars(rf_runfiles* rf) {
-  int n = rf_env_vars_count(rf);
+  int n = rf_env_vars_count();
   vector<pair<string, string> > out;
   out.reserve(static_cast<size_t>(n));
-  char k[128];
-  char v[8192];
   for (int i = 0; i < n; i++) {
-    if (rf_env_var(rf, i, k, sizeof(k), v, sizeof(v))) {
-      out.emplace_back(k, v);
-    }
+    const char* k = rf_env_var_key(i);
+    const char* v = rf_env_var_value(rf, i);
+    if (k && v) out.emplace_back(k, v);
   }
   return out;
 }
 
-// Bridge the std::function predicates from TestOnly_PathsFrom down to
-// the C #rf_predicate function-pointer shape. Not on the production
-// code path.
 using PredicatePair =
     pair<function<bool(const string&)>, function<bool(const string&)> >;
 int PredicateTrampolineIsMf(void* userdata, const char* path) {
@@ -80,16 +73,15 @@ int PredicateTrampolineIsDir(void* userdata, const char* path) {
 
 }  // namespace
 
-Runfiles::~Runfiles() { rf_free(handle_); }
+// Out-of-line only because the class has a virtual destructor.
+Runfiles::~Runfiles() = default;
 
-// Full-parameter constructor — every other Create overload eventually
-// forwards here.
 Runfiles* Runfiles::Create(const string& argv0,
                            const string& runfiles_manifest_file,
                            const string& runfiles_dir,
                            const string& source_repository, string* error) {
   char err[512] = {0};
-  rf_runfiles* handle = rf_create_ex(
+  rf_runfiles* handle = rf_create(
       /*alloc=*/nullptr, argv0.c_str(), runfiles_manifest_file.c_str(),
       runfiles_dir.c_str(), source_repository.c_str(), err, sizeof(err));
   if (!handle) {
@@ -118,7 +110,7 @@ Runfiles* Runfiles::Create(const string& argv0, string* error) {
 Runfiles* Runfiles::CreateForTest(const string& source_repository,
                                   string* error) {
   char err[512] = {0};
-  rf_runfiles* handle = rf_create_for_test_ex(
+  rf_runfiles* handle = rf_create_for_test(
       /*alloc=*/nullptr, source_repository.c_str(), err, sizeof(err));
   if (!handle) {
     if (error) *error = err;
@@ -137,15 +129,23 @@ string Runfiles::Rlocation(const string& path) const {
 
 string Runfiles::Rlocation(const string& path,
                            const string& source_repo) const {
-  // 8 KB output buffer covers any real filesystem path. rf_rlocation
-  // returns <=0 for invalid paths, unknown runfiles, or buffer-too-
-  // small; all of those legitimately produce the empty string on the
-  // C++ side.
-  char buf[8192];
-  int n = rf_rlocation_from(handle_, path.c_str(), source_repo.c_str(), buf,
-                            sizeof(buf));
-  if (n <= 0) return string();
-  return string(buf, static_cast<size_t>(n));
+  // Grow-and-retry at most once: BUF_TOO_SMALL reports the exact
+  // required size, so a second call with `needed + 1` is guaranteed to
+  // fit. std::string handles growth via std::allocator.
+  string buf;
+  buf.resize(4096);
+  size_t needed = 0;
+  rf_rlocation_status s =
+      rf_rlocation(handle_.get(), path.c_str(), source_repo.c_str(), &buf[0],
+                   buf.size(), &needed);
+  if (s == RF_RLOCATION_BUF_TOO_SMALL) {
+    buf.resize(needed + 1);
+    s = rf_rlocation(handle_.get(), path.c_str(), source_repo.c_str(), &buf[0],
+                     buf.size(), &needed);
+  }
+  if (s != RF_RLOCATION_OK) return string();
+  buf.resize(needed);
+  return buf;
 }
 
 namespace testing {
@@ -156,14 +156,16 @@ bool TestOnly_PathsFrom(const string& argv0, string mf, string dir,
                         string* out_manifest, string* out_directory) {
   PredicatePair ctx(std::move(is_runfiles_manifest),
                     std::move(is_runfiles_directory));
-  char mf_buf[4096] = {0};
-  char dir_buf[4096] = {0};
-  int ok =
-      rf_paths_from(argv0.c_str(), mf.c_str(), dir.c_str(),
-                    &PredicateTrampolineIsMf, &PredicateTrampolineIsDir, &ctx,
-                    mf_buf, sizeof(mf_buf), dir_buf, sizeof(dir_buf));
-  *out_manifest = mf_buf;
-  *out_directory = dir_buf;
+  // NULL allocator -> libc malloc; paired with std::free below.
+  char* mf_out = nullptr;
+  char* dir_out = nullptr;
+  int ok = rf_paths_from(argv0.c_str(), mf.c_str(), dir.c_str(),
+                         &PredicateTrampolineIsMf, &PredicateTrampolineIsDir,
+                         &ctx, /*alloc=*/nullptr, &mf_out, &dir_out);
+  out_manifest->assign(mf_out ? mf_out : "");
+  out_directory->assign(dir_out ? dir_out : "");
+  std::free(mf_out);
+  std::free(dir_out);
   return ok != 0;
 }
 

--- a/cc/runfiles/runfiles.h
+++ b/cc/runfiles/runfiles.h
@@ -12,236 +12,195 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Runfiles lookup library for Bazel-built C++ binaries and tests.
-//
-// USAGE:
-// 1.  Depend on this runfiles library from your build rule:
-//
-//       cc_binary(
-//           name = "my_binary",
-//           ...
-//           deps = ["@rules_cc//cc/runfiles"],
-//       )
-//
-// 2.  Include the runfiles library.
-//
-//       #include "rules_cc/cc/runfiles/runfiles.h"
-//
-//       using rules_cc::cc::runfiles::Runfiles;
-//
-// 3.  Create a Runfiles object and use rlocation to look up runfile paths:
-//
-//       int main(int argc, char** argv) {
-//         std::string error;
-//         std::unique_ptr<Runfiles> runfiles(
-//             Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
-//
-//         // Important:
-//         //   If this is a test, use
-//         //   Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error).
-//
-//         if (runfiles == nullptr) {
-//           ...  // error handling
-//         }
-//         std::string path =
-//             runfiles->Rlocation("my_workspace/path/to/my/data.txt");
-//         ...
-//
-//      The code above creates a Runfiles object and retrieves a runfile path.
-//      The BAZEL_CURRENT_REPOSITORY macro is available in every target that
-//      depends on the runfiles library.
-//
-//      The Runfiles::Create function uses the runfiles manifest and the
-//      runfiles directory from the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
-//      environment variables. If not present, the function looks for the
-//      manifest and directory near argv[0], the path of the main program.
-//
-// To start child processes that also need runfiles, you need to set the right
-// environment variables for them:
-//
-//   std::unique_ptr<Runfiles> runfiles(Runfiles::Create(
-//     argv[0], BAZEL_CURRENT_REPOSITORY, &error));
-//
-//   std::string path = runfiles->Rlocation("path/to/binary"));
-//   if (!path.empty()) {
-//     ... // create "args" argument vector for execv
-//     const auto envvars = runfiles->EnvVars();
-//     pid_t child = fork();
-//     if (child) {
-//       int status;
-//       waitpid(child, &status, 0);
-//     } else {
-//       for (const auto i : envvars) {
-//         setenv(i.first.c_str(), i.second.c_str(), 1);
-//       }
-//       execv(args[0], args);
-//     }
+/// @file runfiles.h
+/// @brief Runfiles lookup library for Bazel-built C++ binaries and tests.
+///
+/// ### Usage
+///
+/// 1. Depend on this runfiles library from your build rule:
+///
+/// @code{.py}
+///   cc_binary(
+///       name = "my_binary",
+///       ...
+///       deps = ["@rules_cc//cc/runfiles"],
+///   )
+/// @endcode
+///
+/// 2. Include the runfiles library.
+///
+/// @code{.cpp}
+///   #include "rules_cc/cc/runfiles/runfiles.h"
+///
+///   using rules_cc::cc::runfiles::Runfiles;
+/// @endcode
+///
+/// 3. Create a #rules_cc::cc::runfiles::Runfiles instance and use
+///    #rules_cc::cc::runfiles::Runfiles::Rlocation to look up runfile
+///    paths:
+///
+/// @code{.cpp}
+///   int main(int argc, char** argv) {
+///     std::string error;
+///     std::unique_ptr<Runfiles> runfiles(
+///         Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
+///
+///     // Important: if this is a test, use
+///     //   Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error).
+///
+///     if (runfiles == nullptr) { /* handle error */ }
+///     std::string path =
+///         runfiles->Rlocation("my_workspace/path/to/my/data.txt");
+///     ...
+///   }
+/// @endcode
+///
+/// The `BAZEL_CURRENT_REPOSITORY` macro is available in every target
+/// that depends on the runfiles library.
+///
+/// `Runfiles::Create` uses the runfiles manifest and the runfiles
+/// directory from the `RUNFILES_MANIFEST_FILE` and `RUNFILES_DIR`
+/// environment variables. If not present, the function looks for the
+/// manifest and directory near `argv[0]`, the path of the main
+/// program.
+///
+/// ### Subprocesses
+///
+/// To start child processes that also need runfiles, iterate
+/// #rules_cc::cc::runfiles::Runfiles::EnvVars and set the returned
+/// key/value pairs in the child's environment.
+///
+/// ### Sharing / lifetime
+///
+/// Each `Runfiles::Create` call parses the manifest and `_repo_mapping`
+/// from disk and returns an instance that fully owns its parsed data.
+/// Callers that want to reuse a parse across scopes / threads should
+/// hold the returned #Runfiles via a `std::shared_ptr<Runfiles>`
+/// themselves — the library does not maintain a process-wide cache.
+///
+/// ### Thread safety
+///
+/// Different #Runfiles instances are independent. A single instance is
+/// safe for parallel #Rlocation reads (the parsed state is immutable
+/// after construction); mixing reads with destruction is the caller's
+/// problem — same contract as `std::vector`.
 
 #ifndef RULES_CC_CC_RUNFILES_RUNFILES_H_
-#define RULES_CC_CC_RUNFILES_RUNFILES_H_ 1
+#define RULES_CC_CC_RUNFILES_RUNFILES_H_
 
 #include <functional>
-#include <map>
-#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
+
+// Opaque C handle owned by every #Runfiles instance. Forward-declared
+// here so the C header does not need to be included by C++ callers.
+extern "C" {
+struct rf_runfiles;
+}
 
 namespace rules_cc {
 namespace cc {
 namespace runfiles {
 
+/// Runfiles lookup for Bazel-built C++ binaries and tests.
+///
+/// Thin RAII wrapper over the underlying pure-C runfiles library (see
+/// `runfiles_c.h`); every lookup delegates to the C implementation so
+/// the two languages share exactly one parser / lookup / repo-mapping
+/// implementation.
 class Runfiles {
  public:
-  virtual ~Runfiles() {}
+  virtual ~Runfiles();
 
-  // Returns a new `Runfiles` instance.
-  //
-  // Use this from within `cc_test` rules.
-  //
-  // Returns nullptr on error. If `error` is provided, the method prints an
-  // error message into it.
-  //
-  // This method looks at the RUNFILES_MANIFEST_FILE and TEST_SRCDIR
-  // environment variables.
-  //
-  // If source_repository is not provided, it defaults to the main repository
-  // (also known as the workspace).
+  /// Create a #Runfiles instance for a `cc_test`.
+  ///
+  /// Reads `RUNFILES_MANIFEST_FILE` and `TEST_SRCDIR` from the
+  /// environment.
+  ///
+  /// @param error Optional out-pointer for a human-readable error
+  ///   message on failure.
+  /// @return New instance on success (owned by caller), or `nullptr`
+  ///   on error.
   static Runfiles* CreateForTest(std::string* error = nullptr);
+
+  /// Create a #Runfiles instance for a `cc_test` with an explicit
+  /// source repository.
   static Runfiles* CreateForTest(const std::string& source_repository,
                                  std::string* error = nullptr);
 
-  // Returns a new `Runfiles` instance.
-  //
-  // Use this from `cc_binary` or `cc_library` rules. You may pass an empty
-  // `argv0` if `argv[0]` from the `main` method is unknown.
-  //
-  // Returns nullptr on error. If `error` is provided, the method prints an
-  // error message into it.
-  //
-  // This method looks at the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
-  // environment variables. If either is empty, the method looks for the
-  // manifest or directory using the other environment variable, or using argv0
-  // (unless it's empty).
-  //
-  // If source_repository is not provided, it defaults to the main repository
-  // (also known as the workspace).
+  /// Create a #Runfiles instance for a `cc_binary` or `cc_library`.
+  ///
+  /// Reads `RUNFILES_MANIFEST_FILE` and `RUNFILES_DIR` from the
+  /// environment; if either is empty, falls back to the other or to
+  /// argv0-based discovery.
   static Runfiles* Create(const std::string& argv0,
                           std::string* error = nullptr);
+
+  /// Overload accepting an explicit source repository.
   static Runfiles* Create(const std::string& argv0,
                           const std::string& source_repository,
                           std::string* error = nullptr);
 
-  // Returns a new `Runfiles` instance.
-  //
-  // Use this from any `cc_*` rule if you want to manually specify the paths to
-  // the runfiles manifest and/or runfiles directory. You may pass an empty
-  // `argv0` if `argv[0]` from the `main` method is unknown.
-  //
-  // This method is the same as `Create(argv0, error)`, except it uses
-  // `runfiles_manifest_file` and `runfiles_dir` as the corresponding
-  // environment variable values, instead of looking up the actual environment
-  // variables.
+  /// Overload that lets callers pin the manifest and directory paths
+  /// instead of consulting the environment.
   static Runfiles* Create(const std::string& argv0,
                           const std::string& runfiles_manifest_file,
                           const std::string& runfiles_dir,
                           std::string* error = nullptr);
+
+  /// Full-parameter overload.
   static Runfiles* Create(const std::string& argv0,
                           const std::string& runfiles_manifest_file,
                           const std::string& runfiles_dir,
                           const std::string& source_repository,
                           std::string* error = nullptr);
 
-  // Returns the runtime path of a runfile.
-  //
-  // Runfiles are data-dependencies of Bazel-built binaries and tests.
-  //
-  // The returned path may not exist. The caller should verify the path's
-  // existence.
-  //
-  // The function may return an empty string if it cannot find a runfile.
-  //
-  // Args:
-  //   path: runfiles-root-relative path of the runfile; must not be empty and
-  //     must not contain uplevel references.
-  //   source_repository: if provided, overrides the source repository set when
-  //     this Runfiles instance was created.
-  // Returns:
-  //   the path to the runfile, which the caller should check for existence, or
-  //   an empty string if the method doesn't know about this runfile
+  /// Resolve the runtime path of a runfile using this instance's
+  /// default source repository.
   std::string Rlocation(const std::string& path) const;
+
+  /// Resolve a runfile using a per-call source repository override.
   std::string Rlocation(const std::string& path,
                         const std::string& source_repository) const;
 
-  // Returns environment variables for subprocesses.
-  //
-  // The caller should set the returned key-value pairs in the environment of
-  // subprocesses, so that those subprocesses can also access runfiles (in case
-  // they are also Bazel-built binaries).
+  /// Environment variables to publish to subprocesses (populated once
+  /// at construction from the C library's `rf_env_var`).
   const std::vector<std::pair<std::string, std::string> >& EnvVars() const {
     return envvars_;
   }
 
-  // Returns a new Runfiles instance that by default uses the provided source
-  // repository as a default for all calls to Rlocation.
-  //
-  // The current instance remains valid.
-  std::unique_ptr<Runfiles> WithSourceRepository(
-      const std::string& source_repository) const {
-    return std::unique_ptr<Runfiles>(new Runfiles(
-        runfiles_map_, directory_, repo_mapping_, envvars_, source_repository));
-  }
-
  private:
-  Runfiles(
-      std::map<std::string, std::string> runfiles_map, std::string directory,
-      std::map<std::pair<std::string, std::string>, std::string> repo_mapping,
-      std::vector<std::pair<std::string, std::string> > envvars,
-      std::string source_repository)
-      : runfiles_map_(std::move(runfiles_map)),
-        directory_(std::move(directory)),
-        repo_mapping_(std::move(repo_mapping)),
-        envvars_(std::move(envvars)),
-        source_repository_(std::move(source_repository)) {}
+  Runfiles(rf_runfiles* handle, std::string source_repository,
+           std::vector<std::pair<std::string, std::string> > envvars)
+      : handle_(handle),
+        source_repository_(std::move(source_repository)),
+        envvars_(std::move(envvars)) {}
   Runfiles(const Runfiles&) = delete;
   Runfiles(Runfiles&&) = delete;
   Runfiles& operator=(const Runfiles&) = delete;
   Runfiles& operator=(Runfiles&&) = delete;
 
-  static std::string RlocationUnchecked(
-      const std::string& path,
-      const std::map<std::string, std::string>& runfiles_map,
-      const std::string& directory);
-
-  const std::map<std::string, std::string> runfiles_map_;
-  const std::string directory_;
-  const std::map<std::pair<std::string, std::string>, std::string>
-      repo_mapping_;
-  const std::vector<std::pair<std::string, std::string> > envvars_;
+  rf_runfiles* const handle_;
   const std::string source_repository_;
+  const std::vector<std::pair<std::string, std::string> > envvars_;
 };
 
-// The "testing" namespace contains functions that allow unit testing the code.
-// Do not use these outside of runfiles_test.cc, they are only part of the
-// public API for the benefit of the tests.
-// These functions and their interface may change without notice.
+/// Test-only helpers.
+///
+/// Do NOT use these outside of `runfiles_test.cc`; they are exposed as
+/// part of the public API purely for the benefit of the unit tests and
+/// may change without notice.
 namespace testing {
 
-// For testing only.
-//
-// Computes the path of the runfiles manifest and the runfiles directory.
-//
-// If the method finds both a valid manifest and valid directory according to
-// `is_runfiles_manifest` and `is_runfiles_directory`, then the method sets
-// the corresponding values to `out_manifest` and `out_directory` and returns
-// true.
-//
-// If the method only finds a valid manifest or a valid directory, but not
-// both, then it sets the corresponding output variable (`out_manifest` or
-// `out_directory`) to the value while clearing the other output variable. The
-// method still returns true in this case.
-//
-// If the method cannot find either a valid manifest or valid directory, it
-// clears both output variables and returns false.
+/// Test-only: compute the path of the runfiles manifest and directory.
+///
+/// If the method finds both a valid manifest and valid directory
+/// according to @p is_runfiles_manifest and @p is_runfiles_directory,
+/// it sets the corresponding output variables and returns `true`. If
+/// it finds only one, it sets that one and clears the other, still
+/// returning `true`. If it finds neither, it clears both and returns
+/// `false`.
 bool TestOnly_PathsFrom(
     const std::string& argv0, std::string runfiles_manifest_file,
     std::string runfiles_dir,
@@ -249,11 +208,8 @@ bool TestOnly_PathsFrom(
     std::function<bool(const std::string&)> is_runfiles_directory,
     std::string* out_manifest, std::string* out_directory);
 
-// For testing only.
-// Returns true if `path` is an absolute Unix or Windows path.
-// For Windows paths, this function does not regard drive-less absolute paths
-// (i.e. absolute-on-current-drive, e.g. "\foo\bar") as absolute and returns
-// false for these.
+/// Test-only: return `true` if @p path is an absolute Unix or Windows
+/// path.
 bool TestOnly_IsAbsolute(const std::string& path);
 
 }  // namespace testing

--- a/cc/runfiles/runfiles.h
+++ b/cc/runfiles/runfiles.h
@@ -76,19 +76,20 @@
 /// from disk and returns an instance that fully owns its parsed data.
 /// Callers that want to reuse a parse across scopes / threads should
 /// hold the returned #Runfiles via a `std::shared_ptr<Runfiles>`
-/// themselves — the library does not maintain a process-wide cache.
+/// themselves -- the library does not maintain a process-wide cache.
 ///
 /// ### Thread safety
 ///
 /// Different #Runfiles instances are independent. A single instance is
 /// safe for parallel #Rlocation reads (the parsed state is immutable
 /// after construction); mixing reads with destruction is the caller's
-/// problem — same contract as `std::vector`.
+/// problem -- same contract as `std::vector`.
 
 #ifndef RULES_CC_CC_RUNFILES_RUNFILES_H_
 #define RULES_CC_CC_RUNFILES_RUNFILES_H_
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -97,6 +98,7 @@
 // here so the C header does not need to be included by C++ callers.
 extern "C" {
 struct rf_runfiles;
+void rf_free(struct rf_runfiles*);
 }
 
 namespace rules_cc {
@@ -165,15 +167,41 @@ class Runfiles {
                         const std::string& source_repository) const;
 
   /// Environment variables to publish to subprocesses (populated once
-  /// at construction from the C library's `rf_env_var`).
+  /// at construction from the C library's `rf_env_var_key` /
+  /// `rf_env_var_value`).
   const std::vector<std::pair<std::string, std::string> >& EnvVars() const {
     return envvars_;
   }
 
+  /// Return a new #Runfiles instance that defaults to @p
+  /// source_repository for #Rlocation calls.
+  ///
+  /// The current instance remains valid. The underlying `rf_runfiles`
+  /// handle (and the parsed manifest / `_repo_mapping` it owns) is
+  /// shared with the current instance via `std::shared_ptr`, so this
+  /// does NOT re-parse the manifest -- it's an O(1) refcount bump plus
+  /// two small string copies.
+  ///
+  /// @param source_repository New default source repository (canonical
+  ///   name); `""` denotes the main workspace.
+  /// @return Owning pointer to the new #Runfiles.
+  std::unique_ptr<Runfiles> WithSourceRepository(
+      const std::string& source_repository) const {
+    return std::unique_ptr<Runfiles>(
+        new Runfiles(handle_, source_repository, envvars_));
+  }
+
  private:
+  // Wraps a fresh raw handle with rf_free as the shared_ptr deleter.
   Runfiles(rf_runfiles* handle, std::string source_repository,
            std::vector<std::pair<std::string, std::string> > envvars)
-      : handle_(handle),
+      : handle_(handle, &rf_free),
+        source_repository_(std::move(source_repository)),
+        envvars_(std::move(envvars)) {}
+  // Shares an existing handle (WithSourceRepository).
+  Runfiles(std::shared_ptr<rf_runfiles> handle, std::string source_repository,
+           std::vector<std::pair<std::string, std::string> > envvars)
+      : handle_(std::move(handle)),
         source_repository_(std::move(source_repository)),
         envvars_(std::move(envvars)) {}
   Runfiles(const Runfiles&) = delete;
@@ -181,7 +209,7 @@ class Runfiles {
   Runfiles& operator=(const Runfiles&) = delete;
   Runfiles& operator=(Runfiles&&) = delete;
 
-  rf_runfiles* const handle_;
+  const std::shared_ptr<rf_runfiles> handle_;
   const std::string source_repository_;
   const std::vector<std::pair<std::string, std::string> > envvars_;
 };

--- a/cc/runfiles/runfiles_c.c
+++ b/cc/runfiles/runfiles_c.c
@@ -1,0 +1,1261 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runfiles_c.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "runfiles_c_internal.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+#define RF_LINE_INITIAL 8192
+#define RF_MANIFEST_INITIAL_CAPACITY 256
+#define RF_REPO_MAP_INITIAL_CAPACITY 32
+
+// ==========================================================================
+// Libc-backed default allocator.
+//
+// Used when a caller passes NULL for the allocator to rf_create*. The
+// function pointers are static wrappers so the vtable dispatch has one
+// shape everywhere and no code path needs to branch on "is this the
+// default?".
+// ==========================================================================
+
+static void* rf_libc_malloc(void* ud, size_t n) {
+  (void)ud;
+  return malloc(n);
+}
+static void* rf_libc_realloc(void* ud, void* p, size_t n) {
+  (void)ud;
+  return realloc(p, n);
+}
+static void rf_libc_free(void* ud, void* p) {
+  (void)ud;
+  free(p);
+}
+static const rf_allocator g_libc_allocator = {rf_libc_malloc, rf_libc_realloc,
+                                              rf_libc_free, NULL};
+
+// ==========================================================================
+// Allocator helpers — one vtable dispatch, no default-vs-custom branch.
+// ==========================================================================
+
+static void* rf_a_malloc(const rf_allocator* a, size_t n) {
+  return a->malloc(a->userdata, n);
+}
+static void* rf_a_realloc(const rf_allocator* a, void* p, size_t n) {
+  return a->realloc(a->userdata, p, n);
+}
+static void rf_a_free(const rf_allocator* a, void* p) {
+  a->free(a->userdata, p);
+}
+
+static char* rf_a_strdup(const rf_allocator* a, const char* s) {
+  if (!s) return NULL;
+  size_t len = strlen(s);
+  char* copy = (char*)rf_a_malloc(a, len + 1);
+  if (copy) memcpy(copy, s, len + 1);
+  return copy;
+}
+
+static char* rf_a_strdupn(const rf_allocator* a, const char* s, size_t len) {
+  char* copy = (char*)rf_a_malloc(a, len + 1);
+  if (copy) {
+    if (len) memcpy(copy, s, len);
+    copy[len] = '\0';
+  }
+  return copy;
+}
+
+// ==========================================================================
+// Windows Unicode helpers
+//
+// On Windows, all filesystem and env-var access is done through W-variant
+// Win32 APIs so that non-ASCII paths and env values (which would otherwise
+// be mangled by the process ANSI code page) work correctly. Runfiles paths
+// and env-var values are treated as UTF-8 at the library boundary.
+//
+// The two conversion helpers use a caller-provided stack buffer first and
+// only fall back to `malloc` when the stack buffer is too small — this
+// keeps the hot path (short paths, short env-var values) allocation-free.
+// They intentionally bypass the pluggable rf_allocator: the buffers are
+// transient (freed immediately after the Win32 call) and never observed
+// by callers.
+// ==========================================================================
+
+#ifdef _WIN32
+// Convert @p utf8 to UTF-16. Writes into @p stack_buf when the result
+// fits in @p stack_cap wchars; otherwise mallocs a fresh buffer. Caller
+// must `if (result != stack_buf) free(result);` after use. Returns NULL
+// on invalid UTF-8 or allocation failure.
+static wchar_t* rf_utf8_to_wide(const char* utf8, wchar_t* stack_buf,
+                                size_t stack_cap) {
+  if (!utf8) return NULL;
+  int n = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, NULL, 0);
+  if (n <= 0) return NULL;
+  wchar_t* w = ((size_t)n <= stack_cap)
+                   ? stack_buf
+                   : (wchar_t*)malloc((size_t)n * sizeof(wchar_t));
+  if (!w) return NULL;
+  if (MultiByteToWideChar(CP_UTF8, 0, utf8, -1, w, n) <= 0) {
+    if (w != stack_buf) free(w);
+    return NULL;
+  }
+  return w;
+}
+
+// Convert @p wide to UTF-8 with the same stack-first / heap-fallback
+// contract as rf_utf8_to_wide.
+static char* rf_wide_to_utf8(const wchar_t* wide, char* stack_buf,
+                             size_t stack_cap) {
+  if (!wide) return NULL;
+  int n = WideCharToMultiByte(CP_UTF8, 0, wide, -1, NULL, 0, NULL, NULL);
+  if (n <= 0) return NULL;
+  char* s = ((size_t)n <= stack_cap) ? stack_buf : (char*)malloc((size_t)n);
+  if (!s) return NULL;
+  if (WideCharToMultiByte(CP_UTF8, 0, wide, -1, s, n, NULL, NULL) <= 0) {
+    if (s != stack_buf) free(s);
+    return NULL;
+  }
+  return s;
+}
+#endif  // _WIN32
+
+// ==========================================================================
+// rf_fopen_utf8 — cross-platform fopen accepting UTF-8 paths.
+//
+// Windows: converts the path to UTF-16 and calls _wfopen. POSIX: plain
+// fopen (paths are already UTF-8 there). Single home for the wide-char
+// open dance so every filesystem call site is one line.
+// ==========================================================================
+
+FILE* rf_fopen_utf8(const char* path, const char* mode) {
+#ifdef _WIN32
+  wchar_t stack_path[1024];
+  wchar_t stack_mode[16];
+  wchar_t* wpath =
+      rf_utf8_to_wide(path, stack_path, sizeof(stack_path) / sizeof(wchar_t));
+  if (!wpath) return NULL;
+  wchar_t* wmode =
+      rf_utf8_to_wide(mode, stack_mode, sizeof(stack_mode) / sizeof(wchar_t));
+  FILE* f = wmode ? _wfopen(wpath, wmode) : NULL;
+  if (wpath != stack_path) free(wpath);
+  if (wmode && wmode != stack_mode) free(wmode);
+  return f;
+#else
+  return fopen(path, mode);
+#endif
+}
+
+// ==========================================================================
+// Path / filesystem helpers (no allocation)
+// ==========================================================================
+
+int rf_is_absolute(const char* path) {
+  if (!path || !path[0]) return 0;
+  char c = path[0];
+  // Unix-style absolute: leading '/' that is NOT a UNC-style "//host".
+  if (c == '/') return path[1] != '/';
+  // Windows drive-letter absolute: "<letter>:\..." or "<letter>:/...".
+  if (((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) && path[1] == ':' &&
+      (path[2] == '\\' || path[2] == '/'))
+    return 1;
+#ifdef _WIN32
+  // Windows UNC path: "\\server\share\..." (also "\\?\..." device
+  // namespace prefix). POSIX systems don't have UNC, so this branch is
+  // Windows-only — matches the existing test that pins "//host/share"
+  // to non-absolute on all platforms.
+  if (c == '\\' && path[1] == '\\') return 1;
+#endif
+  return 0;
+}
+
+int rf_is_readable_file(const char* path) {
+  FILE* f = rf_fopen_utf8(path, "r");
+  if (f) {
+    fclose(f);
+    return 1;
+  }
+  return 0;
+}
+
+int rf_is_directory(const char* path) {
+#ifdef _WIN32
+  wchar_t stack[1024];
+  wchar_t* wpath =
+      rf_utf8_to_wide(path, stack, sizeof(stack) / sizeof(wchar_t));
+  if (!wpath) return 0;  // OOM or bad UTF-8: treat as not-a-directory
+  DWORD attrs = GetFileAttributesW(wpath);
+  if (wpath != stack) free(wpath);
+  return (attrs != INVALID_FILE_ATTRIBUTES) &&
+         (attrs & FILE_ATTRIBUTE_DIRECTORY);
+#else
+  struct stat buf;
+  return stat(path, &buf) == 0 && S_ISDIR(buf.st_mode);
+#endif
+}
+
+// Read an env-var as a newly-allocated UTF-8 string. Caller frees with
+// `free()`. Returns NULL if unset. Used by the rf_create* entry points
+// so Windows sees env vars set via SetEnvironmentVariableW (not visible
+// through the CRT `_environ` block) and so non-ASCII values round-trip
+// through UTF-16. Also called from the C++ facade (see runfiles.cc's
+// GetEnv) so the Windows-Unicode env-var dance lives in one place.
+char* rf_getenv_alloc(const char* name) {
+#ifdef _WIN32
+  // Env-var names are always short ASCII (e.g. "RUNFILES_MANIFEST_FILE",
+  // "TEST_SRCDIR"), so ASCII → UTF-16 is a straight widening copy — no
+  // MultiByteToWideChar call, no allocation.
+  wchar_t wname[128];
+  size_t i;
+  for (i = 0; name[i] && i < sizeof(wname) / sizeof(wchar_t) - 1; i++) {
+    wname[i] = (wchar_t)(unsigned char)name[i];
+  }
+  if (name[i]) return NULL;  // name too long for our stack buffer
+  wname[i] = L'\0';
+
+  DWORD wsize = GetEnvironmentVariableW(wname, NULL, 0);
+  if (wsize == 0) return NULL;
+
+  wchar_t stack_val[1024];
+  wchar_t* wval = ((size_t)wsize <= sizeof(stack_val) / sizeof(wchar_t))
+                      ? stack_val
+                      : (wchar_t*)malloc((size_t)wsize * sizeof(wchar_t));
+  if (!wval) return NULL;
+  DWORD written = GetEnvironmentVariableW(wname, wval, wsize);
+  if (written == 0 || written >= wsize) {
+    if (wval != stack_val) free(wval);
+    return NULL;
+  }
+  // rf_wide_to_utf8 with a NULL stack buffer forces heap allocation, so
+  // the returned pointer is always caller-owned (never stack).
+  char* out = rf_wide_to_utf8(wval, NULL, 0);
+  if (wval != stack_val) free(wval);
+  return out;
+#else
+  const char* v = getenv(name);
+  if (!v) return NULL;
+  size_t len = strlen(v);
+  char* copy = (char*)malloc(len + 1);
+  if (!copy) return NULL;
+  memcpy(copy, v, len + 1);
+  return copy;
+#endif
+}
+
+int rf_path_is_rlocation_valid(const char* path) {
+  if (!path || !path[0]) return 0;
+  size_t len = strlen(path);
+  // Treat both '/' and '\' as separators for the traversal checks.
+  // Bazel manifests use forward slashes, so a backslash in a caller-
+  // supplied rlocation key is suspicious on any platform; rejecting
+  // unconditionally closes the Windows path-traversal hole (e.g.
+  // "..\\..\\etc\\passwd") without needing a platform ifdef.
+#define RF_IS_SEP(c) ((c) == '/' || (c) == '\\')
+  // starts with "../" or "..\\"
+  if (len >= 3 && path[0] == '.' && path[1] == '.' && RF_IS_SEP(path[2]))
+    return 0;
+  // starts with "./" or ".\\"
+  if (len >= 2 && path[0] == '.' && RF_IS_SEP(path[1])) return 0;
+  // ends with "/." or "\\."
+  if (len >= 2 && RF_IS_SEP(path[len - 2]) && path[len - 1] == '.') return 0;
+  // contains "/..", "/./", or "//" (and their backslash variants)
+  for (size_t i = 0; i + 1 < len; i++) {
+    if (RF_IS_SEP(path[i])) {
+      if (RF_IS_SEP(path[i + 1])) return 0;
+      if (i + 2 < len && path[i + 1] == '.' && path[i + 2] == '.') return 0;
+      if (i + 2 < len && path[i + 1] == '.' && RF_IS_SEP(path[i + 2])) return 0;
+    }
+  }
+#undef RF_IS_SEP
+  return 1;
+}
+
+// ==========================================================================
+// Unescape
+// ==========================================================================
+
+size_t rf_unescape_into(const char* in, size_t in_len, char* out) {
+  size_t j = 0;
+  for (size_t i = 0; i < in_len; ++i) {
+    if (in[i] == '\\' && i + 1 < in_len) {
+      switch (in[i + 1]) {
+        case 's':
+          out[j++] = ' ';
+          ++i;
+          break;
+        case 'n':
+          out[j++] = '\n';
+          ++i;
+          break;
+        case 'b':
+          out[j++] = '\\';
+          ++i;
+          break;
+        default:
+          out[j++] = in[i];
+          out[j++] = in[i + 1];
+          ++i;
+          break;
+      }
+    } else {
+      out[j++] = in[i];
+    }
+  }
+  out[j] = '\0';
+  return j;
+}
+
+// ==========================================================================
+// PathsFrom
+// ==========================================================================
+
+// Suffix appended to argv0 to discover the runfiles manifest inside a
+// runfiles directory.
+static const char kRunfilesSlashManifest[] = ".runfiles/MANIFEST";
+static const char kRunfilesDir[] = ".runfiles";
+static const char kRunfilesManifest[] = ".runfiles_manifest";
+static const char kSlashManifest[] = "/MANIFEST";
+static const char kUnderscoreManifest[] = "_manifest";
+
+// Concatenate a and b into out. Returns 1 on success, 0 if the buffer
+// is too small.
+static int rf_join2(const char* a, const char* b, char* out, size_t out_len) {
+  size_t la = strlen(a);
+  size_t lb = strlen(b);
+  if (la + lb + 1 > out_len) return 0;
+  memcpy(out, a, la);
+  memcpy(out + la, b, lb);
+  out[la + lb] = '\0';
+  return 1;
+}
+
+// Invoke a caller-provided predicate if non-NULL, else the built-in
+// rf_is_readable_file / rf_is_directory. Keeps the rf_paths_from body
+// free of null-check boilerplate.
+#define RF_IS_FILE(path)                                           \
+  (is_readable_file ? is_readable_file(predicate_userdata, (path)) \
+                    : rf_is_readable_file(path))
+#define RF_IS_DIR(path)                                    \
+  (is_directory ? is_directory(predicate_userdata, (path)) \
+                : rf_is_directory(path))
+
+int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
+                  const char* runfiles_dir, rf_predicate is_readable_file,
+                  rf_predicate is_directory, void* predicate_userdata,
+                  char* out_manifest, size_t out_manifest_len,
+                  char* out_directory, size_t out_directory_len) {
+  if (!out_manifest || out_manifest_len == 0 || !out_directory ||
+      out_directory_len == 0)
+    return 0;
+
+  // Copy inputs into local buffers we can rewrite while searching.
+  // Empty ("") indicates "not set / not yet discovered".
+  char mf_buf[4096];
+  char dir_buf[4096];
+
+  const char* mf_in = runfiles_manifest_file ? runfiles_manifest_file : "";
+  const char* dir_in = runfiles_dir ? runfiles_dir : "";
+
+  if (strlen(mf_in) + 1 > sizeof(mf_buf)) return 0;
+  if (strlen(dir_in) + 1 > sizeof(dir_buf)) return 0;
+
+  strcpy(mf_buf, mf_in);
+  strcpy(dir_buf, dir_in);
+
+  int mf_valid = mf_buf[0] && RF_IS_FILE(mf_buf);
+  int dir_valid = dir_buf[0] && RF_IS_DIR(dir_buf);
+
+  if (argv0 && argv0[0] && !mf_valid && !dir_valid) {
+    // argv0.runfiles/MANIFEST + argv0.runfiles
+    if (!rf_join2(argv0, kRunfilesSlashManifest, mf_buf, sizeof(mf_buf)))
+      return 0;
+    if (!rf_join2(argv0, kRunfilesDir, dir_buf, sizeof(dir_buf))) return 0;
+    mf_valid = RF_IS_FILE(mf_buf);
+    dir_valid = RF_IS_DIR(dir_buf);
+    if (!mf_valid) {
+      if (!rf_join2(argv0, kRunfilesManifest, mf_buf, sizeof(mf_buf))) return 0;
+      mf_valid = RF_IS_FILE(mf_buf);
+    }
+  }
+
+  if (!mf_valid && !dir_valid) return 0;
+
+  if (!mf_valid) {
+    // Try dir + "/MANIFEST" then dir + "_manifest".
+    if (!rf_join2(dir_buf, kSlashManifest, mf_buf, sizeof(mf_buf))) return 0;
+    mf_valid = RF_IS_FILE(mf_buf);
+    if (!mf_valid) {
+      if (!rf_join2(dir_buf, kUnderscoreManifest, mf_buf, sizeof(mf_buf)))
+        return 0;
+      mf_valid = RF_IS_FILE(mf_buf);
+    }
+  }
+
+  if (!dir_valid) {
+    // If mf ends with ".runfiles_manifest" or "/MANIFEST", derive the
+    // directory by stripping the 9-char suffix ("_manifest" or
+    // "/MANIFEST"). Each suffix check must guard against mf being
+    // shorter than the suffix itself to avoid reading before mf_buf.
+    size_t mf_len = strlen(mf_buf);
+    const size_t kStripLen = 9;
+    const size_t kRunfilesManifestLen = sizeof(kRunfilesManifest) - 1;
+    const size_t kSlashManifestLen = sizeof(kSlashManifest) - 1;
+    int matches =
+        (mf_len >= kRunfilesManifestLen &&
+         strcmp(mf_buf + mf_len - kRunfilesManifestLen, kRunfilesManifest) ==
+             0) ||
+        (mf_len >= kSlashManifestLen &&
+         strcmp(mf_buf + mf_len - kSlashManifestLen, kSlashManifest) == 0);
+    if (matches) {
+      if (mf_len - kStripLen + 1 > sizeof(dir_buf)) return 0;
+      memcpy(dir_buf, mf_buf, mf_len - kStripLen);
+      dir_buf[mf_len - kStripLen] = '\0';
+      dir_valid = RF_IS_DIR(dir_buf);
+    }
+  }
+
+  if (mf_valid) {
+    size_t l = strlen(mf_buf);
+    if (l + 1 > out_manifest_len) return 0;
+    memcpy(out_manifest, mf_buf, l + 1);
+  } else {
+    out_manifest[0] = '\0';
+  }
+
+  if (dir_valid) {
+    size_t l = strlen(dir_buf);
+    if (l + 1 > out_directory_len) return 0;
+    memcpy(out_directory, dir_buf, l + 1);
+  } else {
+    out_directory[0] = '\0';
+  }
+
+  return 1;
+}
+#undef RF_IS_FILE
+#undef RF_IS_DIR
+
+// ==========================================================================
+// Streaming line reader
+// ==========================================================================
+
+/// Read a single line from @p f into `*line_buf`, growing it as
+/// needed via the pluggable allocator. Strips trailing `\n` and `\r`.
+///
+/// Reads one byte at a time via `getc_unlocked` (POSIX) / `_getc_nolock`
+/// (MSVC) so embedded NUL bytes are preserved verbatim (an `fgets`+`strlen`
+/// shape would silently truncate any line containing a `\0`). Using the
+/// unlocked getc variant skips the per-call FILE lock that `fgetc` takes
+/// — safe here because the FILE* is a function-local resource never
+/// shared across threads.
+///
+/// @param f Open input stream.
+/// @param line_buf In/out: growing heap buffer. May start as `NULL`
+///   with `*line_cap == 0`.
+/// @param line_cap In/out: current capacity of `*line_buf`.
+/// @param a Allocator used for grow-a-buffer operations.
+/// @retval >=0 Line length written to `*line_buf`.
+/// @retval -1 EOF with nothing read.
+/// @retval -2 I/O error.
+/// @retval -3 Allocation failure.
+static int rf_read_line(FILE* f, char** line_buf, size_t* line_cap,
+                        const rf_allocator* a) {
+#ifdef _WIN32
+#define RF_GETC(fp) _getc_nolock(fp)
+#else
+#define RF_GETC(fp) getc_unlocked(fp)
+#endif
+  size_t used = 0;
+  for (;;) {
+    // Need room for one more byte plus a NUL terminator.
+    if (used + 2 >= *line_cap) {
+      size_t new_cap = *line_cap ? *line_cap * 2 : RF_LINE_INITIAL;
+      char* np = (char*)rf_a_realloc(a, *line_buf, new_cap);
+      if (!np) return -3;
+      *line_buf = np;
+      *line_cap = new_cap;
+    }
+    int ch = RF_GETC(f);
+    if (ch == EOF) {
+      if (ferror(f)) return -2;
+      if (used == 0) return -1;
+      break;
+    }
+    (*line_buf)[used++] = (char)ch;
+    if (ch == '\n') break;
+  }
+  (*line_buf)[used] = '\0';
+  while (used > 0 &&
+         ((*line_buf)[used - 1] == '\n' || (*line_buf)[used - 1] == '\r')) {
+    (*line_buf)[--used] = '\0';
+  }
+  return (int)used;
+#undef RF_GETC
+}
+
+// ==========================================================================
+// Format helpers (pure — no I/O, no allocation). Shared by the C-side
+// streaming parsers below AND by the C++ facade in runfiles.cc.
+// ==========================================================================
+
+rf_status rf_manifest_split_line(const char* line, size_t line_len,
+                                 int line_index, const char* path_for_err,
+                                 size_t* key_off, size_t* key_len,
+                                 size_t* val_off, size_t* val_len,
+                                 int* needs_unescape, char* error_buf,
+                                 int error_buf_len) {
+  // " escaped_key escaped_value"  -> needs_unescape=1
+  // "raw_key raw_value"           -> needs_unescape=0
+  int escaped = (line_len > 0 && line[0] == ' ');
+  size_t head_off = escaped ? 1 : 0;
+  const char* head = line + head_off;
+  size_t head_len = line_len - head_off;
+  const char* space = (const char*)memchr(head, ' ', head_len);
+  if (!space) {
+    if (error_buf && error_buf_len > 0)
+      snprintf(
+          error_buf, error_buf_len,
+          "ERROR: bad runfiles manifest entry in \"%s\" line #%d: \"%.*s\"",
+          path_for_err ? path_for_err : "?", line_index, (int)line_len, line);
+    return RF_ERR_FORMAT;
+  }
+  *key_off = head_off;
+  *key_len = (size_t)(space - head);
+  *val_off = head_off + *key_len + 1;
+  *val_len = line_len - *val_off;
+  *needs_unescape = escaped;
+  return RF_OK;
+}
+
+rf_status rf_repo_mapping_split_line(const char* line, size_t line_len,
+                                     int line_index, const char* path_for_err,
+                                     size_t* src_off, size_t* src_len,
+                                     size_t* ta_off, size_t* ta_len,
+                                     size_t* tgt_off, size_t* tgt_len,
+                                     char* error_buf, int error_buf_len) {
+  const char* first = (const char*)memchr(line, ',', line_len);
+  const char* second = NULL;
+  if (first) {
+    size_t after_first = (size_t)(first - line) + 1;
+    second =
+        (const char*)memchr(line + after_first, ',', line_len - after_first);
+  }
+  if (!first || !second) {
+    if (error_buf && error_buf_len > 0)
+      snprintf(
+          error_buf, error_buf_len,
+          "ERROR: bad repository mapping entry in \"%s\" line #%d: \"%.*s\"",
+          path_for_err ? path_for_err : "?", line_index, (int)line_len, line);
+    return RF_ERR_FORMAT;
+  }
+  *src_off = 0;
+  *src_len = (size_t)(first - line);
+  *ta_off = *src_len + 1;
+  *ta_len = (size_t)(second - (first + 1));
+  *tgt_off = *ta_off + *ta_len + 1;
+  *tgt_len = line_len - *tgt_off;
+  return RF_OK;
+}
+
+// ==========================================================================
+// Manifest parser (streaming, C-private). Used by rf_data_build only —
+// the C++ facade has its own FILE*-based parser and does NOT call this.
+// ==========================================================================
+
+static rf_status rf_parse_manifest_into(
+    const char* path,
+    int (*on_entry)(void* userdata, const char* key, size_t key_len,
+                    const char* value, size_t value_len),
+    void* userdata, char* error_buf, int error_buf_len, const rf_allocator* a) {
+  FILE* f = rf_fopen_utf8(path, "r");
+  if (!f) {
+    if (error_buf && error_buf_len > 0)
+      snprintf(error_buf, error_buf_len,
+               "ERROR: cannot open runfiles manifest \"%s\"", path);
+    return RF_ERR_IO;
+  }
+
+  char* line = NULL;
+  size_t line_cap = 0;
+  char* scratch = NULL;  // buffer for unescaped key/value
+  size_t scratch_cap = 0;
+  rf_status status = RF_OK;
+  int line_count = 0;
+
+  for (;;) {
+    int len = rf_read_line(f, &line, &line_cap, a);
+    if (len == -1) break;
+    if (len == -2) {
+      if (error_buf && error_buf_len > 0)
+        snprintf(error_buf, error_buf_len,
+                 "ERROR: I/O error reading manifest \"%s\"", path);
+      status = RF_ERR_IO;
+      break;
+    }
+    if (len == -3) {
+      status = RF_ERR_ALLOC;
+      break;
+    }
+    line_count++;
+    // Match the original C++ implementation: a blank line terminates
+    // parsing (Bazel-emitted manifests never contain them).
+    if (len == 0) break;
+
+    size_t key_off, key_len, val_off, val_len;
+    int needs_unescape;
+    status = rf_manifest_split_line(line, (size_t)len, line_count, path,
+                                    &key_off, &key_len, &val_off, &val_len,
+                                    &needs_unescape, error_buf, error_buf_len);
+    if (status != RF_OK) break;
+
+    int abort;
+    if (needs_unescape) {
+      size_t need = key_len + 1 + val_len + 1;
+      if (need > scratch_cap) {
+        char* np = (char*)rf_a_realloc(a, scratch, need);
+        if (!np) {
+          status = RF_ERR_ALLOC;
+          break;
+        }
+        scratch = np;
+        scratch_cap = need;
+      }
+      size_t kn = rf_unescape_into(line + key_off, key_len, scratch);
+      size_t vn = rf_unescape_into(line + val_off, val_len, scratch + kn + 1);
+      abort = on_entry(userdata, scratch, kn, scratch + kn + 1, vn);
+    } else {
+      abort =
+          on_entry(userdata, line + key_off, key_len, line + val_off, val_len);
+    }
+    if (abort != 0) {
+      status = RF_ERR_CALLBACK;
+      break;
+    }
+  }
+
+  rf_a_free(a, scratch);
+  rf_a_free(a, line);
+  fclose(f);
+  return status;
+}
+
+// ==========================================================================
+// Repo-mapping parser (streaming, C-private).
+// ==========================================================================
+
+static rf_status rf_parse_repo_mapping_into(
+    const char* path,
+    int (*on_entry)(void* userdata, const char* target_apparent,
+                    size_t target_apparent_len, const char* source,
+                    size_t source_len, const char* target, size_t target_len),
+    void* userdata, char* error_buf, int error_buf_len, const rf_allocator* a) {
+  FILE* f = rf_fopen_utf8(path, "r");
+  if (!f) return RF_OK;  // matches C++ silent-skip semantics
+
+  char* line = NULL;
+  size_t line_cap = 0;
+  rf_status status = RF_OK;
+  int line_count = 0;
+
+  for (;;) {
+    int len = rf_read_line(f, &line, &line_cap, a);
+    if (len == -1) break;
+    if (len == -2) {
+      if (error_buf && error_buf_len > 0)
+        snprintf(error_buf, error_buf_len,
+                 "ERROR: I/O error reading repo mapping \"%s\"", path);
+      status = RF_ERR_IO;
+      break;
+    }
+    if (len == -3) {
+      status = RF_ERR_ALLOC;
+      break;
+    }
+    line_count++;
+    // Match the original C++ implementation: a blank line terminates
+    // parsing (Bazel-emitted manifests never contain them).
+    if (len == 0) break;
+
+    size_t src_off, src_len, ta_off, ta_len, tgt_off, tgt_len;
+    status = rf_repo_mapping_split_line(
+        line, (size_t)len, line_count, path, &src_off, &src_len, &ta_off,
+        &ta_len, &tgt_off, &tgt_len, error_buf, error_buf_len);
+    if (status != RF_OK) break;
+
+    if (on_entry(userdata, line + ta_off, ta_len, line + src_off, src_len,
+                 line + tgt_off, tgt_len) != 0) {
+      status = RF_ERR_CALLBACK;
+      break;
+    }
+  }
+
+  rf_a_free(a, line);
+  fclose(f);
+  return status;
+}
+
+// ==========================================================================
+// rf_runfiles — parsed state owned by exactly one handle.
+//
+// No refcount, no sharing across handles, no locking. Each rf_create*
+// produces a fresh handle; rf_free releases everything it owns.
+// ==========================================================================
+
+/// One repo-mapping row. Sorted lexicographically by
+/// `(target_apparent, source_repo)` — reproduces
+/// `std::pair<string,string>::operator<` exactly, including
+/// "'*' sorts before every valid repo-name char" for wildcard entries.
+typedef struct {
+  char* target_apparent;
+  size_t ta_len;
+  char* source_repo;  ///< May end in `*` for wildcard entries.
+  size_t sr_len;
+  char* value;
+  size_t value_len;
+} rf_repo_entry;
+
+/// One manifest row. `key_len` is cached so binary search doesn't need
+/// to `strlen` the stored key on every probe.
+typedef struct {
+  char* key;
+  size_t key_len;
+  char* value;
+} rf_manifest_entry;
+
+struct rf_runfiles {
+  /// Owned copy of the allocator vtable this handle was built with.
+  /// Copying the struct in — rather than storing a pointer — lets
+  /// callers pass a short-lived (e.g. stack-local) #rf_allocator to
+  /// #rf_create_ex; the handle uses this copy for its whole lifetime.
+  rf_allocator alloc;
+
+  char* directory;          ///< Resolved runfiles directory (or `""`).
+  char* manifest_file;      ///< Resolved manifest file (or `""`).
+  char* source_repository;  ///< Default source repo for #rf_rlocation.
+
+  rf_manifest_entry* manifest;  ///< Sorted manifest rows.
+  size_t manifest_count;
+  size_t manifest_capacity;
+
+  rf_repo_entry* repo_map;  ///< Sorted `_repo_mapping` rows.
+  size_t repo_map_count;
+  size_t repo_map_capacity;
+
+  // Env-var values are not stored: rf_env_var derives them from
+  // manifest_file / directory above.
+};
+
+// ==========================================================================
+// Sorting parallel arrays (manifest and repo-mapping)
+// ==========================================================================
+
+static int rf_manifest_qsort_cmp(const void* a, const void* b) {
+  const rf_manifest_entry* ea = (const rf_manifest_entry*)a;
+  const rf_manifest_entry* eb = (const rf_manifest_entry*)b;
+  return strcmp(ea->key, eb->key);
+}
+
+// Compare two (target_apparent, source_repo) pairs lexicographically —
+// reproduces std::pair<string,string>::operator< exactly, including
+// "'*' sorts before every valid repo-name char" for wildcard entries.
+// Used both for sorting the repo-map and for binary-searching a lookup
+// key against a stored entry.
+static int rf_repo_key_cmp(const char* ta_a, size_t ta_a_len, const char* sr_a,
+                           size_t sr_a_len, const char* ta_b, size_t ta_b_len,
+                           const char* sr_b, size_t sr_b_len) {
+  size_t nt = ta_a_len < ta_b_len ? ta_a_len : ta_b_len;
+  int cmp = nt ? memcmp(ta_a, ta_b, nt) : 0;
+  if (cmp != 0) return cmp;
+  if (ta_a_len != ta_b_len) return ta_a_len < ta_b_len ? -1 : 1;
+
+  size_t ns = sr_a_len < sr_b_len ? sr_a_len : sr_b_len;
+  cmp = ns ? memcmp(sr_a, sr_b, ns) : 0;
+  if (cmp != 0) return cmp;
+  if (sr_a_len != sr_b_len) return sr_a_len < sr_b_len ? -1 : 1;
+  return 0;
+}
+
+static int rf_repo_qsort_cmp(const void* a, const void* b) {
+  const rf_repo_entry* ea = (const rf_repo_entry*)a;
+  const rf_repo_entry* eb = (const rf_repo_entry*)b;
+  return rf_repo_key_cmp(ea->target_apparent, ea->ta_len, ea->source_repo,
+                         ea->sr_len, eb->target_apparent, eb->ta_len,
+                         eb->source_repo, eb->sr_len);
+}
+
+// ==========================================================================
+// Callbacks for populating rf_runfiles
+//
+// A callback that returns non-zero surfaces as RF_ERR_CALLBACK from the
+// parser and the whole build path unwinds. Returning non-zero on OOM
+// therefore doubles as error propagation — no separate flag needed.
+// ==========================================================================
+
+static int rf_build_manifest_cb(void* userdata, const char* key, size_t klen,
+                                const char* value, size_t vlen) {
+  rf_runfiles* rf = (rf_runfiles*)userdata;
+  const rf_allocator* a = &rf->alloc;
+
+  if (rf->manifest_count >= rf->manifest_capacity) {
+    size_t nc = rf->manifest_capacity ? rf->manifest_capacity * 2
+                                      : RF_MANIFEST_INITIAL_CAPACITY;
+    rf_manifest_entry* nr = (rf_manifest_entry*)rf_a_realloc(
+        a, rf->manifest, sizeof(rf_manifest_entry) * nc);
+    if (!nr) return 1;
+    rf->manifest = nr;
+    rf->manifest_capacity = nc;
+  }
+  char* kk = rf_a_strdupn(a, key, klen);
+  char* vv = rf_a_strdupn(a, value, vlen);
+  if (!kk || !vv) {
+    rf_a_free(a, kk);
+    rf_a_free(a, vv);
+    return 1;
+  }
+  rf_manifest_entry* e = &rf->manifest[rf->manifest_count++];
+  e->key = kk;
+  e->key_len = klen;
+  e->value = vv;
+  return 0;
+}
+
+static int rf_build_repo_map_cb(void* userdata, const char* ta, size_t ta_len,
+                                const char* src, size_t src_len,
+                                const char* tgt, size_t tgt_len) {
+  rf_runfiles* rf = (rf_runfiles*)userdata;
+  const rf_allocator* a = &rf->alloc;
+
+  if (rf->repo_map_count >= rf->repo_map_capacity) {
+    size_t nc = rf->repo_map_capacity ? rf->repo_map_capacity * 2
+                                      : RF_REPO_MAP_INITIAL_CAPACITY;
+    rf_repo_entry* nr = (rf_repo_entry*)rf_a_realloc(
+        a, rf->repo_map, sizeof(rf_repo_entry) * nc);
+    if (!nr) return 1;
+    rf->repo_map = nr;
+    rf->repo_map_capacity = nc;
+  }
+
+  char* ta_copy = rf_a_strdupn(a, ta, ta_len);
+  char* sr_copy = rf_a_strdupn(a, src, src_len);
+  char* vv = rf_a_strdupn(a, tgt, tgt_len);
+  if (!ta_copy || !sr_copy || !vv) {
+    rf_a_free(a, ta_copy);
+    rf_a_free(a, sr_copy);
+    rf_a_free(a, vv);
+    return 1;
+  }
+
+  rf_repo_entry* e = &rf->repo_map[rf->repo_map_count++];
+  e->target_apparent = ta_copy;
+  e->ta_len = ta_len;
+  e->source_repo = sr_copy;
+  e->sr_len = src_len;
+  e->value = vv;
+  e->value_len = tgt_len;
+  return 0;
+}
+
+// ==========================================================================
+// RlocationUnchecked (data-level; no repo mapping / validation)
+// ==========================================================================
+
+/// Binary search on the manifest for a key equal to the first
+/// @p prefix_len bytes of @p path. Does NOT mutate @p path. Passing
+/// `strlen(path)` as @p prefix_len yields an exact-key search.
+///
+/// @return Matching index, or `-1` if no match.
+static int rf_bsearch_manifest_prefix(const rf_runfiles* rf, const char* path,
+                                      size_t prefix_len) {
+  int lo = 0, hi = (int)rf->manifest_count - 1;
+  while (lo <= hi) {
+    int mid = lo + (hi - lo) / 2;
+    const rf_manifest_entry* e = &rf->manifest[mid];
+    size_t n = e->key_len < prefix_len ? e->key_len : prefix_len;
+    int cmp = n ? memcmp(e->key, path, n) : 0;
+    if (cmp == 0)
+      cmp = (e->key_len < prefix_len) ? -1 : (e->key_len > prefix_len) ? 1 : 0;
+    if (cmp == 0) return mid;
+    if (cmp < 0)
+      lo = mid + 1;
+    else
+      hi = mid - 1;
+  }
+  return -1;
+}
+
+// Resolve `path` against the manifest/directory only (no repo mapping,
+// no path validation, no absolute-path passthrough). Returns positive
+// length on success, 0 if not found, -1 on buffer-too-small.
+static int rf_rlocation_unchecked(const rf_runfiles* rf, const char* path,
+                                  char* out, int out_len) {
+  size_t path_len = strlen(path);
+  // 1) Exact match (prefix search with the full path length).
+  int idx = rf_bsearch_manifest_prefix(rf, path, path_len);
+  if (idx >= 0) {
+    const char* v = rf->manifest[idx].value;
+    int vlen = (int)strlen(v);
+    if (vlen + 1 > out_len) return -1;
+    memcpy(out, v, vlen + 1);
+    return vlen;
+  }
+  // 2) Longest-prefix match.
+  if (rf->manifest_count > 0) {
+    size_t prefix_end = path_len;
+    while (prefix_end > 0) {
+      size_t i = prefix_end;
+      while (i > 0 && path[i - 1] != '/') i--;
+      if (i == 0) break;
+      prefix_end = i - 1;
+
+      int pidx = rf_bsearch_manifest_prefix(rf, path, prefix_end);
+      if (pidx >= 0) {
+        const char* v = rf->manifest[pidx].value;
+        int vlen = (int)strlen(v);
+        size_t rem_len = path_len - prefix_end - 1;
+        int total = vlen + 1 + (int)rem_len;
+        if (total + 1 > out_len) return -1;
+        memcpy(out, v, vlen);
+        out[vlen] = '/';
+        memcpy(out + vlen + 1, path + prefix_end + 1, rem_len);
+        out[total] = '\0';
+        return total;
+      }
+    }
+  }
+  // 3) Directory fallback.
+  if (rf->directory && rf->directory[0]) {
+    int dlen = (int)strlen(rf->directory);
+    int total = dlen + 1 + (int)path_len;
+    if (total + 1 > out_len) return -1;
+    memcpy(out, rf->directory, dlen);
+    out[dlen] = '/';
+    memcpy(out + dlen + 1, path, path_len + 1);
+    return total;
+  }
+  return 0;
+}
+
+// Helper: rlocation from a virtually-concatenated `prefix + suffix` key.
+// Used after a repo-mapping rewrite so the caller can pass "canonical +
+// path.substr(first_slash)" without doing the join themselves.
+static int rf_rlocation_unchecked_join(const rf_runfiles* rf,
+                                       const char* prefix, size_t prefix_len,
+                                       const char* suffix, size_t suffix_len,
+                                       char* out, int out_len) {
+  size_t total = prefix_len + suffix_len;
+  char stack_buf[8192];
+  char* tmp;
+  int use_heap = 0;
+  if (total + 1 <= sizeof(stack_buf)) {
+    tmp = stack_buf;
+  } else {
+    tmp = (char*)rf_a_malloc(&rf->alloc, total + 1);
+    if (!tmp) return -1;
+    use_heap = 1;
+  }
+  memcpy(tmp, prefix, prefix_len);
+  if (suffix_len) memcpy(tmp + prefix_len, suffix, suffix_len);
+  tmp[total] = '\0';
+  int r = rf_rlocation_unchecked(rf, tmp, out, out_len);
+  if (use_heap) rf_a_free(&rf->alloc, tmp);
+  return r;
+}
+
+// ==========================================================================
+// Public C API — construction
+// ==========================================================================
+
+// Free every allocation reachable from @p rf, then @p rf itself. Used
+// both by rf_free and by the mid-construction error paths in
+// rf_create_ex.
+static void rf_free_impl(rf_runfiles* rf) {
+  if (!rf) return;
+  // Snapshot the vtable so rf_a_free can still dispatch after `rf`
+  // itself is freed at the end.
+  rf_allocator a = rf->alloc;
+  rf_a_free(&a, rf->directory);
+  rf_a_free(&a, rf->manifest_file);
+  rf_a_free(&a, rf->source_repository);
+  for (size_t i = 0; i < rf->manifest_count; i++) {
+    rf_a_free(&a, rf->manifest[i].key);
+    rf_a_free(&a, rf->manifest[i].value);
+  }
+  rf_a_free(&a, rf->manifest);
+  for (size_t i = 0; i < rf->repo_map_count; i++) {
+    rf_a_free(&a, rf->repo_map[i].target_apparent);
+    rf_a_free(&a, rf->repo_map[i].source_repo);
+    rf_a_free(&a, rf->repo_map[i].value);
+  }
+  rf_a_free(&a, rf->repo_map);
+  rf_a_free(&a, rf);
+}
+
+rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
+                          const char* manifest, const char* dir,
+                          const char* source_repo, char* err, int err_len) {
+  if (!alloc) alloc = &g_libc_allocator;
+
+  char resolved_manifest[4096];
+  char resolved_directory[4096];
+  if (!rf_paths_from(argv0 ? argv0 : "", manifest, dir, NULL, NULL, NULL,
+                     resolved_manifest, sizeof(resolved_manifest),
+                     resolved_directory, sizeof(resolved_directory))) {
+    if (err && err_len > 0) {
+      snprintf(err, err_len, "ERROR: cannot find runfiles (argv0=\"%s\")",
+               argv0 ? argv0 : "");
+    }
+    return NULL;
+  }
+
+  rf_runfiles* rf = (rf_runfiles*)rf_a_malloc(alloc, sizeof(rf_runfiles));
+  if (!rf) return NULL;
+  memset(rf, 0, sizeof(*rf));
+  rf->alloc = *alloc;  // owned copy — safe against short-lived vtables
+
+  rf->directory = rf_a_strdup(alloc, resolved_directory);
+  rf->manifest_file = rf_a_strdup(alloc, resolved_manifest);
+  rf->source_repository = rf_a_strdup(alloc, source_repo ? source_repo : "");
+  if (!rf->directory || !rf->manifest_file || !rf->source_repository) {
+    rf_free_impl(rf);
+    return NULL;
+  }
+
+  if (resolved_manifest[0]) {
+    rf_status s = rf_parse_manifest_into(
+        resolved_manifest, rf_build_manifest_cb, rf, err, err_len, alloc);
+    if (s != RF_OK) {
+      rf_free_impl(rf);
+      return NULL;
+    }
+    if (rf->manifest_count > 1)
+      qsort(rf->manifest, rf->manifest_count, sizeof(rf_manifest_entry),
+            rf_manifest_qsort_cmp);
+  }
+
+  // Resolve the _repo_mapping path against the just-parsed manifest.
+  // Grow from an 8 KB stack buffer up to 1 MB before giving up
+  // (silently, matching C++'s "no repo mapping file" branch).
+  {
+    char stack_buf[8192];
+    char* heap_buf = NULL;
+    char* buf = stack_buf;
+    size_t cap = sizeof(stack_buf);
+    int n = rf_rlocation_unchecked(rf, "_repo_mapping", buf, (int)cap);
+    while (n == -1 && cap < (1u << 20)) {
+      cap *= 2;
+      char* np = (char*)rf_a_realloc(alloc, heap_buf, cap);
+      if (!np) {
+        rf_a_free(alloc, heap_buf);
+        rf_free_impl(rf);
+        return NULL;
+      }
+      heap_buf = np;
+      buf = heap_buf;
+      n = rf_rlocation_unchecked(rf, "_repo_mapping", buf, (int)cap);
+    }
+    if (n > 0) {
+      rf_status s = rf_parse_repo_mapping_into(buf, rf_build_repo_map_cb, rf,
+                                               err, err_len, alloc);
+      if (s != RF_OK) {
+        rf_a_free(alloc, heap_buf);
+        rf_free_impl(rf);
+        return NULL;
+      }
+      if (rf->repo_map_count > 1)
+        qsort(rf->repo_map, rf->repo_map_count, sizeof(rf_repo_entry),
+              rf_repo_qsort_cmp);
+    }
+    rf_a_free(alloc, heap_buf);
+  }
+
+  return rf;
+}
+
+// Shared body of the three env-reading rf_create* entry points. Reads
+// RUNFILES_MANIFEST_FILE and @p dir_env_key from the environment (via
+// rf_getenv_alloc, so Windows Unicode env vars work) and forwards to
+// rf_create_ex.
+static rf_runfiles* rf_create_from_env(const rf_allocator* alloc,
+                                       const char* argv0,
+                                       const char* dir_env_key,
+                                       const char* source_repo, char* err,
+                                       int err_len) {
+  char* mf = rf_getenv_alloc("RUNFILES_MANIFEST_FILE");
+  char* dir = rf_getenv_alloc(dir_env_key);
+  rf_runfiles* r = rf_create_ex(alloc, argv0, mf ? mf : "", dir ? dir : "",
+                                source_repo, err, err_len);
+  free(mf);
+  free(dir);
+  return r;
+}
+
+rf_runfiles* rf_create(const rf_allocator* alloc, const char* argv0, char* err,
+                       int err_len) {
+  return rf_create_from_env(alloc, argv0, "RUNFILES_DIR", "", err, err_len);
+}
+
+rf_runfiles* rf_create_for_test(const rf_allocator* alloc, char* err,
+                                int err_len) {
+  return rf_create_from_env(alloc, "", "TEST_SRCDIR", "", err, err_len);
+}
+
+rf_runfiles* rf_create_for_test_ex(const rf_allocator* alloc,
+                                   const char* source_repo, char* err,
+                                   int err_len) {
+  return rf_create_from_env(alloc, "", "TEST_SRCDIR", source_repo, err,
+                            err_len);
+}
+
+// ==========================================================================
+// Rlocation (with repo-mapping)
+// ==========================================================================
+
+// Return < 0, == 0, > 0 comparing an entry to a lookup key
+// (target_apparent, source_repo). Thin wrapper over rf_repo_key_cmp
+// so sort and lookup share the same lex-order definition.
+static int rf_cmp_lookup_key(const rf_repo_entry* e,
+                             const char* target_apparent, size_t ta_len,
+                             const char* source_repo, size_t sr_len) {
+  return rf_repo_key_cmp(e->target_apparent, e->ta_len, e->source_repo,
+                         e->sr_len, target_apparent, ta_len, source_repo,
+                         sr_len);
+}
+
+// Find upper_bound(key): index of first repo-map entry strictly greater
+// than (target_apparent, source_repo). Returns repo_map_count if none.
+static size_t rf_rm_upper_bound(const rf_runfiles* rf,
+                                const char* target_apparent, size_t ta_len,
+                                const char* source_repo, size_t sr_len) {
+  size_t lo = 0, hi = rf->repo_map_count;
+  while (lo < hi) {
+    size_t mid = lo + (hi - lo) / 2;
+    int cmp = rf_cmp_lookup_key(&rf->repo_map[mid], target_apparent, ta_len,
+                                source_repo, sr_len);
+    if (cmp <= 0)
+      lo = mid + 1;
+    else
+      hi = mid;
+  }
+  return lo;
+}
+
+int rf_rlocation_from(const rf_runfiles* rf, const char* path,
+                      const char* source_repository, char* result_buf,
+                      int result_buf_len) {
+  if (!rf || !path || !result_buf || result_buf_len <= 0) return -1;
+  result_buf[0] = '\0';
+
+  if (!rf_path_is_rlocation_valid(path)) return -1;
+
+  if (rf_is_absolute(path)) {
+    int plen = (int)strlen(path);
+    if (plen + 1 > result_buf_len) return -1;
+    memcpy(result_buf, path, plen + 1);
+    return plen;
+  }
+
+  const char* sr = source_repository ? source_repository : "";
+  size_t sr_len = strlen(sr);
+
+  const char* slash = strchr(path, '/');
+  if (!slash) {
+    // No repo prefix — resolve directly.
+    return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
+  }
+
+  size_t first_slash = (size_t)(slash - path);
+  if (rf->repo_map_count == 0) {
+    return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
+  }
+
+  size_t ub = rf_rm_upper_bound(rf, path, first_slash, sr, sr_len);
+  // Matches C++ std::prev(begin()) semantic: when upper_bound sits at
+  // begin(), floor stays at begin() and we still inspect the first
+  // entry — it may be a wildcard whose target_apparent matches ours,
+  // in which case rewriting must still fire even though the entry
+  // sorts strictly greater than the lookup key.
+  size_t floor = (ub == 0) ? 0 : ub - 1;
+  const rf_repo_entry* e = &rf->repo_map[floor];
+  int cmp = rf_cmp_lookup_key(e, path, first_slash, sr, sr_len);
+  const char* suffix = path + first_slash;
+  size_t suffix_len = strlen(suffix);
+  // Exact match, OR wildcard: entry's target_apparent equals the
+  // lookup's, entry's source_repo ends in '*', and lookup's source_repo
+  // starts with the prefix (source_repo before the '*').
+  int wildcard_match = e->ta_len == first_slash &&
+                       memcmp(e->target_apparent, path, first_slash) == 0 &&
+                       e->sr_len > 0 && e->source_repo[e->sr_len - 1] == '*' &&
+                       e->sr_len - 1 <= sr_len &&
+                       memcmp(e->source_repo, sr, e->sr_len - 1) == 0;
+  if (cmp == 0 || wildcard_match) {
+    return rf_rlocation_unchecked_join(rf, e->value, e->value_len, suffix,
+                                       suffix_len, result_buf, result_buf_len);
+  }
+
+  return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
+}
+
+int rf_rlocation(const rf_runfiles* rf, const char* path, char* result_buf,
+                 int result_buf_len) {
+  if (!rf) return -1;
+  return rf_rlocation_from(rf, path, rf->source_repository, result_buf,
+                           result_buf_len);
+}
+
+// ==========================================================================
+// Envvars
+// ==========================================================================
+
+int rf_env_vars_count(const rf_runfiles* rf) {
+  if (!rf) return 0;
+  return RF_NUM_ENV_VARS;
+}
+
+int rf_env_var(const rf_runfiles* rf, int index, char* key_buf, int key_buf_len,
+               char* val_buf, int val_buf_len) {
+  if (!rf || index < 0 || index >= RF_NUM_ENV_VARS) return 0;
+  if (!key_buf || key_buf_len <= 0 || !val_buf || val_buf_len <= 0) return 0;
+
+  // Values are derived: index 0 -> manifest_file, 1|2 -> directory
+  // (JAVA_RUNFILES aliases RUNFILES_DIR). No storage is allocated for
+  // env values.
+  const char* key = kRfEnvKeys[index];
+  const char* val = (index == 0) ? rf->manifest_file : rf->directory;
+
+  int klen = (int)strlen(key);
+  int vlen = (int)strlen(val);
+  if (klen + 1 > key_buf_len || vlen + 1 > val_buf_len) return 0;
+
+  memcpy(key_buf, key, klen + 1);
+  memcpy(val_buf, val, vlen + 1);
+  return 1;
+}
+
+// ==========================================================================
+// Destructor
+// ==========================================================================
+
+void rf_free(rf_runfiles* rf) { rf_free_impl(rf); }

--- a/cc/runfiles/runfiles_c.c
+++ b/cc/runfiles/runfiles_c.c
@@ -37,10 +37,8 @@
 // ==========================================================================
 // Libc-backed default allocator.
 //
-// Used when a caller passes NULL for the allocator to rf_create*. The
-// function pointers are static wrappers so the vtable dispatch has one
-// shape everywhere and no code path needs to branch on "is this the
-// default?".
+// Wrappers keep the vtable dispatch uniform -- no code path branches on
+// "is this the default?".
 // ==========================================================================
 
 static void* rf_libc_malloc(void* ud, size_t n) {
@@ -59,7 +57,7 @@ static const rf_allocator g_libc_allocator = {rf_libc_malloc, rf_libc_realloc,
                                               rf_libc_free, NULL};
 
 // ==========================================================================
-// Allocator helpers — one vtable dispatch, no default-vs-custom branch.
+// Allocator dispatch helpers.
 // ==========================================================================
 
 static void* rf_a_malloc(const rf_allocator* a, size_t n) {
@@ -92,24 +90,21 @@ static char* rf_a_strdupn(const rf_allocator* a, const char* s, size_t len) {
 // ==========================================================================
 // Windows Unicode helpers
 //
-// On Windows, all filesystem and env-var access is done through W-variant
-// Win32 APIs so that non-ASCII paths and env values (which would otherwise
-// be mangled by the process ANSI code page) work correctly. Runfiles paths
-// and env-var values are treated as UTF-8 at the library boundary.
+// All filesystem and env-var access goes through W-variant Win32 APIs so
+// non-ASCII paths / values don't get mangled by the process ANSI code
+// page. Runfiles paths and env-var values are UTF-8 at the library
+// boundary.
 //
-// The two conversion helpers use a caller-provided stack buffer first and
-// only fall back to `malloc` when the stack buffer is too small — this
-// keeps the hot path (short paths, short env-var values) allocation-free.
-// They intentionally bypass the pluggable rf_allocator: the buffers are
-// transient (freed immediately after the Win32 call) and never observed
-// by callers.
+// rf_utf8_to_wide's output is always transient (freed on the same call
+// stack), so libc malloc is fine for its fallback. rf_wide_to_utf8's
+// output MAY escape to callers via rf_getenv_alloc, so its fallback
+// routes through the pluggable allocator to keep caller-side free
+// pairings correct.
 // ==========================================================================
 
 #ifdef _WIN32
-// Convert @p utf8 to UTF-16. Writes into @p stack_buf when the result
-// fits in @p stack_cap wchars; otherwise mallocs a fresh buffer. Caller
-// must `if (result != stack_buf) free(result);` after use. Returns NULL
-// on invalid UTF-8 or allocation failure.
+// Caller must `if (result != stack_buf) free(result);` after use.
+// Returns NULL on invalid UTF-8 or allocation failure.
 static wchar_t* rf_utf8_to_wide(const char* utf8, wchar_t* stack_buf,
                                 size_t stack_cap) {
   if (!utf8) return NULL;
@@ -126,17 +121,30 @@ static wchar_t* rf_utf8_to_wide(const char* utf8, wchar_t* stack_buf,
   return w;
 }
 
-// Convert @p wide to UTF-8 with the same stack-first / heap-fallback
-// contract as rf_utf8_to_wide.
+// Result may escape to callers, so heap fallback routes through @p
+// alloc (or libc if NULL). Caller frees through the matching path.
 static char* rf_wide_to_utf8(const wchar_t* wide, char* stack_buf,
-                             size_t stack_cap) {
+                             size_t stack_cap, const rf_allocator* alloc) {
   if (!wide) return NULL;
   int n = WideCharToMultiByte(CP_UTF8, 0, wide, -1, NULL, 0, NULL, NULL);
   if (n <= 0) return NULL;
-  char* s = ((size_t)n <= stack_cap) ? stack_buf : (char*)malloc((size_t)n);
+  char* s;
+  if ((size_t)n <= stack_cap) {
+    s = stack_buf;
+  } else if (alloc) {
+    s = (char*)rf_a_malloc(alloc, (size_t)n);
+  } else {
+    s = (char*)malloc((size_t)n);
+  }
   if (!s) return NULL;
   if (WideCharToMultiByte(CP_UTF8, 0, wide, -1, s, n, NULL, NULL) <= 0) {
-    if (s != stack_buf) free(s);
+    if (s != stack_buf) {
+      if (alloc) {
+        rf_a_free(alloc, s);
+      } else {
+        free(s);
+      }
+    }
     return NULL;
   }
   return s;
@@ -144,11 +152,9 @@ static char* rf_wide_to_utf8(const wchar_t* wide, char* stack_buf,
 #endif  // _WIN32
 
 // ==========================================================================
-// rf_fopen_utf8 — cross-platform fopen accepting UTF-8 paths.
-//
-// Windows: converts the path to UTF-16 and calls _wfopen. POSIX: plain
-// fopen (paths are already UTF-8 there). Single home for the wide-char
-// open dance so every filesystem call site is one line.
+// rf_fopen_utf8 -- cross-platform fopen accepting UTF-8 paths.
+// Windows routes through _wfopen; POSIX is plain fopen (paths already
+// UTF-8 there).
 // ==========================================================================
 
 FILE* rf_fopen_utf8(const char* path, const char* mode) {
@@ -179,16 +185,14 @@ int rf_is_absolute(const char* path) {
   // Unix-style absolute: leading '/' that is NOT a UNC-style "//host".
   if (c == '/') return path[1] != '/';
   // Windows drive-letter absolute: "<letter>:\..." or "<letter>:/...".
+  //
+  // Backslash-only paths (`\foo`, `\\host\share`, `\\?\C:\...`) are
+  // intentionally NOT treated as absolute -- matching the upstream
+  // C++ `Runfiles::IsAbsolute` contract on every platform, so
+  // callers get identical behaviour to the pre-C-port implementation.
   if (((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) && path[1] == ':' &&
       (path[2] == '\\' || path[2] == '/'))
     return 1;
-#ifdef _WIN32
-  // Windows UNC path: "\\server\share\..." (also "\\?\..." device
-  // namespace prefix). POSIX systems don't have UNC, so this branch is
-  // Windows-only — matches the existing test that pins "//host/share"
-  // to non-absolute on all platforms.
-  if (c == '\\' && path[1] == '\\') return 1;
-#endif
   return 0;
 }
 
@@ -217,17 +221,13 @@ int rf_is_directory(const char* path) {
 #endif
 }
 
-// Read an env-var as a newly-allocated UTF-8 string. Caller frees with
-// `free()`. Returns NULL if unset. Used by the rf_create* entry points
-// so Windows sees env vars set via SetEnvironmentVariableW (not visible
-// through the CRT `_environ` block) and so non-ASCII values round-trip
-// through UTF-16. Also called from the C++ facade (see runfiles.cc's
-// GetEnv) so the Windows-Unicode env-var dance lives in one place.
-char* rf_getenv_alloc(const char* name) {
+// GetEnvironmentVariableW on Windows so env vars set via
+// SetEnvironmentVariableW (not visible through the CRT `_environ`
+// block) and non-ASCII values both work; getenv on POSIX.
+char* rf_getenv_alloc(const struct rf_allocator* alloc, const char* name) {
 #ifdef _WIN32
-  // Env-var names are always short ASCII (e.g. "RUNFILES_MANIFEST_FILE",
-  // "TEST_SRCDIR"), so ASCII → UTF-16 is a straight widening copy — no
-  // MultiByteToWideChar call, no allocation.
+  // Env-var names are ASCII, so ASCII -> UTF-16 is a straight widening
+  // copy -- no MultiByteToWideChar call, no allocation.
   wchar_t wname[128];
   size_t i;
   for (i = 0; name[i] && i < sizeof(wname) / sizeof(wchar_t) - 1; i++) {
@@ -239,26 +239,46 @@ char* rf_getenv_alloc(const char* name) {
   DWORD wsize = GetEnvironmentVariableW(wname, NULL, 0);
   if (wsize == 0) return NULL;
 
+  // The wide-char buffer is transient (freed on this call stack), but
+  // we still route the heap fallback through @p alloc so a custom
+  // allocator observes every byte of runfiles-attributable traffic.
   wchar_t stack_val[1024];
-  wchar_t* wval = ((size_t)wsize <= sizeof(stack_val) / sizeof(wchar_t))
-                      ? stack_val
-                      : (wchar_t*)malloc((size_t)wsize * sizeof(wchar_t));
+  wchar_t* wval;
+  if ((size_t)wsize <= sizeof(stack_val) / sizeof(wchar_t)) {
+    wval = stack_val;
+  } else if (alloc) {
+    wval = (wchar_t*)rf_a_malloc(alloc, (size_t)wsize * sizeof(wchar_t));
+  } else {
+    wval = (wchar_t*)malloc((size_t)wsize * sizeof(wchar_t));
+  }
   if (!wval) return NULL;
   DWORD written = GetEnvironmentVariableW(wname, wval, wsize);
   if (written == 0 || written >= wsize) {
-    if (wval != stack_val) free(wval);
+    if (wval != stack_val) {
+      if (alloc) {
+        rf_a_free(alloc, wval);
+      } else {
+        free(wval);
+      }
+    }
     return NULL;
   }
-  // rf_wide_to_utf8 with a NULL stack buffer forces heap allocation, so
-  // the returned pointer is always caller-owned (never stack).
-  char* out = rf_wide_to_utf8(wval, NULL, 0);
-  if (wval != stack_val) free(wval);
+  // NULL stack buffer forces heap allocation via @p alloc.
+  char* out = rf_wide_to_utf8(wval, NULL, 0, alloc);
+  if (wval != stack_val) {
+    if (alloc) {
+      rf_a_free(alloc, wval);
+    } else {
+      free(wval);
+    }
+  }
   return out;
 #else
   const char* v = getenv(name);
   if (!v) return NULL;
   size_t len = strlen(v);
-  char* copy = (char*)malloc(len + 1);
+  char* copy =
+      alloc ? (char*)rf_a_malloc(alloc, len + 1) : (char*)malloc(len + 1);
   if (!copy) return NULL;
   memcpy(copy, v, len + 1);
   return copy;
@@ -268,11 +288,10 @@ char* rf_getenv_alloc(const char* name) {
 int rf_path_is_rlocation_valid(const char* path) {
   if (!path || !path[0]) return 0;
   size_t len = strlen(path);
-  // Treat both '/' and '\' as separators for the traversal checks.
-  // Bazel manifests use forward slashes, so a backslash in a caller-
-  // supplied rlocation key is suspicious on any platform; rejecting
-  // unconditionally closes the Windows path-traversal hole (e.g.
-  // "..\\..\\etc\\passwd") without needing a platform ifdef.
+  // Treat '\' as a separator on ALL platforms -- Bazel manifests use
+  // forward slashes, so a backslash in a caller-supplied key is
+  // suspicious and rejecting it closes the Windows path-traversal
+  // hole ("..\\..\\etc\\passwd") without a platform ifdef.
 #define RF_IS_SEP(c) ((c) == '/' || (c) == '\\')
   // starts with "../" or "..\\"
   if (len >= 3 && path[0] == '.' && path[1] == '.' && RF_IS_SEP(path[2]))
@@ -340,21 +359,44 @@ static const char kRunfilesManifest[] = ".runfiles_manifest";
 static const char kSlashManifest[] = "/MANIFEST";
 static const char kUnderscoreManifest[] = "_manifest";
 
-// Concatenate a and b into out. Returns 1 on success, 0 if the buffer
-// is too small.
-static int rf_join2(const char* a, const char* b, char* out, size_t out_len) {
-  size_t la = strlen(a);
-  size_t lb = strlen(b);
-  if (la + lb + 1 > out_len) return 0;
-  memcpy(out, a, la);
-  memcpy(out + la, b, lb);
-  out[la + lb] = '\0';
+// Grow @p *buf to hold at least @p need bytes (including NUL). Doubles
+// on each grow. Returns 1 on success, 0 on allocation failure (in which
+// case @p *buf and @p *cap are left unchanged).
+static int rf_buf_grow(char** buf, size_t* cap, size_t need,
+                       const rf_allocator* alloc) {
+  if (*cap >= need) return 1;
+  size_t nc = *cap ? *cap : 128;
+  while (nc < need) nc *= 2;
+  char* np = (char*)rf_a_realloc(alloc, *buf, nc);
+  if (!np) return 0;
+  *buf = np;
+  *cap = nc;
   return 1;
 }
 
-// Invoke a caller-provided predicate if non-NULL, else the built-in
-// rf_is_readable_file / rf_is_directory. Keeps the rf_paths_from body
-// free of null-check boilerplate.
+static int rf_buf_assign(char** buf, size_t* cap, const rf_allocator* alloc,
+                         const char* s) {
+  size_t l = strlen(s);
+  if (!rf_buf_grow(buf, cap, l + 1, alloc)) return 0;
+  memcpy(*buf, s, l + 1);
+  return 1;
+}
+
+static int rf_buf_join2(char** buf, size_t* cap, const rf_allocator* alloc,
+                        const char* a, const char* b) {
+  size_t la = strlen(a);
+  size_t lb = strlen(b);
+  if (!rf_buf_grow(buf, cap, la + lb + 1, alloc)) return 0;
+  memcpy(*buf, a, la);
+  memcpy(*buf + la, b, lb);
+  (*buf)[la + lb] = '\0';
+  return 1;
+}
+
+static void rf_buf_truncate(char* buf, size_t new_len) { buf[new_len] = '\0'; }
+
+// Predicate dispatch: caller override else the built-in. Keeps
+// rf_paths_from_body free of null-check boilerplate.
 #define RF_IS_FILE(path)                                           \
   (is_readable_file ? is_readable_file(predicate_userdata, (path)) \
                     : rf_is_readable_file(path))
@@ -362,42 +404,35 @@ static int rf_join2(const char* a, const char* b, char* out, size_t out_len) {
   (is_directory ? is_directory(predicate_userdata, (path)) \
                 : rf_is_directory(path))
 
-int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
-                  const char* runfiles_dir, rf_predicate is_readable_file,
-                  rf_predicate is_directory, void* predicate_userdata,
-                  char* out_manifest, size_t out_manifest_len,
-                  char* out_directory, size_t out_directory_len) {
-  if (!out_manifest || out_manifest_len == 0 || !out_directory ||
-      out_directory_len == 0)
-    return 0;
-
-  // Copy inputs into local buffers we can rewrite while searching.
-  // Empty ("") indicates "not set / not yet discovered".
-  char mf_buf[4096];
-  char dir_buf[4096];
-
+// Inner body -- buffers stay in the caller's locals so the wrapper can
+// free them on either path. On success ownership of a valid buffer
+// transfers to *out_manifest / *out_directory (local NULL'd).
+static int rf_paths_from_body(
+    const char* argv0, const char* runfiles_manifest_file,
+    const char* runfiles_dir, rf_predicate is_readable_file,
+    rf_predicate is_directory, void* predicate_userdata,
+    const rf_allocator* alloc, char** mf_buf, size_t* mf_cap, char** dir_buf,
+    size_t* dir_cap, char** out_manifest, char** out_directory) {
   const char* mf_in = runfiles_manifest_file ? runfiles_manifest_file : "";
   const char* dir_in = runfiles_dir ? runfiles_dir : "";
 
-  if (strlen(mf_in) + 1 > sizeof(mf_buf)) return 0;
-  if (strlen(dir_in) + 1 > sizeof(dir_buf)) return 0;
+  if (!rf_buf_assign(mf_buf, mf_cap, alloc, mf_in)) return 0;
+  if (!rf_buf_assign(dir_buf, dir_cap, alloc, dir_in)) return 0;
 
-  strcpy(mf_buf, mf_in);
-  strcpy(dir_buf, dir_in);
-
-  int mf_valid = mf_buf[0] && RF_IS_FILE(mf_buf);
-  int dir_valid = dir_buf[0] && RF_IS_DIR(dir_buf);
+  int mf_valid = (*mf_buf)[0] && RF_IS_FILE(*mf_buf);
+  int dir_valid = (*dir_buf)[0] && RF_IS_DIR(*dir_buf);
 
   if (argv0 && argv0[0] && !mf_valid && !dir_valid) {
     // argv0.runfiles/MANIFEST + argv0.runfiles
-    if (!rf_join2(argv0, kRunfilesSlashManifest, mf_buf, sizeof(mf_buf)))
+    if (!rf_buf_join2(mf_buf, mf_cap, alloc, argv0, kRunfilesSlashManifest))
       return 0;
-    if (!rf_join2(argv0, kRunfilesDir, dir_buf, sizeof(dir_buf))) return 0;
-    mf_valid = RF_IS_FILE(mf_buf);
-    dir_valid = RF_IS_DIR(dir_buf);
+    if (!rf_buf_join2(dir_buf, dir_cap, alloc, argv0, kRunfilesDir)) return 0;
+    mf_valid = RF_IS_FILE(*mf_buf);
+    dir_valid = RF_IS_DIR(*dir_buf);
     if (!mf_valid) {
-      if (!rf_join2(argv0, kRunfilesManifest, mf_buf, sizeof(mf_buf))) return 0;
-      mf_valid = RF_IS_FILE(mf_buf);
+      if (!rf_buf_join2(mf_buf, mf_cap, alloc, argv0, kRunfilesManifest))
+        return 0;
+      mf_valid = RF_IS_FILE(*mf_buf);
     }
   }
 
@@ -405,12 +440,13 @@ int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
 
   if (!mf_valid) {
     // Try dir + "/MANIFEST" then dir + "_manifest".
-    if (!rf_join2(dir_buf, kSlashManifest, mf_buf, sizeof(mf_buf))) return 0;
-    mf_valid = RF_IS_FILE(mf_buf);
+    if (!rf_buf_join2(mf_buf, mf_cap, alloc, *dir_buf, kSlashManifest))
+      return 0;
+    mf_valid = RF_IS_FILE(*mf_buf);
     if (!mf_valid) {
-      if (!rf_join2(dir_buf, kUnderscoreManifest, mf_buf, sizeof(mf_buf)))
+      if (!rf_buf_join2(mf_buf, mf_cap, alloc, *dir_buf, kUnderscoreManifest))
         return 0;
-      mf_valid = RF_IS_FILE(mf_buf);
+      mf_valid = RF_IS_FILE(*mf_buf);
     }
   }
 
@@ -418,42 +454,61 @@ int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
     // If mf ends with ".runfiles_manifest" or "/MANIFEST", derive the
     // directory by stripping the 9-char suffix ("_manifest" or
     // "/MANIFEST"). Each suffix check must guard against mf being
-    // shorter than the suffix itself to avoid reading before mf_buf.
-    size_t mf_len = strlen(mf_buf);
+    // shorter than the suffix itself to avoid reading before *mf_buf.
+    size_t mf_len = strlen(*mf_buf);
     const size_t kStripLen = 9;
     const size_t kRunfilesManifestLen = sizeof(kRunfilesManifest) - 1;
     const size_t kSlashManifestLen = sizeof(kSlashManifest) - 1;
     int matches =
         (mf_len >= kRunfilesManifestLen &&
-         strcmp(mf_buf + mf_len - kRunfilesManifestLen, kRunfilesManifest) ==
+         strcmp(*mf_buf + mf_len - kRunfilesManifestLen, kRunfilesManifest) ==
              0) ||
         (mf_len >= kSlashManifestLen &&
-         strcmp(mf_buf + mf_len - kSlashManifestLen, kSlashManifest) == 0);
+         strcmp(*mf_buf + mf_len - kSlashManifestLen, kSlashManifest) == 0);
     if (matches) {
-      if (mf_len - kStripLen + 1 > sizeof(dir_buf)) return 0;
-      memcpy(dir_buf, mf_buf, mf_len - kStripLen);
-      dir_buf[mf_len - kStripLen] = '\0';
-      dir_valid = RF_IS_DIR(dir_buf);
+      if (!rf_buf_grow(dir_buf, dir_cap, mf_len - kStripLen + 1, alloc))
+        return 0;
+      memcpy(*dir_buf, *mf_buf, mf_len - kStripLen);
+      rf_buf_truncate(*dir_buf, mf_len - kStripLen);
+      dir_valid = RF_IS_DIR(*dir_buf);
     }
   }
 
+  // Hand ownership of the valid buffers to the caller. The invalid
+  // one (and any buffer we allocated but didn't use) stays in
+  // *mf_buf / *dir_buf for the wrapper to free.
   if (mf_valid) {
-    size_t l = strlen(mf_buf);
-    if (l + 1 > out_manifest_len) return 0;
-    memcpy(out_manifest, mf_buf, l + 1);
-  } else {
-    out_manifest[0] = '\0';
+    *out_manifest = *mf_buf;
+    *mf_buf = NULL;
   }
-
   if (dir_valid) {
-    size_t l = strlen(dir_buf);
-    if (l + 1 > out_directory_len) return 0;
-    memcpy(out_directory, dir_buf, l + 1);
-  } else {
-    out_directory[0] = '\0';
+    *out_directory = *dir_buf;
+    *dir_buf = NULL;
   }
-
   return 1;
+}
+
+int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
+                  const char* runfiles_dir, rf_predicate is_readable_file,
+                  rf_predicate is_directory, void* predicate_userdata,
+                  const struct rf_allocator* alloc, char** out_manifest,
+                  char** out_directory) {
+  if (!out_manifest || !out_directory) return 0;
+  *out_manifest = NULL;
+  *out_directory = NULL;
+  if (!alloc) alloc = &g_libc_allocator;
+
+  char* mf_buf = NULL;
+  size_t mf_cap = 0;
+  char* dir_buf = NULL;
+  size_t dir_cap = 0;
+  int ok = rf_paths_from_body(argv0, runfiles_manifest_file, runfiles_dir,
+                              is_readable_file, is_directory,
+                              predicate_userdata, alloc, &mf_buf, &mf_cap,
+                              &dir_buf, &dir_cap, out_manifest, out_directory);
+  rf_a_free(alloc, mf_buf);
+  rf_a_free(alloc, dir_buf);
+  return ok;
 }
 #undef RF_IS_FILE
 #undef RF_IS_DIR
@@ -462,31 +517,23 @@ int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
 // Streaming line reader
 // ==========================================================================
 
-/// Read a single line from @p f into `*line_buf`, growing it as
-/// needed via the pluggable allocator. Strips trailing `\n` and `\r`.
-///
-/// Reads one byte at a time via `getc_unlocked` (POSIX) / `_getc_nolock`
-/// (MSVC) so embedded NUL bytes are preserved verbatim (an `fgets`+`strlen`
-/// shape would silently truncate any line containing a `\0`). Using the
-/// unlocked getc variant skips the per-call FILE lock that `fgetc` takes
-/// — safe here because the FILE* is a function-local resource never
-/// shared across threads.
-///
-/// @param f Open input stream.
-/// @param line_buf In/out: growing heap buffer. May start as `NULL`
-///   with `*line_cap == 0`.
-/// @param line_cap In/out: current capacity of `*line_buf`.
-/// @param a Allocator used for grow-a-buffer operations.
-/// @retval >=0 Line length written to `*line_buf`.
-/// @retval -1 EOF with nothing read.
-/// @retval -2 I/O error.
-/// @retval -3 Allocation failure.
+// Read one line; strip trailing \r/\n. Returns line length, or -1 EOF /
+// -2 I/O error / -3 alloc failure. Reads a byte at a time via the
+// unlocked getc so embedded NULs are preserved (fgets+strlen would
+// silently truncate them); unlocked is safe because the FILE* is
+// function-local.
 static int rf_read_line(FILE* f, char** line_buf, size_t* line_cap,
                         const rf_allocator* a) {
-#ifdef _WIN32
+// Prefer the unlocked getc where we can — the FILE* is function-local
+// so per-byte locking is pure overhead. Fall back to plain getc where
+// no reliable unlocked variant exists (MinGW ships it conditional on
+// __MSVCRT_VERSION__; Cygwin's newlib doesn't guarantee it either).
+#if defined(_MSC_VER)
 #define RF_GETC(fp) _getc_nolock(fp)
-#else
+#elif !defined(_WIN32) && !defined(__CYGWIN__)
 #define RF_GETC(fp) getc_unlocked(fp)
+#else
+#define RF_GETC(fp) getc(fp)
 #endif
   size_t used = 0;
   for (;;) {
@@ -517,8 +564,7 @@ static int rf_read_line(FILE* f, char** line_buf, size_t* line_cap,
 }
 
 // ==========================================================================
-// Format helpers (pure — no I/O, no allocation). Shared by the C-side
-// streaming parsers below AND by the C++ facade in runfiles.cc.
+// Format helpers (pure -- no I/O, no allocation).
 // ==========================================================================
 
 rf_status rf_manifest_split_line(const char* line, size_t line_len,
@@ -581,8 +627,8 @@ rf_status rf_repo_mapping_split_line(const char* line, size_t line_len,
 }
 
 // ==========================================================================
-// Manifest parser (streaming, C-private). Used by rf_data_build only —
-// the C++ facade has its own FILE*-based parser and does NOT call this.
+// Manifest parser (streaming, C-private). Only caller is rf_create,
+// via the rf_build_manifest_cb callback below.
 // ==========================================================================
 
 static rf_status rf_parse_manifest_into(
@@ -718,27 +764,23 @@ static rf_status rf_parse_repo_mapping_into(
 }
 
 // ==========================================================================
-// rf_runfiles — parsed state owned by exactly one handle.
-//
-// No refcount, no sharing across handles, no locking. Each rf_create*
-// produces a fresh handle; rf_free releases everything it owns.
+// rf_runfiles -- parsed state fully owned by one handle. No refcount, no
+// sharing, no locking.
 // ==========================================================================
 
-/// One repo-mapping row. Sorted lexicographically by
-/// `(target_apparent, source_repo)` — reproduces
-/// `std::pair<string,string>::operator<` exactly, including
-/// "'*' sorts before every valid repo-name char" for wildcard entries.
+// Sorted lexicographically by (target_apparent, source_repo) --
+// reproduces std::pair<string,string>::operator< exactly, including
+// "'*' sorts before every valid repo-name char" for wildcards.
 typedef struct {
   char* target_apparent;
   size_t ta_len;
-  char* source_repo;  ///< May end in `*` for wildcard entries.
+  char* source_repo;  // May end in '*' for wildcard entries.
   size_t sr_len;
   char* value;
   size_t value_len;
 } rf_repo_entry;
 
-/// One manifest row. `key_len` is cached so binary search doesn't need
-/// to `strlen` the stored key on every probe.
+// key_len cached so binary search doesn't strlen on every probe.
 typedef struct {
   char* key;
   size_t key_len;
@@ -746,43 +788,48 @@ typedef struct {
 } rf_manifest_entry;
 
 struct rf_runfiles {
-  /// Owned copy of the allocator vtable this handle was built with.
-  /// Copying the struct in — rather than storing a pointer — lets
-  /// callers pass a short-lived (e.g. stack-local) #rf_allocator to
-  /// #rf_create_ex; the handle uses this copy for its whole lifetime.
+  // Owned COPY of the allocator vtable, so callers may pass a
+  // stack-local #rf_allocator to rf_create.
   rf_allocator alloc;
 
-  char* directory;          ///< Resolved runfiles directory (or `""`).
-  char* manifest_file;      ///< Resolved manifest file (or `""`).
-  char* source_repository;  ///< Default source repo for #rf_rlocation.
+  char* directory;
+  char* manifest_file;
+  char* source_repository;
 
-  rf_manifest_entry* manifest;  ///< Sorted manifest rows.
+  rf_manifest_entry* manifest;
   size_t manifest_count;
   size_t manifest_capacity;
 
-  rf_repo_entry* repo_map;  ///< Sorted `_repo_mapping` rows.
+  rf_repo_entry* repo_map;
   size_t repo_map_count;
   size_t repo_map_capacity;
 
-  // Env-var values are not stored: rf_env_var derives them from
-  // manifest_file / directory above.
+  // No separate env-var storage -- rf_env_var_value returns pointers
+  // into manifest_file / directory.
 };
 
 // ==========================================================================
-// Sorting parallel arrays (manifest and repo-mapping)
+// Sort comparators
 // ==========================================================================
 
+// Length-aware to match rf_bsearch_manifest_prefix's memcmp+length
+// compare byte-for-byte. strcmp would disagree with the lookup path on
+// any key containing an embedded NUL (the streaming reader preserves
+// them).
 static int rf_manifest_qsort_cmp(const void* a, const void* b) {
   const rf_manifest_entry* ea = (const rf_manifest_entry*)a;
   const rf_manifest_entry* eb = (const rf_manifest_entry*)b;
-  return strcmp(ea->key, eb->key);
+  size_t n = ea->key_len < eb->key_len ? ea->key_len : eb->key_len;
+  int c = n ? memcmp(ea->key, eb->key, n) : 0;
+  if (c != 0) return c;
+  if (ea->key_len < eb->key_len) return -1;
+  if (ea->key_len > eb->key_len) return 1;
+  return 0;
 }
 
-// Compare two (target_apparent, source_repo) pairs lexicographically —
-// reproduces std::pair<string,string>::operator< exactly, including
-// "'*' sorts before every valid repo-name char" for wildcard entries.
-// Used both for sorting the repo-map and for binary-searching a lookup
-// key against a stored entry.
+// Lex compare on (target_apparent, source_repo). Shared by the sort
+// and the lookup so both paths agree on ordering (incl. '*' sorting
+// before every valid repo-name char for wildcards).
 static int rf_repo_key_cmp(const char* ta_a, size_t ta_a_len, const char* sr_a,
                            size_t sr_a_len, const char* ta_b, size_t ta_b_len,
                            const char* sr_b, size_t sr_b_len) {
@@ -807,11 +854,11 @@ static int rf_repo_qsort_cmp(const void* a, const void* b) {
 }
 
 // ==========================================================================
-// Callbacks for populating rf_runfiles
+// Parser callbacks
 //
-// A callback that returns non-zero surfaces as RF_ERR_CALLBACK from the
-// parser and the whole build path unwinds. Returning non-zero on OOM
-// therefore doubles as error propagation — no separate flag needed.
+// Non-zero return propagates through the parser as RF_ERR_CALLBACK and
+// unwinds the whole build path, so returning non-zero on OOM doubles
+// as error propagation -- no separate flag needed.
 // ==========================================================================
 
 static int rf_build_manifest_cb(void* userdata, const char* key, size_t klen,
@@ -880,13 +927,18 @@ static int rf_build_repo_map_cb(void* userdata, const char* ta, size_t ta_len,
 
 // ==========================================================================
 // RlocationUnchecked (data-level; no repo mapping / validation)
+//
+// Caller-buffer contract: writes NUL-terminated result into @p buf when
+// it fits, always sets @c *needed so callers can grow-and-retry once
+// with an exactly-sized buffer. Internal encoding:
+//   1  -> OK (buf written, *needed = strlen)
+//   0  -> NOT_FOUND
+//   -1 -> BUF_TOO_SMALL (buf untouched, *needed = required)
+//   -2 -> ALLOC_FAILED (only from rf_rlocation_unchecked_join's scratch)
 // ==========================================================================
 
-/// Binary search on the manifest for a key equal to the first
-/// @p prefix_len bytes of @p path. Does NOT mutate @p path. Passing
-/// `strlen(path)` as @p prefix_len yields an exact-key search.
-///
-/// @return Matching index, or `-1` if no match.
+// Passing `strlen(path)` as prefix_len is an exact-key search. Never
+// mutates @p path.
 static int rf_bsearch_manifest_prefix(const rf_runfiles* rf, const char* path,
                                       size_t prefix_len) {
   int lo = 0, hi = (int)rf->manifest_count - 1;
@@ -906,21 +958,23 @@ static int rf_bsearch_manifest_prefix(const rf_runfiles* rf, const char* path,
   return -1;
 }
 
-// Resolve `path` against the manifest/directory only (no repo mapping,
-// no path validation, no absolute-path passthrough). Returns positive
-// length on success, 0 if not found, -1 on buffer-too-small.
+// Never allocates.
 static int rf_rlocation_unchecked(const rf_runfiles* rf, const char* path,
-                                  char* out, int out_len) {
+                                  char* buf, size_t buf_cap, size_t* needed) {
+  *needed = 0;
   size_t path_len = strlen(path);
-  // 1) Exact match (prefix search with the full path length).
+
+  // 1) Exact match.
   int idx = rf_bsearch_manifest_prefix(rf, path, path_len);
   if (idx >= 0) {
     const char* v = rf->manifest[idx].value;
-    int vlen = (int)strlen(v);
-    if (vlen + 1 > out_len) return -1;
-    memcpy(out, v, vlen + 1);
-    return vlen;
+    size_t vlen = strlen(v);
+    *needed = vlen;
+    if (vlen + 1 > buf_cap) return -1;
+    memcpy(buf, v, vlen + 1);
+    return 1;
   }
+
   // 2) Longest-prefix match.
   if (rf->manifest_count > 0) {
     size_t prefix_end = path_len;
@@ -933,68 +987,64 @@ static int rf_rlocation_unchecked(const rf_runfiles* rf, const char* path,
       int pidx = rf_bsearch_manifest_prefix(rf, path, prefix_end);
       if (pidx >= 0) {
         const char* v = rf->manifest[pidx].value;
-        int vlen = (int)strlen(v);
+        size_t vlen = strlen(v);
         size_t rem_len = path_len - prefix_end - 1;
-        int total = vlen + 1 + (int)rem_len;
-        if (total + 1 > out_len) return -1;
-        memcpy(out, v, vlen);
-        out[vlen] = '/';
-        memcpy(out + vlen + 1, path + prefix_end + 1, rem_len);
-        out[total] = '\0';
-        return total;
+        size_t total = vlen + 1 + rem_len;
+        *needed = total;
+        if (total + 1 > buf_cap) return -1;
+        memcpy(buf, v, vlen);
+        buf[vlen] = '/';
+        memcpy(buf + vlen + 1, path + prefix_end + 1, rem_len);
+        buf[total] = '\0';
+        return 1;
       }
     }
   }
+
   // 3) Directory fallback.
   if (rf->directory && rf->directory[0]) {
-    int dlen = (int)strlen(rf->directory);
-    int total = dlen + 1 + (int)path_len;
-    if (total + 1 > out_len) return -1;
-    memcpy(out, rf->directory, dlen);
-    out[dlen] = '/';
-    memcpy(out + dlen + 1, path, path_len + 1);
-    return total;
+    size_t dlen = strlen(rf->directory);
+    size_t total = dlen + 1 + path_len;
+    *needed = total;
+    if (total + 1 > buf_cap) return -1;
+    memcpy(buf, rf->directory, dlen);
+    buf[dlen] = '/';
+    memcpy(buf + dlen + 1, path, path_len + 1);
+    return 1;
   }
   return 0;
 }
 
-// Helper: rlocation from a virtually-concatenated `prefix + suffix` key.
-// Used after a repo-mapping rewrite so the caller can pass "canonical +
-// path.substr(first_slash)" without doing the join themselves.
+// Post-repo-mapping variant: builds a virtual "prefix + suffix" key in
+// allocator-backed scratch, delegates the lookup, frees. Returns -2
+// if the scratch alloc fails -- the ONE alloc the caller-buffer public
+// API makes internally, bounded by prefix_len + suffix_len.
 static int rf_rlocation_unchecked_join(const rf_runfiles* rf,
                                        const char* prefix, size_t prefix_len,
                                        const char* suffix, size_t suffix_len,
-                                       char* out, int out_len) {
+                                       char* buf, size_t buf_cap,
+                                       size_t* needed) {
+  const rf_allocator* a = &rf->alloc;
+  *needed = 0;
   size_t total = prefix_len + suffix_len;
-  char stack_buf[8192];
-  char* tmp;
-  int use_heap = 0;
-  if (total + 1 <= sizeof(stack_buf)) {
-    tmp = stack_buf;
-  } else {
-    tmp = (char*)rf_a_malloc(&rf->alloc, total + 1);
-    if (!tmp) return -1;
-    use_heap = 1;
-  }
-  memcpy(tmp, prefix, prefix_len);
-  if (suffix_len) memcpy(tmp + prefix_len, suffix, suffix_len);
-  tmp[total] = '\0';
-  int r = rf_rlocation_unchecked(rf, tmp, out, out_len);
-  if (use_heap) rf_a_free(&rf->alloc, tmp);
+  char* key = (char*)rf_a_malloc(a, total + 1);
+  if (!key) return -2;
+  memcpy(key, prefix, prefix_len);
+  if (suffix_len) memcpy(key + prefix_len, suffix, suffix_len);
+  key[total] = '\0';
+  int r = rf_rlocation_unchecked(rf, key, buf, buf_cap, needed);
+  rf_a_free(a, key);
   return r;
 }
 
 // ==========================================================================
-// Public C API — construction
+// Public API -- construction
 // ==========================================================================
 
-// Free every allocation reachable from @p rf, then @p rf itself. Used
-// both by rf_free and by the mid-construction error paths in
-// rf_create_ex.
+// Also used by rf_create's mid-construction error paths.
 static void rf_free_impl(rf_runfiles* rf) {
   if (!rf) return;
-  // Snapshot the vtable so rf_a_free can still dispatch after `rf`
-  // itself is freed at the end.
+  // Snapshot the vtable so dispatch still works after `rf` is freed.
   rf_allocator a = rf->alloc;
   rf_a_free(&a, rf->directory);
   rf_a_free(&a, rf->manifest_file);
@@ -1013,16 +1063,15 @@ static void rf_free_impl(rf_runfiles* rf) {
   rf_a_free(&a, rf);
 }
 
-rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
-                          const char* manifest, const char* dir,
-                          const char* source_repo, char* err, int err_len) {
+rf_runfiles* rf_create(const rf_allocator* alloc, const char* argv0,
+                       const char* manifest, const char* dir,
+                       const char* source_repo, char* err, size_t err_len) {
   if (!alloc) alloc = &g_libc_allocator;
 
-  char resolved_manifest[4096];
-  char resolved_directory[4096];
-  if (!rf_paths_from(argv0 ? argv0 : "", manifest, dir, NULL, NULL, NULL,
-                     resolved_manifest, sizeof(resolved_manifest),
-                     resolved_directory, sizeof(resolved_directory))) {
+  char* resolved_manifest = NULL;
+  char* resolved_directory = NULL;
+  if (!rf_paths_from(argv0 ? argv0 : "", manifest, dir, NULL, NULL, NULL, alloc,
+                     &resolved_manifest, &resolved_directory)) {
     if (err && err_len > 0) {
       snprintf(err, err_len, "ERROR: cannot find runfiles (argv0=\"%s\")",
                argv0 ? argv0 : "");
@@ -1031,22 +1080,32 @@ rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
   }
 
   rf_runfiles* rf = (rf_runfiles*)rf_a_malloc(alloc, sizeof(rf_runfiles));
-  if (!rf) return NULL;
+  if (!rf) {
+    rf_a_free(alloc, resolved_manifest);
+    rf_a_free(alloc, resolved_directory);
+    return NULL;
+  }
   memset(rf, 0, sizeof(*rf));
-  rf->alloc = *alloc;  // owned copy — safe against short-lived vtables
+  rf->alloc = *alloc;  // owned copy -- safe against short-lived vtables
 
-  rf->directory = rf_a_strdup(alloc, resolved_directory);
-  rf->manifest_file = rf_a_strdup(alloc, resolved_manifest);
+  rf->directory =
+      rf_a_strdup(alloc, resolved_directory ? resolved_directory : "");
+  rf->manifest_file =
+      rf_a_strdup(alloc, resolved_manifest ? resolved_manifest : "");
   rf->source_repository = rf_a_strdup(alloc, source_repo ? source_repo : "");
   if (!rf->directory || !rf->manifest_file || !rf->source_repository) {
+    rf_a_free(alloc, resolved_manifest);
+    rf_a_free(alloc, resolved_directory);
     rf_free_impl(rf);
     return NULL;
   }
 
-  if (resolved_manifest[0]) {
+  if (resolved_manifest && resolved_manifest[0]) {
     rf_status s = rf_parse_manifest_into(
-        resolved_manifest, rf_build_manifest_cb, rf, err, err_len, alloc);
+        resolved_manifest, rf_build_manifest_cb, rf, err, (int)err_len, alloc);
     if (s != RF_OK) {
+      rf_a_free(alloc, resolved_manifest);
+      rf_a_free(alloc, resolved_directory);
       rf_free_impl(rf);
       return NULL;
     }
@@ -1054,31 +1113,31 @@ rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
       qsort(rf->manifest, rf->manifest_count, sizeof(rf_manifest_entry),
             rf_manifest_qsort_cmp);
   }
+  rf_a_free(alloc, resolved_manifest);
+  rf_a_free(alloc, resolved_directory);
 
-  // Resolve the _repo_mapping path against the just-parsed manifest.
-  // Grow from an 8 KB stack buffer up to 1 MB before giving up
-  // (silently, matching C++'s "no repo mapping file" branch).
+  // Resolve _repo_mapping. Stack buffer covers ~all real paths; on
+  // BUF_TOO_SMALL retry once with the reported size.
   {
-    char stack_buf[8192];
+    char stack_buf[4096];
     char* heap_buf = NULL;
     char* buf = stack_buf;
     size_t cap = sizeof(stack_buf);
-    int n = rf_rlocation_unchecked(rf, "_repo_mapping", buf, (int)cap);
-    while (n == -1 && cap < (1u << 20)) {
-      cap *= 2;
-      char* np = (char*)rf_a_realloc(alloc, heap_buf, cap);
-      if (!np) {
-        rf_a_free(alloc, heap_buf);
+    size_t needed = 0;
+    int r = rf_rlocation_unchecked(rf, "_repo_mapping", buf, cap, &needed);
+    if (r == -1) {
+      heap_buf = (char*)rf_a_malloc(alloc, needed + 1);
+      if (!heap_buf) {
         rf_free_impl(rf);
         return NULL;
       }
-      heap_buf = np;
       buf = heap_buf;
-      n = rf_rlocation_unchecked(rf, "_repo_mapping", buf, (int)cap);
+      cap = needed + 1;
+      r = rf_rlocation_unchecked(rf, "_repo_mapping", buf, cap, &needed);
     }
-    if (n > 0) {
+    if (r == 1 && buf[0]) {
       rf_status s = rf_parse_repo_mapping_into(buf, rf_build_repo_map_cb, rf,
-                                               err, err_len, alloc);
+                                               err, (int)err_len, alloc);
       if (s != RF_OK) {
         rf_a_free(alloc, heap_buf);
         rf_free_impl(rf);
@@ -1094,48 +1153,31 @@ rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
   return rf;
 }
 
-// Shared body of the three env-reading rf_create* entry points. Reads
-// RUNFILES_MANIFEST_FILE and @p dir_env_key from the environment (via
-// rf_getenv_alloc, so Windows Unicode env vars work) and forwards to
-// rf_create_ex.
-static rf_runfiles* rf_create_from_env(const rf_allocator* alloc,
-                                       const char* argv0,
-                                       const char* dir_env_key,
-                                       const char* source_repo, char* err,
-                                       int err_len) {
-  char* mf = rf_getenv_alloc("RUNFILES_MANIFEST_FILE");
-  char* dir = rf_getenv_alloc(dir_env_key);
-  rf_runfiles* r = rf_create_ex(alloc, argv0, mf ? mf : "", dir ? dir : "",
-                                source_repo, err, err_len);
-  free(mf);
-  free(dir);
+rf_runfiles* rf_create_for_test(const rf_allocator* alloc,
+                                const char* source_repo, char* err,
+                                size_t err_len) {
+  // Snapshot so the transient env-var strings get freed via the same
+  // vtable rf_getenv_alloc allocated them with.
+  const rf_allocator* env_alloc = alloc ? alloc : &g_libc_allocator;
+  char* mf = rf_getenv_alloc(env_alloc, "RUNFILES_MANIFEST_FILE");
+  char* dir = rf_getenv_alloc(env_alloc, "TEST_SRCDIR");
+  rf_runfiles* r = rf_create(alloc, "", mf ? mf : "", dir ? dir : "",
+                             source_repo, err, err_len);
+  rf_a_free(env_alloc, mf);
+  rf_a_free(env_alloc, dir);
   return r;
 }
 
-rf_runfiles* rf_create(const rf_allocator* alloc, const char* argv0, char* err,
-                       int err_len) {
-  return rf_create_from_env(alloc, argv0, "RUNFILES_DIR", "", err, err_len);
-}
+// ==========================================================================
+// Public API -- free
+// ==========================================================================
 
-rf_runfiles* rf_create_for_test(const rf_allocator* alloc, char* err,
-                                int err_len) {
-  return rf_create_from_env(alloc, "", "TEST_SRCDIR", "", err, err_len);
-}
-
-rf_runfiles* rf_create_for_test_ex(const rf_allocator* alloc,
-                                   const char* source_repo, char* err,
-                                   int err_len) {
-  return rf_create_from_env(alloc, "", "TEST_SRCDIR", source_repo, err,
-                            err_len);
-}
+void rf_free(rf_runfiles* rf) { rf_free_impl(rf); }
 
 // ==========================================================================
 // Rlocation (with repo-mapping)
 // ==========================================================================
 
-// Return < 0, == 0, > 0 comparing an entry to a lookup key
-// (target_apparent, source_repo). Thin wrapper over rf_repo_key_cmp
-// so sort and lookup share the same lex-order definition.
 static int rf_cmp_lookup_key(const rf_repo_entry* e,
                              const char* target_apparent, size_t ta_len,
                              const char* source_repo, size_t sr_len) {
@@ -1144,8 +1186,8 @@ static int rf_cmp_lookup_key(const rf_repo_entry* e,
                          sr_len);
 }
 
-// Find upper_bound(key): index of first repo-map entry strictly greater
-// than (target_apparent, source_repo). Returns repo_map_count if none.
+// upper_bound(key): index of first entry strictly greater than
+// (target_apparent, source_repo). Returns repo_map_count if none.
 static size_t rf_rm_upper_bound(const rf_runfiles* rf,
                                 const char* target_apparent, size_t ta_len,
                                 const char* source_repo, size_t sr_len) {
@@ -1162,100 +1204,95 @@ static size_t rf_rm_upper_bound(const rf_runfiles* rf,
   return lo;
 }
 
-int rf_rlocation_from(const rf_runfiles* rf, const char* path,
-                      const char* source_repository, char* result_buf,
-                      int result_buf_len) {
-  if (!rf || !path || !result_buf || result_buf_len <= 0) return -1;
-  result_buf[0] = '\0';
+static rf_rlocation_status rf_map_unchecked_status(int r) {
+  switch (r) {
+    case 1:
+      return RF_RLOCATION_OK;
+    case 0:
+      return RF_RLOCATION_NOT_FOUND;
+    case -1:
+      return RF_RLOCATION_BUF_TOO_SMALL;
+    default:
+      return RF_RLOCATION_ALLOC_FAILED;
+  }
+}
 
-  if (!rf_path_is_rlocation_valid(path)) return -1;
+rf_rlocation_status rf_rlocation(rf_runfiles* rf, const char* path,
+                                 const char* source_repository, char* buf,
+                                 size_t buf_cap, size_t* needed) {
+  size_t local_needed = 0;
+  if (!needed) needed = &local_needed;
+  *needed = 0;
+
+  if (!rf || !path) return RF_RLOCATION_INVALID_PATH;
+  if (!rf_path_is_rlocation_valid(path)) return RF_RLOCATION_INVALID_PATH;
 
   if (rf_is_absolute(path)) {
-    int plen = (int)strlen(path);
-    if (plen + 1 > result_buf_len) return -1;
-    memcpy(result_buf, path, plen + 1);
-    return plen;
+    size_t plen = strlen(path);
+    *needed = plen;
+    if (plen + 1 > buf_cap) return RF_RLOCATION_BUF_TOO_SMALL;
+    memcpy(buf, path, plen + 1);
+    return RF_RLOCATION_OK;
   }
 
-  const char* sr = source_repository ? source_repository : "";
+  const char* sr =
+      source_repository ? source_repository : rf->source_repository;
   size_t sr_len = strlen(sr);
 
   const char* slash = strchr(path, '/');
-  if (!slash) {
-    // No repo prefix — resolve directly.
-    return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
+  if (!slash || rf->repo_map_count == 0) {
+    return rf_map_unchecked_status(
+        rf_rlocation_unchecked(rf, path, buf, buf_cap, needed));
   }
 
   size_t first_slash = (size_t)(slash - path);
-  if (rf->repo_map_count == 0) {
-    return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
-  }
-
   size_t ub = rf_rm_upper_bound(rf, path, first_slash, sr, sr_len);
-  // Matches C++ std::prev(begin()) semantic: when upper_bound sits at
-  // begin(), floor stays at begin() and we still inspect the first
-  // entry — it may be a wildcard whose target_apparent matches ours,
-  // in which case rewriting must still fire even though the entry
-  // sorts strictly greater than the lookup key.
+  // C++ std::prev(begin()) semantic: when ub sits at begin(), floor
+  // stays at begin() so we still inspect the first entry -- it may be a
+  // wildcard whose target_apparent matches ours, in which case
+  // rewriting must fire even though the entry sorts strictly greater.
   size_t floor = (ub == 0) ? 0 : ub - 1;
   const rf_repo_entry* e = &rf->repo_map[floor];
   int cmp = rf_cmp_lookup_key(e, path, first_slash, sr, sr_len);
   const char* suffix = path + first_slash;
   size_t suffix_len = strlen(suffix);
-  // Exact match, OR wildcard: entry's target_apparent equals the
-  // lookup's, entry's source_repo ends in '*', and lookup's source_repo
-  // starts with the prefix (source_repo before the '*').
+  // Wildcard: entry.target_apparent == lookup.target_apparent,
+  // entry.source_repo ends in '*', and lookup.source_repo starts with
+  // the prefix (source_repo before the '*').
   int wildcard_match = e->ta_len == first_slash &&
                        memcmp(e->target_apparent, path, first_slash) == 0 &&
                        e->sr_len > 0 && e->source_repo[e->sr_len - 1] == '*' &&
                        e->sr_len - 1 <= sr_len &&
                        memcmp(e->source_repo, sr, e->sr_len - 1) == 0;
+  int r;
   if (cmp == 0 || wildcard_match) {
-    return rf_rlocation_unchecked_join(rf, e->value, e->value_len, suffix,
-                                       suffix_len, result_buf, result_buf_len);
+    r = rf_rlocation_unchecked_join(rf, e->value, e->value_len, suffix,
+                                    suffix_len, buf, buf_cap, needed);
+  } else {
+    r = rf_rlocation_unchecked(rf, path, buf, buf_cap, needed);
   }
-
-  return rf_rlocation_unchecked(rf, path, result_buf, result_buf_len);
-}
-
-int rf_rlocation(const rf_runfiles* rf, const char* path, char* result_buf,
-                 int result_buf_len) {
-  if (!rf) return -1;
-  return rf_rlocation_from(rf, path, rf->source_repository, result_buf,
-                           result_buf_len);
+  return rf_map_unchecked_status(r);
 }
 
 // ==========================================================================
 // Envvars
 // ==========================================================================
 
-int rf_env_vars_count(const rf_runfiles* rf) {
-  if (!rf) return 0;
-  return RF_NUM_ENV_VARS;
+// JAVA_RUNFILES aliases RUNFILES_DIR -- compatibility shim for the Java
+// launcher. TODO(laszlocsomor): remove once the launcher picks up
+// RUNFILES_DIR directly.
+static const char* const kRfEnvKeys[RF_NUM_ENV_VARS] = {
+    "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR", "JAVA_RUNFILES"};
+
+int rf_env_vars_count(void) { return RF_NUM_ENV_VARS; }
+
+const char* rf_env_var_key(int index) {
+  if (index < 0 || index >= RF_NUM_ENV_VARS) return NULL;
+  return kRfEnvKeys[index];
 }
 
-int rf_env_var(const rf_runfiles* rf, int index, char* key_buf, int key_buf_len,
-               char* val_buf, int val_buf_len) {
-  if (!rf || index < 0 || index >= RF_NUM_ENV_VARS) return 0;
-  if (!key_buf || key_buf_len <= 0 || !val_buf || val_buf_len <= 0) return 0;
-
-  // Values are derived: index 0 -> manifest_file, 1|2 -> directory
-  // (JAVA_RUNFILES aliases RUNFILES_DIR). No storage is allocated for
-  // env values.
-  const char* key = kRfEnvKeys[index];
-  const char* val = (index == 0) ? rf->manifest_file : rf->directory;
-
-  int klen = (int)strlen(key);
-  int vlen = (int)strlen(val);
-  if (klen + 1 > key_buf_len || vlen + 1 > val_buf_len) return 0;
-
-  memcpy(key_buf, key, klen + 1);
-  memcpy(val_buf, val, vlen + 1);
-  return 1;
+const char* rf_env_var_value(rf_runfiles* rf, int index) {
+  if (!rf || index < 0 || index >= RF_NUM_ENV_VARS) return NULL;
+  // index 0 -> manifest_file, 1|2 -> directory.
+  return (index == 0) ? rf->manifest_file : rf->directory;
 }
-
-// ==========================================================================
-// Destructor
-// ==========================================================================
-
-void rf_free(rf_runfiles* rf) { rf_free_impl(rf); }

--- a/cc/runfiles/runfiles_c.h
+++ b/cc/runfiles/runfiles_c.h
@@ -1,0 +1,244 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file runfiles_c.h
+/// @brief Runfiles lookup library for Bazel-built C binaries and tests.
+///
+/// This is the pure-C counterpart to `//cc/runfiles:runfiles` (which is C++).
+/// The two libraries implement the same algorithm and stay behavior-parity
+/// (manifest parsing, `_repo_mapping` support, argv0/envvar path discovery,
+/// prefix-match fallback, wildcard rewriting).
+///
+/// ### Usage
+/// @code
+///   #include "rules_cc/cc/runfiles/runfiles_c.h"
+///
+///   int main(int argc, char** argv) {
+///     char err[256];
+///     rf_runfiles* rf = rf_create(NULL, argv[0], err, sizeof(err));
+///     if (!rf) { fputs(err, stderr); return 1; }
+///
+///     char path[4096];
+///     int n = rf_rlocation(rf, "my_workspace/path/to/data.txt",
+///                          path, sizeof(path));
+///     if (n > 0) { /* path is the resolved runfile */ }
+///
+///     rf_free(rf);
+///     return 0;
+///   }
+/// @endcode
+///
+/// ### Subprocesses
+/// Iterate #rf_env_var from `0` to #rf_env_vars_count and set the returned
+/// key/value pairs in the child's environment.
+///
+/// ### Custom allocator
+/// Pass a #rf_allocator vtable as the first argument to any `rf_create*`
+/// function to route all heap allocation through your own callbacks.
+/// Pass `NULL` to use libc `malloc` / `realloc` / `free`. Each handle
+/// remembers the allocator it was built with and always releases its
+/// storage with the matching `free()` in #rf_free.
+///
+/// ### Sharing / lifetime
+/// Each `rf_create*` call parses the manifest and `_repo_mapping` from
+/// disk and returns a handle that fully owns its parsed state — no
+/// process-wide cache, no refcount, no sharing across handles. Callers
+/// that want to reuse the parse across scopes / threads / subsystems
+/// should hold the returned #rf_runfiles* themselves (e.g. wrap it in a
+/// `std::shared_ptr<rf_runfiles>` on the C++ side) rather than calling
+/// `rf_create*` repeatedly.
+///
+/// ### Thread safety
+/// The library carries no global state. Different handles are fully
+/// independent and can be used concurrently from different threads
+/// without synchronization. A single handle is safe for concurrent
+/// #rf_rlocation / #rf_rlocation_from reads (the underlying data is
+/// immutable after construction), but must NOT be freed concurrently
+/// with any in-flight lookup. Same contract as `std::vector`: parallel
+/// reads are fine, mixed reads + destruction is the caller's problem.
+
+#ifndef RULES_CC_CC_RUNFILES_RUNFILES_C_H_
+#define RULES_CC_CC_RUNFILES_RUNFILES_C_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle to a runfiles instance.
+typedef struct rf_runfiles rf_runfiles;
+
+/// Pluggable allocator vtable.
+///
+/// All three function pointers must be non-NULL if the vtable pointer
+/// is non-NULL. `userdata` is passed unchanged as the first argument
+/// to each call. `free(userdata, NULL)` must be a no-op.
+typedef struct rf_allocator {
+  /// `malloc(3)`-shaped allocation.
+  void* (*malloc)(void* userdata, size_t size);
+  /// `realloc(3)`-shaped resize; `ptr == NULL` means fresh allocation.
+  void* (*realloc)(void* userdata, void* ptr, size_t size);
+  /// `free(3)`-shaped release; must accept `NULL`.
+  void (*free)(void* userdata, void* ptr);
+  /// Opaque cookie forwarded to every call.
+  void* userdata;
+} rf_allocator;
+
+/// Create a runfiles handle for a `cc_binary` or `cc_library`.
+///
+/// Uses `RUNFILES_MANIFEST_FILE` and `RUNFILES_DIR` from the
+/// environment; falls back to `argv[0]`-based discovery if the env
+/// vars are unset.
+///
+/// @param alloc Allocator vtable, or `NULL` for libc `malloc`/`free`.
+///   The vtable is copied into the handle at construction so callers
+///   may pass a short-lived (e.g. stack-local) vtable safely.
+/// @param argv0 The program's `argv[0]`; pass `NULL` or `""` if unknown.
+/// @param error_buf Optional buffer that receives a human-readable
+///   error message on failure (NUL-terminated, truncated to
+///   `error_buf_len`).
+/// @param error_buf_len Size of @p error_buf in bytes.
+/// @return New handle on success (release with #rf_free), or `NULL` on
+///   error.
+rf_runfiles* rf_create(const rf_allocator* alloc, const char* argv0,
+                       char* error_buf, int error_buf_len);
+
+/// Create a runfiles handle for a `cc_test`.
+///
+/// Uses `RUNFILES_MANIFEST_FILE` and `TEST_SRCDIR` from the
+/// environment.
+///
+/// @param alloc Allocator vtable, or `NULL` for libc.
+/// @param error_buf Optional error message buffer; see #rf_create.
+/// @param error_buf_len Size of @p error_buf.
+/// @return New handle, or `NULL` on error.
+rf_runfiles* rf_create_for_test(const rf_allocator* alloc, char* error_buf,
+                                int error_buf_len);
+
+/// Extended constructor: pass explicit manifest / directory paths and a
+/// default source repository. Any string may be `NULL` or `""` to skip
+/// it (in which case discovery follows the same rules as #rf_create).
+///
+/// @param alloc Allocator vtable, or `NULL` for libc.
+/// @param argv0 Program `argv[0]`, or `NULL`/`""` if unknown.
+/// @param runfiles_manifest_file Explicit manifest path, or `""` to
+///   defer to argv0 discovery.
+/// @param runfiles_dir Explicit runfiles directory, or `""` to defer.
+/// @param source_repository Default source repository (canonical name);
+///   `""` denotes the main workspace.
+/// @param error_buf Optional error buffer.
+/// @param error_buf_len Size of @p error_buf.
+/// @return New handle, or `NULL` on error.
+rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
+                          const char* runfiles_manifest_file,
+                          const char* runfiles_dir,
+                          const char* source_repository, char* error_buf,
+                          int error_buf_len);
+
+/// Test variant of #rf_create_ex that reads paths from `TEST_SRCDIR` /
+/// `RUNFILES_MANIFEST_FILE` but lets the caller pin the source repo.
+///
+/// @param alloc Allocator vtable, or `NULL` for libc.
+/// @param source_repository Default source repository; `""` for main.
+/// @param error_buf Optional error buffer.
+/// @param error_buf_len Size of @p error_buf.
+/// @return New handle, or `NULL` on error.
+rf_runfiles* rf_create_for_test_ex(const rf_allocator* alloc,
+                                   const char* source_repository,
+                                   char* error_buf, int error_buf_len);
+
+/// Resolve @p path (a runfiles-root-relative path) using the handle's
+/// default source repository.
+///
+/// Rules (mirroring the C++ implementation):
+///   - Absolute paths are returned as-is.
+///   - Paths containing `".."`, `"./"`, `"/./"`, `"//"`, or trailing
+///     `"/."` are rejected with `-1`. Backslash-separator variants of
+///     the same patterns are also rejected.
+///   - The first path component may be rewritten via `_repo_mapping`.
+///   - Falls back to the runfiles directory if the manifest has no
+///     match.
+///
+/// @param rf Runfiles handle.
+/// @param path Runfiles-root-relative path to resolve.
+/// @param result_buf Output buffer (NUL-terminated on success).
+/// @param result_buf_len Size of @p result_buf.
+/// @retval >0 Length of the resolved path (excluding NUL).
+/// @retval 0 Path is well-formed but the runfile is unknown; @p
+///   result_buf is set to `""`.
+/// @retval -1 NULL argument, invalid path, or @p result_buf too small.
+int rf_rlocation(const rf_runfiles* rf, const char* path, char* result_buf,
+                 int result_buf_len);
+
+/// Same as #rf_rlocation but overrides the source repository for this
+/// call only.
+///
+/// @param rf Runfiles handle.
+/// @param path Runfiles-root-relative path.
+/// @param source_repository Source repo for `_repo_mapping` lookup;
+///   `NULL` or `""` for the main workspace.
+/// @param result_buf Output buffer.
+/// @param result_buf_len Size of @p result_buf.
+/// @return Same encoding as #rf_rlocation.
+int rf_rlocation_from(const rf_runfiles* rf, const char* path,
+                      const char* source_repository, char* result_buf,
+                      int result_buf_len);
+
+/// Number of environment variable pairs to publish to subprocesses.
+///
+/// Currently 3: `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`,
+/// `JAVA_RUNFILES`.
+///
+/// @param rf Runfiles handle.
+/// @return Count, or 0 if @p rf is `NULL`.
+int rf_env_vars_count(const rf_runfiles* rf);
+
+/// Retrieve the @p index-th environment variable pair.
+///
+/// @param rf Runfiles handle.
+/// @param index Zero-based index; must be `< rf_env_vars_count(rf)`.
+/// @param key_buf Output buffer for the variable name (NUL-terminated).
+/// @param key_buf_len Size of @p key_buf.
+/// @param val_buf Output buffer for the value (NUL-terminated).
+/// @param val_buf_len Size of @p val_buf.
+/// @retval 1 Success.
+/// @retval 0 Out-of-range index, NULL buffers, or a buffer too small.
+int rf_env_var(const rf_runfiles* rf, int index, char* key_buf, int key_buf_len,
+               char* val_buf, int val_buf_len);
+
+/// Release a handle and free its parsed data.
+///
+/// No-op if @p rf is `NULL`. Uses the allocator that was remembered
+/// when @p rf was built (the vtable copied in at #rf_create* time).
+///
+/// @param rf Handle to free.
+void rf_free(rf_runfiles* rf);
+
+/// Test whether @p path is absolute.
+///
+/// Recognises Unix leading `/` (but not UNC-style `//host/...`),
+/// Windows drive-letter paths (e.g. `C:\foo`), and on Windows also
+/// UNC paths (`\\server\share\...`). Never allocates.
+///
+/// @param path Path to test; may be `NULL`.
+/// @retval 1 Absolute.
+/// @retval 0 Relative, empty, or NULL.
+int rf_is_absolute(const char* path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RULES_CC_CC_RUNFILES_RUNFILES_C_H_

--- a/cc/runfiles/runfiles_c.h
+++ b/cc/runfiles/runfiles_c.h
@@ -15,10 +15,24 @@
 /// @file runfiles_c.h
 /// @brief Runfiles lookup library for Bazel-built C binaries and tests.
 ///
-/// This is the pure-C counterpart to `//cc/runfiles:runfiles` (which is C++).
-/// The two libraries implement the same algorithm and stay behavior-parity
-/// (manifest parsing, `_repo_mapping` support, argv0/envvar path discovery,
-/// prefix-match fallback, wildcard rewriting).
+/// This is the pure-C counterpart to `//cc/runfiles:runfiles` (which is
+/// a thin C++ facade over this library). Both surfaces implement the
+/// same algorithm and stay behavior-parity with the upstream Bazel C++
+/// runfiles library (manifest parsing, `_repo_mapping` support,
+/// argv0/envvar path discovery, prefix-match fallback, wildcard
+/// rewriting).
+///
+/// ### Output contract
+/// Variable-length outputs (resolved paths) use caller-provided buffers
+/// with an snprintf-style "here's the size I needed" report. Callers
+/// decide the grow-or-bail policy: use a stack buffer for the common
+/// case, retry with the reported size on #RF_RLOCATION_BUF_TOO_SMALL,
+/// or refuse to grow and error out. Env-var keys/values are returned
+/// as pointers into static/handle-owned storage -- never freed by the
+/// caller.
+///
+/// A future release may add an ergonomic alloc-out companion; the
+/// caller-buffer form here is the low-level primitive both would share.
 ///
 /// ### Usage
 /// @code
@@ -26,33 +40,38 @@
 ///
 ///   int main(int argc, char** argv) {
 ///     char err[256];
-///     rf_runfiles* rf = rf_create(NULL, argv[0], err, sizeof(err));
+///     rf_runfiles* rf = rf_create(NULL, argv[0], NULL, NULL, "",
+///                                 err, sizeof(err));
 ///     if (!rf) { fputs(err, stderr); return 1; }
 ///
-///     char path[4096];
-///     int n = rf_rlocation(rf, "my_workspace/path/to/data.txt",
-///                          path, sizeof(path));
-///     if (n > 0) { /* path is the resolved runfile */ }
-///
+///     char buf[4096];
+///     size_t needed = 0;
+///     if (rf_rlocation(rf, "my_workspace/path/to/data.txt", NULL,
+///                      buf, sizeof(buf), &needed) == RF_RLOCATION_OK) {
+///       // buf is a NUL-terminated string, `needed` bytes long.
+///     }
 ///     rf_free(rf);
 ///     return 0;
 ///   }
 /// @endcode
 ///
 /// ### Subprocesses
-/// Iterate #rf_env_var from `0` to #rf_env_vars_count and set the returned
-/// key/value pairs in the child's environment.
+/// Iterate #rf_env_var_key and #rf_env_var_value from `0` to
+/// #rf_env_vars_count and set the returned key/value pairs in the
+/// child's environment.
 ///
 /// ### Custom allocator
 /// Pass a #rf_allocator vtable as the first argument to any `rf_create*`
-/// function to route all heap allocation through your own callbacks.
-/// Pass `NULL` to use libc `malloc` / `realloc` / `free`. Each handle
-/// remembers the allocator it was built with and always releases its
-/// storage with the matching `free()` in #rf_free.
+/// function to route the library's internal allocations (parsed
+/// manifest, `_repo_mapping` table, parser scratch, repo-mapping
+/// concatenation scratch used in #rf_rlocation) through your own
+/// callbacks. Pass `NULL` to use libc `malloc` / `realloc` / `free`.
+/// Each handle remembers the allocator it was built with and always
+/// releases its storage with the matching `free()` in #rf_free.
 ///
 /// ### Sharing / lifetime
 /// Each `rf_create*` call parses the manifest and `_repo_mapping` from
-/// disk and returns a handle that fully owns its parsed state — no
+/// disk and returns a handle that fully owns its parsed state -- no
 /// process-wide cache, no refcount, no sharing across handles. Callers
 /// that want to reuse the parse across scopes / threads / subsystems
 /// should hold the returned #rf_runfiles* themselves (e.g. wrap it in a
@@ -63,10 +82,10 @@
 /// The library carries no global state. Different handles are fully
 /// independent and can be used concurrently from different threads
 /// without synchronization. A single handle is safe for concurrent
-/// #rf_rlocation / #rf_rlocation_from reads (the underlying data is
-/// immutable after construction), but must NOT be freed concurrently
-/// with any in-flight lookup. Same contract as `std::vector`: parallel
-/// reads are fine, mixed reads + destruction is the caller's problem.
+/// #rf_rlocation reads (the underlying data is immutable after
+/// construction), but must NOT be freed concurrently with any in-flight
+/// lookup. Same contract as `std::vector`: parallel reads are fine,
+/// mixed reads + destruction is the caller's problem.
 
 #ifndef RULES_CC_CC_RUNFILES_RUNFILES_C_H_
 #define RULES_CC_CC_RUNFILES_RUNFILES_C_H_
@@ -96,127 +115,77 @@ typedef struct rf_allocator {
   void* userdata;
 } rf_allocator;
 
-/// Create a runfiles handle for a `cc_binary` or `cc_library`.
+/// Result codes for #rf_rlocation.
+typedef enum {
+  /// Success; @p buf is NUL-terminated and @c *needed is `strlen(buf)`.
+  RF_RLOCATION_OK = 0,
+  /// Well-formed path but the runfile is unknown to this handle. @p buf
+  /// is untouched and @c *needed is `0`.
+  RF_RLOCATION_NOT_FOUND = 1,
+  /// Path fails validation (empty, `..`-traversal, `//`, `/./`,
+  /// trailing `/.`, or a `NULL` argument). @p buf is untouched.
+  RF_RLOCATION_INVALID_PATH = 2,
+  /// @p buf_cap is too small to hold the result. @p buf is untouched
+  /// (no partial write) and @c *needed is the exact byte length the
+  /// result would occupy (excluding the NUL terminator). Retry with a
+  /// buffer of at least `*needed + 1` bytes.
+  RF_RLOCATION_BUF_TOO_SMALL = 3,
+  /// The handle's allocator failed while building an internal scratch
+  /// key for `_repo_mapping` rewriting. Rare -- the scratch is bounded
+  /// by the input path length plus the matched canonical name length --
+  /// but surfaced explicitly so arena-backed callers can detect it.
+  RF_RLOCATION_ALLOC_FAILED = 4,
+} rf_rlocation_status;
+
+/// Create a runfiles handle.
 ///
-/// Uses `RUNFILES_MANIFEST_FILE` and `RUNFILES_DIR` from the
-/// environment; falls back to `argv[0]`-based discovery if the env
-/// vars are unset.
+/// All string arguments are optional; passing `NULL` or `""` for
+/// @p runfiles_manifest_file / @p runfiles_dir defers to argv0-based
+/// discovery. @p source_repository is `""` for the main workspace.
+///
+/// Environment variables are NOT read by this function. Callers that
+/// want automatic env discovery in production code should read
+/// `RUNFILES_MANIFEST_FILE` and `RUNFILES_DIR` themselves and pass the
+/// values here -- this keeps the library out of the process-env-reading
+/// business and lets embedded consumers hand it whatever paths they've
+/// resolved through their own configuration surface.
 ///
 /// @param alloc Allocator vtable, or `NULL` for libc `malloc`/`free`.
 ///   The vtable is copied into the handle at construction so callers
 ///   may pass a short-lived (e.g. stack-local) vtable safely.
-/// @param argv0 The program's `argv[0]`; pass `NULL` or `""` if unknown.
-/// @param error_buf Optional buffer that receives a human-readable
-///   error message on failure (NUL-terminated, truncated to
-///   `error_buf_len`).
-/// @param error_buf_len Size of @p error_buf in bytes.
+/// @param argv0 Program `argv[0]`, or `NULL`/`""` if unknown.
+/// @param runfiles_manifest_file Explicit manifest path, or `NULL`/`""`
+///   to defer to argv0 discovery.
+/// @param runfiles_dir Explicit runfiles directory, or `NULL`/`""` to
+///   defer.
+/// @param source_repository Default source repository (canonical name);
+///   `""` denotes the main workspace.
+/// @param err_buf Optional buffer that receives a human-readable error
+///   message on failure (NUL-terminated, truncated to @p err_buf_len).
+/// @param err_buf_len Size of @p err_buf in bytes.
 /// @return New handle on success (release with #rf_free), or `NULL` on
 ///   error.
 rf_runfiles* rf_create(const rf_allocator* alloc, const char* argv0,
-                       char* error_buf, int error_buf_len);
+                       const char* runfiles_manifest_file,
+                       const char* runfiles_dir, const char* source_repository,
+                       char* err_buf, size_t err_buf_len);
 
-/// Create a runfiles handle for a `cc_test`.
+/// Create a runfiles handle from `RUNFILES_MANIFEST_FILE` and
+/// `TEST_SRCDIR` -- the environment variables Bazel sets for `cc_test`
+/// binaries.
 ///
-/// Uses `RUNFILES_MANIFEST_FILE` and `TEST_SRCDIR` from the
-/// environment.
-///
-/// @param alloc Allocator vtable, or `NULL` for libc.
-/// @param error_buf Optional error message buffer; see #rf_create.
-/// @param error_buf_len Size of @p error_buf.
-/// @return New handle, or `NULL` on error.
-rf_runfiles* rf_create_for_test(const rf_allocator* alloc, char* error_buf,
-                                int error_buf_len);
-
-/// Extended constructor: pass explicit manifest / directory paths and a
-/// default source repository. Any string may be `NULL` or `""` to skip
-/// it (in which case discovery follows the same rules as #rf_create).
-///
-/// @param alloc Allocator vtable, or `NULL` for libc.
-/// @param argv0 Program `argv[0]`, or `NULL`/`""` if unknown.
-/// @param runfiles_manifest_file Explicit manifest path, or `""` to
-///   defer to argv0 discovery.
-/// @param runfiles_dir Explicit runfiles directory, or `""` to defer.
-/// @param source_repository Default source repository (canonical name);
-///   `""` denotes the main workspace.
-/// @param error_buf Optional error buffer.
-/// @param error_buf_len Size of @p error_buf.
-/// @return New handle, or `NULL` on error.
-rf_runfiles* rf_create_ex(const rf_allocator* alloc, const char* argv0,
-                          const char* runfiles_manifest_file,
-                          const char* runfiles_dir,
-                          const char* source_repository, char* error_buf,
-                          int error_buf_len);
-
-/// Test variant of #rf_create_ex that reads paths from `TEST_SRCDIR` /
-/// `RUNFILES_MANIFEST_FILE` but lets the caller pin the source repo.
+/// This is the sole entry point that reads process environment
+/// variables. Production code should route env-reading through the
+/// caller and pass results into #rf_create.
 ///
 /// @param alloc Allocator vtable, or `NULL` for libc.
 /// @param source_repository Default source repository; `""` for main.
-/// @param error_buf Optional error buffer.
-/// @param error_buf_len Size of @p error_buf.
+/// @param err_buf Optional error buffer.
+/// @param err_buf_len Size of @p err_buf.
 /// @return New handle, or `NULL` on error.
-rf_runfiles* rf_create_for_test_ex(const rf_allocator* alloc,
-                                   const char* source_repository,
-                                   char* error_buf, int error_buf_len);
-
-/// Resolve @p path (a runfiles-root-relative path) using the handle's
-/// default source repository.
-///
-/// Rules (mirroring the C++ implementation):
-///   - Absolute paths are returned as-is.
-///   - Paths containing `".."`, `"./"`, `"/./"`, `"//"`, or trailing
-///     `"/."` are rejected with `-1`. Backslash-separator variants of
-///     the same patterns are also rejected.
-///   - The first path component may be rewritten via `_repo_mapping`.
-///   - Falls back to the runfiles directory if the manifest has no
-///     match.
-///
-/// @param rf Runfiles handle.
-/// @param path Runfiles-root-relative path to resolve.
-/// @param result_buf Output buffer (NUL-terminated on success).
-/// @param result_buf_len Size of @p result_buf.
-/// @retval >0 Length of the resolved path (excluding NUL).
-/// @retval 0 Path is well-formed but the runfile is unknown; @p
-///   result_buf is set to `""`.
-/// @retval -1 NULL argument, invalid path, or @p result_buf too small.
-int rf_rlocation(const rf_runfiles* rf, const char* path, char* result_buf,
-                 int result_buf_len);
-
-/// Same as #rf_rlocation but overrides the source repository for this
-/// call only.
-///
-/// @param rf Runfiles handle.
-/// @param path Runfiles-root-relative path.
-/// @param source_repository Source repo for `_repo_mapping` lookup;
-///   `NULL` or `""` for the main workspace.
-/// @param result_buf Output buffer.
-/// @param result_buf_len Size of @p result_buf.
-/// @return Same encoding as #rf_rlocation.
-int rf_rlocation_from(const rf_runfiles* rf, const char* path,
-                      const char* source_repository, char* result_buf,
-                      int result_buf_len);
-
-/// Number of environment variable pairs to publish to subprocesses.
-///
-/// Currently 3: `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`,
-/// `JAVA_RUNFILES`.
-///
-/// @param rf Runfiles handle.
-/// @return Count, or 0 if @p rf is `NULL`.
-int rf_env_vars_count(const rf_runfiles* rf);
-
-/// Retrieve the @p index-th environment variable pair.
-///
-/// @param rf Runfiles handle.
-/// @param index Zero-based index; must be `< rf_env_vars_count(rf)`.
-/// @param key_buf Output buffer for the variable name (NUL-terminated).
-/// @param key_buf_len Size of @p key_buf.
-/// @param val_buf Output buffer for the value (NUL-terminated).
-/// @param val_buf_len Size of @p val_buf.
-/// @retval 1 Success.
-/// @retval 0 Out-of-range index, NULL buffers, or a buffer too small.
-int rf_env_var(const rf_runfiles* rf, int index, char* key_buf, int key_buf_len,
-               char* val_buf, int val_buf_len);
+rf_runfiles* rf_create_for_test(const rf_allocator* alloc,
+                                const char* source_repository, char* err_buf,
+                                size_t err_buf_len);
 
 /// Release a handle and free its parsed data.
 ///
@@ -226,15 +195,79 @@ int rf_env_var(const rf_runfiles* rf, int index, char* key_buf, int key_buf_len,
 /// @param rf Handle to free.
 void rf_free(rf_runfiles* rf);
 
+/// Resolve @p path (a runfiles-root-relative path) to a filesystem
+/// path, writing the result into @p buf.
+///
+/// Snprintf-style contract: @c *needed is always set on the two data
+/// statuses (#RF_RLOCATION_OK and #RF_RLOCATION_BUF_TOO_SMALL) so a
+/// caller can grow-and-retry exactly once with the reported size, or
+/// bail out on a hard budget. @p buf is left untouched on
+/// #RF_RLOCATION_BUF_TOO_SMALL (no partial write).
+///
+/// @c buf may be `NULL` and @c buf_cap `0` -- this reduces the call to
+/// a pure size query, returning #RF_RLOCATION_BUF_TOO_SMALL with the
+/// required size in @c *needed. Useful for consumers that want to
+/// allocate exactly-sized storage before the fill call.
+///
+/// Rules (mirroring the upstream C++ implementation):
+///   - Absolute paths are returned as-is.
+///   - Paths containing `".."`, `"./"`, `"/./"`, `"//"`, or trailing
+///     `"/."` are rejected as #RF_RLOCATION_INVALID_PATH. Backslash-
+///     separator variants of the same patterns are also rejected.
+///   - The first path component may be rewritten via `_repo_mapping`.
+///   - Falls back to the runfiles directory if the manifest has no
+///     match.
+///
+/// @param rf Runfiles handle.
+/// @param path Runfiles-root-relative path.
+/// @param source_repository Source repo for `_repo_mapping` lookup.
+///   `NULL` selects the handle's default source repository. Pass `""`
+///   to explicitly override with the main workspace.
+/// @param buf Caller-owned output buffer, or `NULL` for a size query.
+///   Written NUL-terminated on #RF_RLOCATION_OK; untouched otherwise.
+/// @param buf_cap Size of @p buf in bytes.
+/// @param needed Out-only. Set on #RF_RLOCATION_OK and
+///   #RF_RLOCATION_BUF_TOO_SMALL to the byte length the result would
+///   occupy (excluding the NUL). Set to `0` on the other statuses.
+///   May be `NULL` if the caller has no interest in the size hint.
+/// @return See #rf_rlocation_status.
+rf_rlocation_status rf_rlocation(rf_runfiles* rf, const char* path,
+                                 const char* source_repository, char* buf,
+                                 size_t buf_cap, size_t* needed);
+
+/// Number of environment variable pairs to publish to subprocesses.
+///
+/// Currently `3`: `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`,
+/// `JAVA_RUNFILES`.
+int rf_env_vars_count(void);
+
+/// Static name of the @p index-th env var to publish.
+///
+/// @param index Zero-based index; must be `< rf_env_vars_count()`.
+/// @return Pointer into static storage -- do NOT free. Returns `NULL`
+///   if @p index is out of range.
+const char* rf_env_var_key(int index);
+
+/// Value of the @p index-th env var for this handle.
+///
+/// The returned pointer aliases handle-owned storage -- valid until
+/// #rf_free is called on @p rf, and must NOT be freed. May be the
+/// empty string (e.g. `RUNFILES_DIR` is `""` in manifest-only mode).
+///
+/// @param rf Runfiles handle.
+/// @param index Zero-based index; must be `< rf_env_vars_count()`.
+/// @return Handle-owned NUL-terminated string, or `NULL` if @p index
+///   is out of range or @p rf is `NULL`.
+const char* rf_env_var_value(rf_runfiles* rf, int index);
+
 /// Test whether @p path is absolute.
 ///
-/// Recognises Unix leading `/` (but not UNC-style `//host/...`),
-/// Windows drive-letter paths (e.g. `C:\foo`), and on Windows also
-/// UNC paths (`\\server\share\...`). Never allocates.
+/// Recognises Unix leading `/` (but not UNC-style `//host/...`) and
+/// Windows drive-letter paths. Never allocates.
 ///
 /// @param path Path to test; may be `NULL`.
 /// @retval 1 Absolute.
-/// @retval 0 Relative, empty, or NULL.
+/// @retval 0 Relative, empty, or `NULL`.
 int rf_is_absolute(const char* path);
 
 #ifdef __cplusplus

--- a/cc/runfiles/runfiles_c_internal.h
+++ b/cc/runfiles/runfiles_c_internal.h
@@ -1,0 +1,258 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file runfiles_c_internal.h
+/// @brief Internal helpers of the runfiles C library.
+///
+/// These functions are shared between the C API in `runfiles_c.h` and
+/// the C++ facade in `runfiles.cc` so both languages use the same
+/// parsers, the same path-discovery logic, and the same validation
+/// rules.
+///
+/// This header is NOT part of the public API. It is exposed only via
+/// the `textual_hdrs` attribute of `//cc/runfiles:runfiles_c` so that
+/// the C++ wrapper can `#include` it inside `extern "C" {}`.
+
+#ifndef RULES_CC_CC_RUNFILES_RUNFILES_C_INTERNAL_H_
+#define RULES_CC_CC_RUNFILES_RUNFILES_C_INTERNAL_H_
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Result codes for streaming parser helpers.
+typedef enum {
+  RF_OK = 0,           ///< Success.
+  RF_ERR_IO = 1,       ///< `fopen` / `read` failure.
+  RF_ERR_FORMAT = 2,   ///< Malformed manifest / repo-mapping entry.
+  RF_ERR_ALLOC = 3,    ///< Out of memory in the parser's scratch buffer.
+  RF_ERR_CALLBACK = 4  ///< Callback returned non-zero to abort.
+} rf_status;
+
+/// Number of environment variable pairs both libraries publish to
+/// subprocesses. The names live in #kRfEnvKeys below; the values are
+/// per-handle (they encode the manifest / directory paths).
+#define RF_NUM_ENV_VARS 3
+
+/// Canonical order of the three env var names both libraries emit:
+///   - `[0]` `RUNFILES_MANIFEST_FILE`
+///   - `[1]` `RUNFILES_DIR`
+///   - `[2]` `JAVA_RUNFILES` (compatibility shim for the Java launcher;
+///     the TODO to remove it lives here so both languages see the same
+///     intent).
+///
+/// Shared between `runfiles_c.c` and `runfiles.cc` so a change (e.g.
+/// dropping `JAVA_RUNFILES`) happens in one place.
+static const char* const kRfEnvKeys[RF_NUM_ENV_VARS] = {
+    "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR",
+    // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can
+    // pick up RUNFILES_DIR.
+    "JAVA_RUNFILES"};
+
+// --------------------------------------------------------------------------
+// Path / filesystem helpers (no allocation)
+// --------------------------------------------------------------------------
+
+/// Test whether @p path is absolute.
+///
+/// Recognises Unix leading `/` (but not UNC-style `//host/...`) and
+/// Windows drive-letter paths. Drive-less absolute Windows paths like
+/// `\foo` are NOT absolute. Matches `Runfiles::IsAbsolute`.
+///
+/// @param path Path to test.
+/// @retval 1 Absolute.
+/// @retval 0 Otherwise.
+int rf_is_absolute(const char* path);
+
+/// Test whether @p path is openable for reading.
+/// @param path Filesystem path.
+/// @retval 1 Openable.
+/// @retval 0 Not openable.
+int rf_is_readable_file(const char* path);
+
+/// Test whether @p path names an existing directory.
+/// @param path Filesystem path.
+/// @retval 1 Directory.
+/// @retval 0 Not a directory (or not present).
+int rf_is_directory(const char* path);
+
+/// Read an environment variable as a newly-allocated UTF-8 string.
+///
+/// On Windows uses `GetEnvironmentVariableW` so env vars published via
+/// `SetEnvironmentVariable*` (which don't update the CRT `_environ`
+/// block) are visible, and so non-ASCII values round-trip through
+/// UTF-16. On POSIX defers to `getenv`. Caller frees with `free()`.
+///
+/// @param name ASCII env-var name.
+/// @return Newly-allocated UTF-8 value, or `NULL` if unset / failure.
+char* rf_getenv_alloc(const char* name);
+
+/// `fopen` that accepts a UTF-8 @p path on all platforms.
+///
+/// On Windows converts @p path to UTF-16 and calls `_wfopen`. On POSIX
+/// this is a direct `fopen`.
+///
+/// @param path UTF-8 file path.
+/// @param mode `fopen` mode string (e.g. `"r"`).
+/// @return `FILE*` on success, `NULL` on failure.
+FILE* rf_fopen_utf8(const char* path, const char* mode);
+
+/// Test whether @p path satisfies the Rlocation invariants.
+///
+/// Rejects empty paths, `../` and `./` prefixes, `/..`, `/./`, `//`,
+/// and trailing `/.`.
+///
+/// @param path Path to validate.
+/// @retval 1 Well-formed.
+/// @retval 0 Rejected.
+int rf_path_is_rlocation_valid(const char* path);
+
+// --------------------------------------------------------------------------
+// Unescape helper
+// --------------------------------------------------------------------------
+
+/// Unescape a manifest entry into @p out.
+///
+/// Recognised escapes: `\s -> ' '`, `\n -> '\n'`, `\b -> '\\'`. Any
+/// other backslash sequence is passed through literally. Never
+/// allocates.
+///
+/// @param in Source bytes (need not be NUL-terminated).
+/// @param in_len Number of bytes to read from @p in.
+/// @param out Destination buffer; must have space for `in_len + 1`
+///   bytes. Written NUL-terminated.
+/// @return Number of bytes written (excluding the trailing NUL).
+size_t rf_unescape_into(const char* in, size_t in_len, char* out);
+
+// --------------------------------------------------------------------------
+// Path discovery
+// --------------------------------------------------------------------------
+
+/// Predicate signature for #rf_paths_from.
+///
+/// @param userdata Opaque cookie forwarded from the caller.
+/// @param path Path to test.
+/// @retval 1 True.
+/// @retval 0 False.
+typedef int (*rf_predicate)(void* userdata, const char* path);
+
+/// Discover the runfiles manifest and/or directory.
+///
+/// Mirrors the C++ `PathsFrom` logic in `runfiles.cc`:
+///   1. If @p argv0 is set and neither manifest nor directory is
+///      already valid, try `argv0.runfiles/MANIFEST` +
+///      `argv0.runfiles`, then `argv0.runfiles_manifest`.
+///   2. If a directory was found but no manifest, try
+///      `dir/MANIFEST` and `dir_manifest`.
+///   3. If a manifest was found but no directory, try stripping the
+///      `_manifest` / `/MANIFEST` suffix from the manifest path.
+///
+/// @param argv0 Program `argv[0]`, or `NULL`/`""` if unknown.
+/// @param runfiles_manifest_file Env-provided manifest path (may be
+///   `NULL` or `""`).
+/// @param runfiles_dir Env-provided directory (may be `NULL` or `""`).
+/// @param is_readable_file Predicate for existence checks; if `NULL`,
+///   the built-in #rf_is_readable_file is used.
+/// @param is_directory Predicate for directory checks; if `NULL`, the
+///   built-in #rf_is_directory is used.
+/// @param predicate_userdata Passed unchanged to both predicates.
+/// @param out_manifest Output buffer for the resolved manifest path
+///   (NUL-terminated, `""` if none found).
+/// @param out_manifest_len Size of @p out_manifest.
+/// @param out_directory Output buffer for the resolved directory path
+///   (NUL-terminated, `""` if none found).
+/// @param out_directory_len Size of @p out_directory.
+/// @retval 1 At least one of {manifest, directory} was found.
+/// @retval 0 Nothing found, or an output buffer is too small (in which
+///   case both output buffers are left untouched).
+int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
+                  const char* runfiles_dir, rf_predicate is_readable_file,
+                  rf_predicate is_directory, void* predicate_userdata,
+                  char* out_manifest, size_t out_manifest_len,
+                  char* out_directory, size_t out_directory_len);
+
+// --------------------------------------------------------------------------
+// Format helpers (no I/O, no allocation) shared by both languages' parsers
+// --------------------------------------------------------------------------
+
+/// Parse one manifest line. Never touches the filesystem, never
+/// allocates.
+///
+/// The manifest line format is one of:
+///   - `" escaped_key escaped_value"` — leading space; both fields
+///     need #rf_unescape_into before use.
+///   - `"raw_key raw_value"` — no escaping; key and value are the
+///     literal bytes.
+///
+/// On success returns #RF_OK and writes byte offsets INTO @p line:
+///   - `*key_off`, `*key_len` — the key span within @p line.
+///   - `*val_off`, `*val_len` — the value span within @p line.
+///   - `*needs_unescape` — `1` if the escaped form was used, else `0`.
+///
+/// @param line Line bytes (need not be NUL-terminated).
+/// @param line_len Number of bytes in @p line.
+/// @param line_index 1-based line number (used only in error text).
+/// @param path_for_err Path label used in the error message; may be
+///   `NULL` (rendered as `"?"`).
+/// @param key_off Out: byte offset of the key.
+/// @param key_len Out: byte length of the key.
+/// @param val_off Out: byte offset of the value.
+/// @param val_len Out: byte length of the value.
+/// @param needs_unescape Out: `1` if escaped form, `0` if raw.
+/// @param error_buf Optional buffer for a human-readable format error.
+/// @param error_buf_len Size of @p error_buf.
+/// @retval RF_OK Success.
+/// @retval RF_ERR_FORMAT Malformed line.
+rf_status rf_manifest_split_line(const char* line, size_t line_len,
+                                 int line_index, const char* path_for_err,
+                                 size_t* key_off, size_t* key_len,
+                                 size_t* val_off, size_t* val_len,
+                                 int* needs_unescape, char* error_buf,
+                                 int error_buf_len);
+
+/// Parse one repo-mapping line of the form
+/// `"source,target_apparent,target"`.
+///
+/// Never touches the filesystem, never allocates. Writes byte offsets
+/// into @p line on success.
+///
+/// @param line Line bytes.
+/// @param line_len Number of bytes in @p line.
+/// @param line_index 1-based line number (used only in error text).
+/// @param path_for_err Path label used in the error message.
+/// @param src_off Out: byte offset of the source-repo field.
+/// @param src_len Out: byte length of the source-repo field.
+/// @param ta_off Out: byte offset of the target-apparent field.
+/// @param ta_len Out: byte length of the target-apparent field.
+/// @param tgt_off Out: byte offset of the target field.
+/// @param tgt_len Out: byte length of the target field.
+/// @param error_buf Optional buffer for a human-readable format error.
+/// @param error_buf_len Size of @p error_buf.
+/// @retval RF_OK Success.
+/// @retval RF_ERR_FORMAT Malformed line.
+rf_status rf_repo_mapping_split_line(const char* line, size_t line_len,
+                                     int line_index, const char* path_for_err,
+                                     size_t* src_off, size_t* src_len,
+                                     size_t* ta_off, size_t* ta_len,
+                                     size_t* tgt_off, size_t* tgt_len,
+                                     char* error_buf, int error_buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RULES_CC_CC_RUNFILES_RUNFILES_C_INTERNAL_H_

--- a/cc/runfiles/runfiles_c_internal.h
+++ b/cc/runfiles/runfiles_c_internal.h
@@ -19,10 +19,6 @@
 /// the C++ facade in `runfiles.cc` so both languages use the same
 /// parsers, the same path-discovery logic, and the same validation
 /// rules.
-///
-/// This header is NOT part of the public API. It is exposed only via
-/// the `textual_hdrs` attribute of `//cc/runfiles:runfiles_c` so that
-/// the C++ wrapper can `#include` it inside `extern "C" {}`.
 
 #ifndef RULES_CC_CC_RUNFILES_RUNFILES_C_INTERNAL_H_
 #define RULES_CC_CC_RUNFILES_RUNFILES_C_INTERNAL_H_
@@ -34,6 +30,11 @@
 extern "C" {
 #endif
 
+// Forward-declared to keep this header independent of runfiles_c.h.
+// Every TU that includes us also includes runfiles_c.h (which
+// supplies the typedef), so signatures below use `struct rf_allocator*`.
+struct rf_allocator;
+
 /// Result codes for streaming parser helpers.
 typedef enum {
   RF_OK = 0,           ///< Success.
@@ -43,25 +44,10 @@ typedef enum {
   RF_ERR_CALLBACK = 4  ///< Callback returned non-zero to abort.
 } rf_status;
 
-/// Number of environment variable pairs both libraries publish to
-/// subprocesses. The names live in #kRfEnvKeys below; the values are
-/// per-handle (they encode the manifest / directory paths).
+/// Count of env-var pairs the library publishes
+/// (RUNFILES_MANIFEST_FILE, RUNFILES_DIR, JAVA_RUNFILES). The name
+/// table itself lives in `runfiles_c.c` -- see rf_env_var_key.
 #define RF_NUM_ENV_VARS 3
-
-/// Canonical order of the three env var names both libraries emit:
-///   - `[0]` `RUNFILES_MANIFEST_FILE`
-///   - `[1]` `RUNFILES_DIR`
-///   - `[2]` `JAVA_RUNFILES` (compatibility shim for the Java launcher;
-///     the TODO to remove it lives here so both languages see the same
-///     intent).
-///
-/// Shared between `runfiles_c.c` and `runfiles.cc` so a change (e.g.
-/// dropping `JAVA_RUNFILES`) happens in one place.
-static const char* const kRfEnvKeys[RF_NUM_ENV_VARS] = {
-    "RUNFILES_MANIFEST_FILE", "RUNFILES_DIR",
-    // TODO(laszlocsomor): remove JAVA_RUNFILES once the Java launcher can
-    // pick up RUNFILES_DIR.
-    "JAVA_RUNFILES"};
 
 // --------------------------------------------------------------------------
 // Path / filesystem helpers (no allocation)
@@ -95,11 +81,17 @@ int rf_is_directory(const char* path);
 /// On Windows uses `GetEnvironmentVariableW` so env vars published via
 /// `SetEnvironmentVariable*` (which don't update the CRT `_environ`
 /// block) are visible, and so non-ASCII values round-trip through
-/// UTF-16. On POSIX defers to `getenv`. Caller frees with `free()`.
+/// UTF-16. On POSIX defers to `getenv`.
 ///
+/// Returned buffer is allocated via @p alloc (or libc `malloc` if @p
+/// alloc is `NULL`) so custom allocators observe the allocation
+/// symmetrically. Caller frees via `rf_a_free(alloc, ...)` (or `free`
+/// if @p alloc was `NULL`).
+///
+/// @param alloc Allocator vtable, or `NULL` for libc default.
 /// @param name ASCII env-var name.
 /// @return Newly-allocated UTF-8 value, or `NULL` if unset / failure.
-char* rf_getenv_alloc(const char* name);
+char* rf_getenv_alloc(const struct rf_allocator* alloc, const char* name);
 
 /// `fopen` that accepts a UTF-8 @p path on all platforms.
 ///
@@ -161,6 +153,13 @@ typedef int (*rf_predicate)(void* userdata, const char* path);
 ///   3. If a manifest was found but no directory, try stripping the
 ///      `_manifest` / `/MANIFEST` suffix from the manifest path.
 ///
+/// Resolved paths are returned as newly-allocated NUL-terminated
+/// strings via @p alloc (which the caller frees with `rf_a_free`) so
+/// paths of any length -- including Windows extended-length paths up
+/// to ~32K -- round-trip without truncation. If one of manifest /
+/// directory is not found the corresponding out-pointer is set to
+/// `NULL`.
+///
 /// @param argv0 Program `argv[0]`, or `NULL`/`""` if unknown.
 /// @param runfiles_manifest_file Env-provided manifest path (may be
 ///   `NULL` or `""`).
@@ -170,20 +169,21 @@ typedef int (*rf_predicate)(void* userdata, const char* path);
 /// @param is_directory Predicate for directory checks; if `NULL`, the
 ///   built-in #rf_is_directory is used.
 /// @param predicate_userdata Passed unchanged to both predicates.
-/// @param out_manifest Output buffer for the resolved manifest path
-///   (NUL-terminated, `""` if none found).
-/// @param out_manifest_len Size of @p out_manifest.
-/// @param out_directory Output buffer for the resolved directory path
-///   (NUL-terminated, `""` if none found).
-/// @param out_directory_len Size of @p out_directory.
+/// @param alloc Allocator vtable, or `NULL` for libc default.
+/// @param out_manifest Set to a newly-allocated string on success (may
+///   be `NULL` if manifest was not found); caller frees via
+///   `rf_a_free(alloc, ...)`.
+/// @param out_directory Set to a newly-allocated string on success (may
+///   be `NULL` if directory was not found); caller frees via
+///   `rf_a_free(alloc, ...)`.
 /// @retval 1 At least one of {manifest, directory} was found.
-/// @retval 0 Nothing found, or an output buffer is too small (in which
-///   case both output buffers are left untouched).
+/// @retval 0 Nothing found or allocation failed (both out-pointers set
+///   to `NULL`).
 int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
                   const char* runfiles_dir, rf_predicate is_readable_file,
                   rf_predicate is_directory, void* predicate_userdata,
-                  char* out_manifest, size_t out_manifest_len,
-                  char* out_directory, size_t out_directory_len);
+                  const struct rf_allocator* alloc, char** out_manifest,
+                  char** out_directory);
 
 // --------------------------------------------------------------------------
 // Format helpers (no I/O, no allocation) shared by both languages' parsers
@@ -193,15 +193,15 @@ int rf_paths_from(const char* argv0, const char* runfiles_manifest_file,
 /// allocates.
 ///
 /// The manifest line format is one of:
-///   - `" escaped_key escaped_value"` — leading space; both fields
+///   - `" escaped_key escaped_value"` -- leading space; both fields
 ///     need #rf_unescape_into before use.
-///   - `"raw_key raw_value"` — no escaping; key and value are the
+///   - `"raw_key raw_value"` -- no escaping; key and value are the
 ///     literal bytes.
 ///
 /// On success returns #RF_OK and writes byte offsets INTO @p line:
-///   - `*key_off`, `*key_len` — the key span within @p line.
-///   - `*val_off`, `*val_len` — the value span within @p line.
-///   - `*needs_unescape` — `1` if the escaped form was used, else `0`.
+///   - `*key_off`, `*key_len` -- the key span within @p line.
+///   - `*val_off`, `*val_len` -- the value span within @p line.
+///   - `*needs_unescape` -- `1` if the escaped form was used, else `0`.
 ///
 /// @param line Line bytes (need not be NUL-terminated).
 /// @param line_len Number of bytes in @p line.

--- a/docs/runfiles.md
+++ b/docs/runfiles.md
@@ -1,0 +1,347 @@
+# Runfiles
+
+`rules_cc` provides two source-level libraries for looking up runfiles from
+Bazel-built C and C++ programs. They implement the same algorithm and stay
+behavior-parity; they differ only in language surface and allocation
+policy.
+
+| Library  | Bazel target                         | Include                              |
+|----------|--------------------------------------|--------------------------------------|
+| C++      | `@rules_cc//cc/runfiles:runfiles`    | `rules_cc/cc/runfiles/runfiles.h`    |
+| Pure C   | `@rules_cc//cc/runfiles:runfiles_c`  | `rules_cc/cc/runfiles/runfiles_c.h`  |
+
+The C library exposes a pluggable allocator (`rf_set_allocator`) so C
+consumers can route every heap allocation through their own memory
+backend. The C++ library uses `std::allocator` exclusively — it never
+invokes the C-side allocator hook.
+
+## Choosing between them
+
+Use the C++ library from any C++ source. It's the default and lets you
+work with `std::string` / `std::map` / `std::unique_ptr` directly.
+
+Use the pure-C library when you need to look up runfiles from C code, or
+when you cannot link libstdc++, or when you want to control the runfiles
+library's allocation. Typical cases: embedded programs, foreign-function
+bindings (Rust, Go, Fortran, …), and toolchains that ship their own C
+runtime.
+
+Mixing both in the same process is safe — each library keeps its own
+per-process cache of parsed data. The manifest is parsed at most twice
+(once per language), and neither library ever holds memory owned by the
+other's allocator.
+
+## C++ library
+
+### Depend on it
+
+```python
+cc_binary(
+    name = "my_binary",
+    srcs = ["my_binary.cc"],
+    deps = ["@rules_cc//cc/runfiles"],
+)
+```
+
+### Look up a runfile
+
+```cpp
+#include "rules_cc/cc/runfiles/runfiles.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+using rules_cc::cc::runfiles::Runfiles;
+
+int main(int argc, char** argv) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(
+      Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
+  if (!runfiles) {
+    std::cerr << error << std::endl;
+    return 1;
+  }
+
+  std::string path = runfiles->Rlocation("my_workspace/path/to/data.txt");
+  // `path` is empty if the runfile is unknown; the file may or may not
+  // exist on disk regardless — callers should check.
+}
+```
+
+`BAZEL_CURRENT_REPOSITORY` is defined for every target that depends on
+`//cc/runfiles:runfiles`; it names the repo that contains the calling
+target and is required for `_repo_mapping` rewrites (see below) to
+resolve correctly.
+
+### In a `cc_test`
+
+Use `Runfiles::CreateForTest` instead of `Runfiles::Create` — it reads
+`RUNFILES_MANIFEST_FILE` and `TEST_SRCDIR` (set by `bazel test`) instead
+of doing argv0-based discovery.
+
+```cpp
+std::unique_ptr<Runfiles> r(
+    Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+```
+
+### API
+
+Full API in
+[`cc/runfiles/runfiles.h`](../cc/runfiles/runfiles.h). The public
+surface is:
+
+- `Runfiles::Create(argv0, [manifest, dir,] [source_repo,] error)` and
+  `Runfiles::CreateForTest([source_repo,] error)` — construction.
+- `std::string Rlocation(path)` /
+  `std::string Rlocation(path, source_repo)` — path lookup.
+- `const std::vector<std::pair<std::string, std::string>>& EnvVars() const` —
+  subprocess env.
+- `std::unique_ptr<Runfiles> WithSourceRepository(source_repo)` —
+  returns a new handle that shares parsed data with `this` but overrides
+  the default source repository.
+
+`Create` returns a fresh `Runfiles*` per call (transfer ownership to the
+caller — wrap in `std::unique_ptr` or `delete` yourself), but the
+underlying parsed manifest is shared via a process-wide
+`std::shared_ptr<const RunfilesData>` cache keyed on the resolved
+`(manifest, directory)` pair. This means: repeated `Create` calls with
+the same effective configuration do not re-parse the manifest.
+`WithSourceRepository` is O(1) — a `shared_ptr` copy, not a data copy.
+
+## Pure C library
+
+### Depend on it
+
+```python
+cc_binary(
+    name = "my_binary",
+    srcs = ["my_binary.c"],
+    deps = ["@rules_cc//cc/runfiles:runfiles_c"],
+)
+```
+
+### Look up a runfile
+
+```c
+#include "rules_cc/cc/runfiles/runfiles_c.h"
+
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  char err[256];
+  rf_runfiles* rf = rf_create(argv[0], err, sizeof(err));
+  if (!rf) {
+    fputs(err, stderr);
+    return 1;
+  }
+
+  char path[4096];
+  int n = rf_rlocation(rf, "my_workspace/path/to/data.txt", path,
+                       sizeof(path));
+  if (n > 0) {
+    /* path is the resolved runfile, `n` bytes long (excluding NUL). */
+  } else if (n == 0) {
+    /* Well-formed path but the runfile is unknown. */
+  } else {
+    /* -1: NULL arg, invalid path, or result buffer too small. */
+  }
+
+  rf_free(rf);
+  return 0;
+}
+```
+
+`rf_rlocation` writes into a caller-provided buffer. Passing a
+too-small buffer returns `-1`; retry with a larger one if needed.
+`PATH_MAX` (typically 4096) is a safe upper bound for real runfiles
+paths.
+
+### Custom allocator
+
+Every heap allocation the C library performs — long-lived handle state,
+the shared parsed data, the cache-slot key strings, and the parser's
+transient scratch buffers — routes through a pluggable allocator
+vtable. Install it once at process start, BEFORE the first `rf_create*`
+call:
+
+```c
+static void* my_malloc(void* ud, size_t n)           { /* … */ }
+static void* my_realloc(void* ud, void* p, size_t n) { /* … */ }
+static void  my_free(void* ud, void* p)              { /* … */ }
+
+rf_allocator alloc = {my_malloc, my_realloc, my_free, /*userdata=*/NULL};
+rf_set_allocator(&alloc);
+```
+
+- `rf_set_allocator(NULL)` restores libc `malloc`/`realloc`/`free`.
+- The setter is process-wide. It IS safe to call concurrently with
+  `rf_create*` (both sides take the library mutex), but if you race
+  them the newly-created handle uses whichever allocator the write-side
+  lock happened to publish first. There is no data race — the storage
+  a handle allocates and the storage `rf_free` releases always come
+  from the same allocator — but you cannot predict which allocator a
+  concurrent create observes.
+- Each handle *remembers* the allocator that was active when it was
+  built. If you install allocator A, create a handle, then install
+  allocator B, freeing the first handle still routes through allocator
+  A. This means allocator userdata must outlive the last handle that
+  was created under it.
+- File I/O (`fopen`, `fclose`, `fgets`) is inherent to libc and cannot
+  be redirected through the allocator hook.
+
+### API
+
+Full API in
+[`cc/runfiles/runfiles_c.h`](../cc/runfiles/runfiles_c.h). The public
+surface is:
+
+- `rf_create(argv0, err, err_len)` /
+  `rf_create_for_test(err, err_len)` — env-var-based construction.
+- `rf_create_ex(argv0, manifest, dir, source_repo, err, err_len)` /
+  `rf_create_for_test_ex(source_repo, err, err_len)` — explicit paths
+  and source repo.
+- `rf_with_source_repository(rf, source_repo)` — clone with a different
+  default source repo, shared data.
+- `rf_rlocation(rf, path, buf, buf_len)` /
+  `rf_rlocation_from(rf, path, source_repo, buf, buf_len)` — path
+  lookup.
+- `rf_env_vars_count(rf)` + `rf_env_var(rf, i, k, kl, v, vl)` —
+  subprocess env.
+- `rf_free(rf)` — destructor. No-op on `NULL`.
+- `rf_set_allocator(alloc)` — install/clear the global allocator.
+- `rf_is_absolute(path)` — utility; matches the algorithm the library
+  uses internally.
+
+## Discovery, path lookup, and repo mapping
+
+Both libraries implement identical algorithms. This section describes
+what they do.
+
+### Path discovery order
+
+Both libraries try, in order:
+
+1. Explicit `manifest`/`directory` arguments (if you called
+   `Runfiles::Create(argv0, mf, dir, …)` or `rf_create_ex(argv0, mf,
+   dir, …)`).
+2. Environment variables — `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`
+   (for `Create`) or `TEST_SRCDIR` (for `CreateForTest`).
+3. Argv0-based fallback:
+   `<argv0>.runfiles/MANIFEST` + `<argv0>.runfiles/`, then
+   `<argv0>.runfiles_manifest`.
+4. If a manifest was found but no directory, derive the directory by
+   stripping the `_manifest` or `/MANIFEST` suffix.
+
+The library succeeds if at least one of `{manifest, directory}` is
+found. Manifest-based mode returns `""` for unknown runfiles;
+directory-based mode falls back to `<directory>/<path>` and lets the
+caller check the filesystem.
+
+### `_repo_mapping`
+
+Bzlmod builds emit a `_repo_mapping` file in the runfiles that rewrites
+apparent repository names (what your code says) to canonical repository
+names (what Bazel writes on disk). Both libraries read it at
+construction and apply it during `Rlocation`.
+
+The lookup algorithm on `some_apparent/path`:
+
+1. If a mapping entry exists for `(some_apparent, source_repo)`,
+   rewrite the first path component and look up
+   `<canonical>/path` in the manifest.
+2. Otherwise, if the largest entry `≤ (some_apparent, source_repo)` in
+   the sorted map has `.first == some_apparent`, `.second` ends in
+   `*`, and `source_repo` starts with the `.second` prefix, apply the
+   wildcard rewrite.
+3. Otherwise, look up the input path as-is.
+
+The `source_repo` is either the handle's default (set at `Create` /
+`rf_create_ex`) or the per-call override (`Rlocation(path, source_repo)`
+/ `rf_rlocation_from(rf, path, source_repo, …)`).
+
+`BAZEL_CURRENT_REPOSITORY` is defined by `rules_cc` for every target
+that depends on the runfiles library; it evaluates to the canonical
+repo name that contains the current target and is the correct value
+for `source_repo` in C++.
+
+### Path validation
+
+`Rlocation` / `rf_rlocation` reject paths that would allow directory
+traversal:
+
+- Empty paths.
+- Paths starting with `../` or `./`.
+- Paths containing `/..`, `/./`, `//`.
+- Paths ending in `/.`.
+
+Absolute paths (Unix `/foo`, Windows `C:\foo`) are returned as-is,
+without any manifest lookup.
+
+### Manifest format
+
+The manifest is a UTF-8 text file, one entry per line, in one of two
+forms:
+
+```text
+raw_key raw_value                # first char is not space; no escaping
+ escaped_key escaped_value       # first char IS space; both fields use escapes
+```
+
+Recognized escape sequences (in the second form only):
+
+| Escape | Character   |
+|--------|-------------|
+| `\s`   | space       |
+| `\n`   | newline     |
+| `\b`   | backslash   |
+
+Any other backslash sequence passes through literally. This matches
+the format Bazel emits.
+
+## Caching and thread safety
+
+Both libraries maintain a process-wide cache of parsed data, keyed on
+the resolved `(manifest, directory)` pair. The first `Create` /
+`rf_create*` call for a given key does the file I/O and parsing;
+subsequent calls with the same key are O(cache-lookup) and allocate
+only a new handle wrapper.
+
+- **C++**: `std::shared_ptr<const RunfilesData>` in a `std::mutex`-guarded
+  `std::vector`. Released at process exit by normal C++ destructors.
+- **C**: A refcounted `rf_runfiles_data` in a fixed-slot table
+  (128 slots), guarded by a POSIX/Windows mutex. Released by an
+  `atexit` handler.
+
+All entry points are safe to call concurrently from multiple threads:
+
+- `Create` / `rf_create*` / `WithSourceRepository` / `rf_with_source_repository`
+  serialize on the library mutex only for cache lookup / insert and
+  refcount updates.
+- `Rlocation` / `rf_rlocation*` is lock-free. Once a handle exists, its
+  `source_repository` is per-handle and immutable and the shared
+  `RunfilesData` / `rf_runfiles_data` it points at is const after
+  construction, so parallel lookups on the same or different handles
+  never contend.
+- `rf_free` / `delete` on a handle take the mutex only long enough to
+  decrement the shared-data refcount.
+- `rf_set_allocator` also takes the mutex, so it's safe to call
+  concurrently with `rf_create*`. The only wrinkle is *ordering*: a
+  concurrent create might snapshot either the old or the new allocator,
+  depending on interleaving. This never produces a mismatch — the
+  handle allocates and frees with the same allocator throughout its
+  lifetime.
+
+## Testing
+
+The test suites in `//tests/runfiles/` cover manifest parsing (both
+forms + escapes), envvar / argv0 / directory discovery,
+`_repo_mapping` in all its variants (exact match, wildcard, per-call
+source-repo override), and — for the C API — the custom allocator
+hook, handle-remembers-allocator semantics, and shared-data reuse
+across `rf_create` calls.
+
+```bash
+bazel test //tests/runfiles:runfiles_test    # C++ API
+bazel test //tests/runfiles:runfiles_c_test  # C API
+```

--- a/docs/runfiles.md
+++ b/docs/runfiles.md
@@ -1,35 +1,40 @@
 # Runfiles
 
 `rules_cc` provides two source-level libraries for looking up runfiles from
-Bazel-built C and C++ programs. They implement the same algorithm and stay
-behavior-parity; they differ only in language surface and allocation
-policy.
+Bazel-built C and C++ programs. Both implement the same algorithm
+(manifest parsing, `_repo_mapping` support, argv0/envvar path discovery,
+prefix-match fallback, wildcard rewriting).
 
-| Library  | Bazel target                         | Include                              |
-|----------|--------------------------------------|--------------------------------------|
-| C++      | `@rules_cc//cc/runfiles:runfiles`    | `rules_cc/cc/runfiles/runfiles.h`    |
-| Pure C   | `@rules_cc//cc/runfiles:runfiles_c`  | `rules_cc/cc/runfiles/runfiles_c.h`  |
+| Library | Bazel target                        | Include                              |
+|---------|-------------------------------------|--------------------------------------|
+| C++     | `@rules_cc//cc/runfiles:runfiles`   | `rules_cc/cc/runfiles/runfiles.h`    |
+| Pure C  | `@rules_cc//cc/runfiles:runfiles_c` | `rules_cc/cc/runfiles/runfiles_c.h`  |
 
-The C library exposes a pluggable allocator (`rf_set_allocator`) so C
-consumers can route every heap allocation through their own memory
-backend. The C++ library uses `std::allocator` exclusively — it never
-invokes the C-side allocator hook.
+The C library exposes a pluggable allocator: every `rf_create*` entry
+point takes a `const rf_allocator*` as its first argument. Pass `NULL`
+for libc `malloc`/`realloc`/`free`, or a caller-owned vtable to route
+the library's internal allocations (parsed manifest, `_repo_mapping`
+table, parser scratch, repo-mapping join scratch) through your own
+backend. Variable-length outputs (resolved paths) go into a
+caller-provided buffer with an snprintf-style "here's the required
+size" report — callers decide when to grow. The C++ facade wraps this
+with `std::string` and `std::allocator`, so C++ consumers never touch
+the allocator vtable and never manage output-buffer growth themselves.
 
 ## Choosing between them
 
 Use the C++ library from any C++ source. It's the default and lets you
-work with `std::string` / `std::map` / `std::unique_ptr` directly.
+work with `std::string` / `std::unique_ptr` directly.
 
-Use the pure-C library when you need to look up runfiles from C code, or
-when you cannot link libstdc++, or when you want to control the runfiles
-library's allocation. Typical cases: embedded programs, foreign-function
-bindings (Rust, Go, Fortran, …), and toolchains that ship their own C
-runtime.
+Use the pure-C library when you need to look up runfiles from C code,
+when you cannot link libstdc++, or when you want a custom allocator.
+Typical cases: embedded programs, foreign-function bindings (Rust, Go,
+Fortran, …), and toolchains that ship their own C runtime.
 
-Mixing both in the same process is safe — each library keeps its own
-per-process cache of parsed data. The manifest is parsed at most twice
-(once per language), and neither library ever holds memory owned by the
-other's allocator.
+Mixing both in the same process is safe. Each `Runfiles` C++ instance
+owns exactly one underlying `rf_runfiles` handle, and each `rf_create*`
+call parses fresh — there is no shared cache across handles in either
+direction.
 
 ## C++ library
 
@@ -70,9 +75,9 @@ int main(int argc, char** argv) {
 ```
 
 `BAZEL_CURRENT_REPOSITORY` is defined for every target that depends on
-`//cc/runfiles:runfiles`; it names the repo that contains the calling
-target and is required for `_repo_mapping` rewrites (see below) to
-resolve correctly.
+`//cc/runfiles:runfiles`; it names the canonical repo that contains the
+calling target and is required for `_repo_mapping` rewrites (see below)
+to resolve correctly.
 
 ### In a `cc_test`
 
@@ -87,27 +92,25 @@ std::unique_ptr<Runfiles> r(
 
 ### API
 
-Full API in
-[`cc/runfiles/runfiles.h`](../cc/runfiles/runfiles.h). The public
-surface is:
+Full API in [`cc/runfiles/runfiles.h`](../cc/runfiles/runfiles.h). The
+public surface is:
 
 - `Runfiles::Create(argv0, [manifest, dir,] [source_repo,] error)` and
   `Runfiles::CreateForTest([source_repo,] error)` — construction.
 - `std::string Rlocation(path)` /
   `std::string Rlocation(path, source_repo)` — path lookup.
-- `const std::vector<std::pair<std::string, std::string>>& EnvVars() const` —
-  subprocess env.
 - `std::unique_ptr<Runfiles> WithSourceRepository(source_repo)` —
-  returns a new handle that shares parsed data with `this` but overrides
-  the default source repository.
+  derive a sibling instance that shares the underlying handle but
+  uses a different default source repository. The handle is refcounted
+  via `std::shared_ptr` under the hood, so the derived instance stays
+  live even after the parent is dropped.
+- `const std::vector<std::pair<std::string, std::string>>& EnvVars() const` —
+  environment variables to publish to subprocesses.
 
-`Create` returns a fresh `Runfiles*` per call (transfer ownership to the
-caller — wrap in `std::unique_ptr` or `delete` yourself), but the
-underlying parsed manifest is shared via a process-wide
-`std::shared_ptr<const RunfilesData>` cache keyed on the resolved
-`(manifest, directory)` pair. This means: repeated `Create` calls with
-the same effective configuration do not re-parse the manifest.
-`WithSourceRepository` is O(1) — a `shared_ptr` copy, not a data copy.
+Each `Create` call parses the manifest and `_repo_mapping` from disk
+and returns a fully-owning `Runfiles*`; there is no process-wide cache.
+Callers that want to reuse a parse across scopes / threads should hold
+the returned `Runfiles*` themselves.
 
 ## Pure C library
 
@@ -130,21 +133,41 @@ cc_binary(
 
 int main(int argc, char** argv) {
   char err[256];
-  rf_runfiles* rf = rf_create(argv[0], err, sizeof(err));
+  // First arg is the allocator; NULL uses libc malloc/realloc/free.
+  // Env variables are NOT read: pass explicit manifest / dir paths
+  // (or "" to defer to argv0-based discovery).
+  rf_runfiles* rf = rf_create(/*alloc=*/NULL, argv[0],
+                              /*manifest=*/"", /*dir=*/"",
+                              /*source_repo=*/"", err, sizeof(err));
   if (!rf) {
     fputs(err, stderr);
     return 1;
   }
 
-  char path[4096];
-  int n = rf_rlocation(rf, "my_workspace/path/to/data.txt", path,
-                       sizeof(path));
-  if (n > 0) {
-    /* path is the resolved runfile, `n` bytes long (excluding NUL). */
-  } else if (n == 0) {
-    /* Well-formed path but the runfile is unknown. */
-  } else {
-    /* -1: NULL arg, invalid path, or result buffer too small. */
+  char buf[4096];
+  size_t needed = 0;
+  rf_rlocation_status s = rf_rlocation(
+      rf, "my_workspace/path/to/data.txt",
+      /*source_repository=*/NULL,  // NULL -> handle's default source repo
+      buf, sizeof(buf), &needed);
+  switch (s) {
+    case RF_RLOCATION_OK:
+      /* buf is NUL-terminated; `needed` == strlen(buf). */
+      break;
+    case RF_RLOCATION_BUF_TOO_SMALL:
+      /* buf is untouched; `needed` = required size. Caller decides:
+         grow to needed+1 and retry, bail with an error, or truncate. */
+      break;
+    case RF_RLOCATION_NOT_FOUND:
+      /* Well-formed path but the runfile is unknown to this handle. */
+      break;
+    case RF_RLOCATION_INVALID_PATH:
+      /* Path fails validation (empty, ..-traversal, //, etc.). */
+      break;
+    case RF_RLOCATION_ALLOC_FAILED:
+      /* Handle's allocator failed during the internal _repo_mapping
+         join scratch (rare — bounded by input length). */
+      break;
   }
 
   rf_free(rf);
@@ -152,64 +175,113 @@ int main(int argc, char** argv) {
 }
 ```
 
-`rf_rlocation` writes into a caller-provided buffer. Passing a
-too-small buffer returns `-1`; retry with a larger one if needed.
-`PATH_MAX` (typically 4096) is a safe upper bound for real runfiles
-paths.
+`rf_rlocation` writes into a caller-owned buffer. On success, `*needed`
+is `strlen(buf)`. On `RF_RLOCATION_BUF_TOO_SMALL`, `buf` is left
+untouched (no partial write) and `*needed` reports the exact byte
+length the result would occupy — retry once with a buffer of at least
+`*needed + 1` bytes. `buf = NULL, buf_cap = 0` reduces the call to a
+pure size query (returns `RF_RLOCATION_BUF_TOO_SMALL` with the
+required size), useful when the caller wants to allocate exactly-sized
+storage in one shot.
+
+Callers who want zero-alloc lookups plug an arena into `rf_allocator`
+for the library's internal scratch (the repo-mapping join buffer);
+their own output buffer is already zero-alloc since they own it.
+
+A future release may add an ergonomic alloc-out companion (e.g.
+`rf_rlocation_alloc(rf, path, sr, char** out)`) that hides the
+grow-and-retry dance behind the vtable — the caller-buffer form here
+is the low-level primitive both shapes would share.
+
+### In a `cc_test`
+
+Use `rf_create_for_test`, which reads `RUNFILES_MANIFEST_FILE` and
+`TEST_SRCDIR` from the environment. This is the only entry point in the
+C library that reads process env vars — production code should call
+`getenv` (or the platform equivalent) itself and pass the results to
+`rf_create`.
+
+```c
+char err[256];
+rf_runfiles* rf = rf_create_for_test(/*alloc=*/NULL, /*source_repo=*/"",
+                                     err, sizeof(err));
+```
 
 ### Custom allocator
 
-Every heap allocation the C library performs — long-lived handle state,
-the shared parsed data, the cache-slot key strings, and the parser's
-transient scratch buffers — routes through a pluggable allocator
-vtable. Install it once at process start, BEFORE the first `rf_create*`
-call:
+Every internal heap allocation — the handle itself, the parsed
+manifest, the `_repo_mapping` table, transient parser scratch, the
+path-discovery working buffers, and the repo-mapping join scratch used
+by `rf_rlocation` — routes through the `rf_allocator` you pass to
+`rf_create*`. Skip the parameter (pass `NULL`) and it defaults to libc.
+`rf_rlocation`'s output buffer is caller-owned and NEVER routed through
+the vtable; the vtable only sees the library's *internal* allocations.
 
 ```c
 static void* my_malloc(void* ud, size_t n)           { /* … */ }
 static void* my_realloc(void* ud, void* p, size_t n) { /* … */ }
 static void  my_free(void* ud, void* p)              { /* … */ }
 
-rf_allocator alloc = {my_malloc, my_realloc, my_free, /*userdata=*/NULL};
-rf_set_allocator(&alloc);
+rf_allocator my_alloc = {my_malloc, my_realloc, my_free,
+                         /*userdata=*/NULL};
+rf_runfiles* rf = rf_create(&my_alloc, argv[0], "", "", "", err, sizeof(err));
 ```
 
-- `rf_set_allocator(NULL)` restores libc `malloc`/`realloc`/`free`.
-- The setter is process-wide. It IS safe to call concurrently with
-  `rf_create*` (both sides take the library mutex), but if you race
-  them the newly-created handle uses whichever allocator the write-side
-  lock happened to publish first. There is no data race — the storage
-  a handle allocates and the storage `rf_free` releases always come
-  from the same allocator — but you cannot predict which allocator a
-  concurrent create observes.
-- Each handle *remembers* the allocator that was active when it was
-  built. If you install allocator A, create a handle, then install
-  allocator B, freeing the first handle still routes through allocator
-  A. This means allocator userdata must outlive the last handle that
-  was created under it.
+- The vtable is **copied into the handle** at construction, so a
+  short-lived (e.g. stack-local) `rf_allocator` is safe — you don't
+  need to keep the original struct alive.
+- The `userdata` pointer, however, IS held by reference: whatever it
+  points at must outlive the last live `rf_runfiles*` built under this
+  allocator.
 - File I/O (`fopen`, `fclose`, `fgets`) is inherent to libc and cannot
   be redirected through the allocator hook.
+- No global setter — no `rf_set_allocator`; the allocator lives per
+  handle. Different handles in the same process can use different
+  allocators without collision.
+
+### Subprocess environment
+
+The C library publishes three env-var pairs — `RUNFILES_MANIFEST_FILE`,
+`RUNFILES_DIR`, and `JAVA_RUNFILES` (compatibility alias for
+`RUNFILES_DIR`) — that a launched child needs to find the same runfiles
+tree. Iterate with:
+
+```c
+int n = rf_env_vars_count();  // currently always 3
+for (int i = 0; i < n; ++i) {
+  const char* k = rf_env_var_key(i);        // static string — do NOT free
+  const char* v = rf_env_var_value(rf, i);  // handle-owned — do NOT free
+  setenv(k, v, /*overwrite=*/1);
+}
+```
+
+The keys are static strings from a fixed table; the values alias the
+handle's internal `manifest_file` / `directory` storage and are valid
+until `rf_free`. Neither is caller-owned, so neither needs freeing.
 
 ### API
 
-Full API in
-[`cc/runfiles/runfiles_c.h`](../cc/runfiles/runfiles_c.h). The public
-surface is:
+Full API in [`cc/runfiles/runfiles_c.h`](../cc/runfiles/runfiles_c.h).
+The public surface is:
 
-- `rf_create(argv0, err, err_len)` /
-  `rf_create_for_test(err, err_len)` — env-var-based construction.
-- `rf_create_ex(argv0, manifest, dir, source_repo, err, err_len)` /
-  `rf_create_for_test_ex(source_repo, err, err_len)` — explicit paths
-  and source repo.
-- `rf_with_source_repository(rf, source_repo)` — clone with a different
-  default source repo, shared data.
-- `rf_rlocation(rf, path, buf, buf_len)` /
-  `rf_rlocation_from(rf, path, source_repo, buf, buf_len)` — path
-  lookup.
-- `rf_env_vars_count(rf)` + `rf_env_var(rf, i, k, kl, v, vl)` —
-  subprocess env.
-- `rf_free(rf)` — destructor. No-op on `NULL`.
-- `rf_set_allocator(alloc)` — install/clear the global allocator.
+- `rf_create(alloc, argv0, manifest, dir, source_repo, err, err_len)` —
+  main construction entry point. Env vars are NOT read; caller supplies
+  everything.
+- `rf_create_for_test(alloc, source_repo, err, err_len)` — test
+  convenience that reads `RUNFILES_MANIFEST_FILE` and `TEST_SRCDIR`
+  from the environment.
+- `rf_rlocation(rf, path, source_repository, buf, buf_cap, needed)` —
+  caller-buffer path lookup. `source_repository = NULL` uses the
+  handle's default; any non-`NULL` string (including `""` for the main
+  workspace) is an explicit override. Returns an `rf_rlocation_status`;
+  on `RF_RLOCATION_OK`, `buf` holds a NUL-terminated string of length
+  `*needed`; on `RF_RLOCATION_BUF_TOO_SMALL`, `buf` is untouched and
+  `*needed` reports the exact size a retry needs.
+- `rf_env_vars_count()` / `rf_env_var_key(i)` / `rf_env_var_value(rf, i)` —
+  subprocess environment publication. Keys are static strings; values
+  alias handle-owned storage. Neither is caller-owned.
+- `rf_free(rf)` — destructor. No-op on `NULL`. Uses the allocator that
+  was passed to `rf_create*`.
 - `rf_is_absolute(path)` — utility; matches the algorithm the library
   uses internally.
 
@@ -222,21 +294,32 @@ what they do.
 
 Both libraries try, in order:
 
-1. Explicit `manifest`/`directory` arguments (if you called
-   `Runfiles::Create(argv0, mf, dir, …)` or `rf_create_ex(argv0, mf,
+1. Explicit `manifest` / `directory` arguments (if you called
+   `Runfiles::Create(argv0, mf, dir, …)` or `rf_create(alloc, argv0, mf,
    dir, …)`).
-2. Environment variables — `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`
-   (for `Create`) or `TEST_SRCDIR` (for `CreateForTest`).
-3. Argv0-based fallback:
-   `<argv0>.runfiles/MANIFEST` + `<argv0>.runfiles/`, then
-   `<argv0>.runfiles_manifest`.
+2. Environment variables — `RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR` (for
+   `Runfiles::Create` from C++, or when a C caller passes env-read
+   values into `rf_create`) or `TEST_SRCDIR` (for
+   `Runfiles::CreateForTest` / `rf_create_for_test`). On Windows these
+   are read via `GetEnvironmentVariableW` so env vars set with
+   `SetEnvironmentVariableW` (which don't touch the CRT `_environ`
+   block) and non-ASCII values are both visible.
+3. Argv0-based fallback: `<argv0>.runfiles/MANIFEST` +
+   `<argv0>.runfiles/`, then `<argv0>.runfiles_manifest`.
 4. If a manifest was found but no directory, derive the directory by
    stripping the `_manifest` or `/MANIFEST` suffix.
 
 The library succeeds if at least one of `{manifest, directory}` is
-found. Manifest-based mode returns `""` for unknown runfiles;
-directory-based mode falls back to `<directory>/<path>` and lets the
-caller check the filesystem.
+found. Manifest-based mode returns `""` (or `RF_RLOCATION_NOT_FOUND`)
+for unknown runfiles; directory-based mode falls back to
+`<directory>/<path>` and lets the caller check the filesystem.
+
+Resolved paths on the C side go into a caller-provided buffer with an
+snprintf-style "here's the required size" report — the caller decides
+when to grow. The C++ facade wraps this with a `std::string` that
+grows once from a 4 KB stack-backed starting size to the exact
+reported length, so Windows extended-length (`\\?\`) paths up to
+~32 767 chars round-trip cleanly with no fixed cap.
 
 ### `_repo_mapping`
 
@@ -257,8 +340,8 @@ The lookup algorithm on `some_apparent/path`:
 3. Otherwise, look up the input path as-is.
 
 The `source_repo` is either the handle's default (set at `Create` /
-`rf_create_ex`) or the per-call override (`Rlocation(path, source_repo)`
-/ `rf_rlocation_from(rf, path, source_repo, …)`).
+`rf_create`) or the per-call override (`Rlocation(path, source_repo)` /
+`rf_rlocation(rf, path, source_repo, …)`).
 
 `BAZEL_CURRENT_REPOSITORY` is defined by `rules_cc` for every target
 that depends on the runfiles library; it evaluates to the canonical
@@ -274,6 +357,9 @@ traversal:
 - Paths starting with `../` or `./`.
 - Paths containing `/..`, `/./`, `//`.
 - Paths ending in `/.`.
+- Backslash-separator variants of any of the above (rejected on all
+  platforms; Bazel manifests use forward slashes, so a `\` in a caller-
+  supplied key is suspicious and closes a Windows traversal hole).
 
 Absolute paths (Unix `/foo`, Windows `C:\foo`) are returned as-is,
 without any manifest lookup.
@@ -290,58 +376,27 @@ raw_key raw_value                # first char is not space; no escaping
 
 Recognized escape sequences (in the second form only):
 
-| Escape | Character   |
-|--------|-------------|
-| `\s`   | space       |
-| `\n`   | newline     |
-| `\b`   | backslash   |
+| Escape | Character |
+|--------|-----------|
+| `\s`   | space     |
+| `\n`   | newline   |
+| `\b`   | backslash |
 
 Any other backslash sequence passes through literally. This matches
 the format Bazel emits.
 
-## Caching and thread safety
+## Lifetime and thread safety
 
-Both libraries maintain a process-wide cache of parsed data, keyed on
-the resolved `(manifest, directory)` pair. The first `Create` /
-`rf_create*` call for a given key does the file I/O and parsing;
-subsequent calls with the same key are O(cache-lookup) and allocate
-only a new handle wrapper.
+There is no process-wide cache in either library. Each `Create` /
+`rf_create*` call reads the manifest and `_repo_mapping` from disk and
+returns an instance that fully owns its parsed data. Callers who want
+to reuse a parse should hold the returned handle themselves (e.g. via
+`std::shared_ptr<Runfiles>` on the C++ side, `WithSourceRepository` for
+derived instances that share the parse, or by holding the
+`rf_runfiles*` in a struct on the C side).
 
-- **C++**: `std::shared_ptr<const RunfilesData>` in a `std::mutex`-guarded
-  `std::vector`. Released at process exit by normal C++ destructors.
-- **C**: A refcounted `rf_runfiles_data` in a fixed-slot table
-  (128 slots), guarded by a POSIX/Windows mutex. Released by an
-  `atexit` handler.
-
-All entry points are safe to call concurrently from multiple threads:
-
-- `Create` / `rf_create*` / `WithSourceRepository` / `rf_with_source_repository`
-  serialize on the library mutex only for cache lookup / insert and
-  refcount updates.
-- `Rlocation` / `rf_rlocation*` is lock-free. Once a handle exists, its
-  `source_repository` is per-handle and immutable and the shared
-  `RunfilesData` / `rf_runfiles_data` it points at is const after
-  construction, so parallel lookups on the same or different handles
-  never contend.
-- `rf_free` / `delete` on a handle take the mutex only long enough to
-  decrement the shared-data refcount.
-- `rf_set_allocator` also takes the mutex, so it's safe to call
-  concurrently with `rf_create*`. The only wrinkle is *ordering*: a
-  concurrent create might snapshot either the old or the new allocator,
-  depending on interleaving. This never produces a mismatch — the
-  handle allocates and frees with the same allocator throughout its
-  lifetime.
-
-## Testing
-
-The test suites in `//tests/runfiles/` cover manifest parsing (both
-forms + escapes), envvar / argv0 / directory discovery,
-`_repo_mapping` in all its variants (exact match, wildcard, per-call
-source-repo override), and — for the C API — the custom allocator
-hook, handle-remembers-allocator semantics, and shared-data reuse
-across `rf_create` calls.
-
-```bash
-bazel test //tests/runfiles:runfiles_test    # C++ API
-bazel test //tests/runfiles:runfiles_c_test  # C API
-```
+Different handles are fully independent and safe to use concurrently
+from different threads. A single handle is safe for parallel `Rlocation`
+/ `rf_rlocation` reads — the parsed state is immutable after
+construction — but mixing reads with destruction is the caller's
+responsibility (same contract as `std::vector`).

--- a/tests/runfiles/BUILD
+++ b/tests/runfiles/BUILD
@@ -10,3 +10,18 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "runfiles_c_test",
+    srcs = ["runfiles_c_test.cc"],
+    deps = [
+        "//cc/runfiles:runfiles_c",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "runfiles_c_pure_test",
+    srcs = ["runfiles_c_test.c"],
+    deps = ["//cc/runfiles:runfiles_c"],
+)

--- a/tests/runfiles/runfiles_c_test.c
+++ b/tests/runfiles/runfiles_c_test.c
@@ -1,0 +1,323 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file runfiles_c_test.c
+/// @brief Pure-C smoketest for the runfiles C API.
+///
+/// Complements runfiles_c_test.cc (which is C++/googletest) by exercising
+/// the public C headers from a real C translation unit — proves the API
+/// compiles under C, that no C++-only syntax has leaked into the public
+/// header, and that the `extern "C"` boundary works end-to-end. Deliberately
+/// small: this is a smoketest, not a replacement for the full C++ suite.
+///
+/// ### Structure
+/// Each test is a `static int test_<name>(void)` returning the number of
+/// assertion failures it observed (0 = pass). `main()` iterates the
+/// `g_tests` array, prints gtest-style RUN/OK/FAILED banners, and exits
+/// non-zero if any test failed.
+
+#include "rules_cc/cc/runfiles/runfiles_c.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <io.h>
+#define UNLINK(p) _unlink(p)
+#else
+#include <unistd.h>
+#define UNLINK(p) unlink(p)
+#endif
+
+// CHECK macros expect the enclosing test function to have an `int fails`
+// in scope; each failure increments it. The test returns `fails` as its
+// assertion-failure count.
+#define CHECK(cond, msg)                                           \
+  do {                                                             \
+    if (cond) {                                                    \
+      printf("    pass: %s\n", (msg));                             \
+    } else {                                                       \
+      printf("    FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+      ++fails;                                                     \
+    }                                                              \
+  } while (0)
+
+#define CHECK_EQ_INT(actual, expected, msg)                              \
+  do {                                                                   \
+    long a_ = (long)(actual);                                            \
+    long e_ = (long)(expected);                                          \
+    if (a_ == e_) {                                                      \
+      printf("    pass: %s\n", (msg));                                   \
+    } else {                                                             \
+      printf("    FAIL: %s: got %ld, want %ld (%s:%d)\n", (msg), a_, e_, \
+             __FILE__, __LINE__);                                        \
+      ++fails;                                                           \
+    }                                                                    \
+  } while (0)
+
+#define CHECK_EQ_STR(actual, expected, msg)                                    \
+  do {                                                                         \
+    const char* a_ = (actual);                                                 \
+    const char* e_ = (expected);                                               \
+    if (strcmp(a_, e_) == 0) {                                                 \
+      printf("    pass: %s\n", (msg));                                         \
+    } else {                                                                   \
+      printf("    FAIL: %s: got \"%s\", want \"%s\" (%s:%d)\n", (msg), a_, e_, \
+             __FILE__, __LINE__);                                              \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+// Manifest created once in main and shared across tests via the C
+// library's per-(manifest, directory) cache. Bazel gives each test its
+// own TEST_TMPDIR so the fixed filename does not collide across tests.
+static char g_mf_path[4096];
+
+static void cleanup_mf(void) {
+  if (g_mf_path[0]) UNLINK(g_mf_path);
+}
+
+static int create_manifest(void) {
+  const char* tmp = getenv("TEST_TMPDIR");
+  if (!tmp || !tmp[0]) {
+    fprintf(stderr, "TEST_TMPDIR is unset\n");
+    return 0;
+  }
+  int written = snprintf(g_mf_path, sizeof(g_mf_path),
+                         "%s/runfiles_c_test.runfiles_manifest", tmp);
+  if (written <= 0 || (size_t)written >= sizeof(g_mf_path)) return 0;
+  atexit(cleanup_mf);
+
+  FILE* f = fopen(g_mf_path, "w");
+  if (!f) {
+    fprintf(stderr, "cannot open %s: %s\n", g_mf_path, strerror(errno));
+    return 0;
+  }
+  fputs("hello/world resolved/hello/world\n", f);
+  fputs("data/config.json config/config.json\n", f);
+  fputs("nested/dir resolved/nested/dir\n", f);
+  fclose(f);
+  return 1;
+}
+
+// Open a runfiles handle against the shared manifest. Returns NULL and
+// prints diagnostics on failure so the caller can bail early.
+static rf_runfiles* open_rf(void) {
+  char err[256] = {0};
+  rf_runfiles* rf = rf_create_ex(NULL, "", g_mf_path, "", "", err, sizeof(err));
+  if (!rf) fprintf(stderr, "    rf_create_ex failed: %s\n", err);
+  return rf;
+}
+
+// ==========================================================================
+// Tests
+// ==========================================================================
+
+/// Standalone smoketest for #rf_is_absolute.
+///
+/// No runfiles state required — the function is pure and stateless.
+/// Covers: POSIX leading-`/`, Windows drive-letter (`C:/`), a relative
+/// path, the empty string, and `NULL`. Deliberately does NOT cover the
+/// Windows-only UNC (`\\host\share`) branch — that would need a
+/// platform-conditional expectation and lives in the C++ suite.
+static int test_is_absolute(void) {
+  int fails = 0;
+  CHECK_EQ_INT(rf_is_absolute("/absolute/path"), 1, "unix absolute");
+  CHECK_EQ_INT(rf_is_absolute("C:/foo"), 1, "drive-letter absolute");
+  CHECK_EQ_INT(rf_is_absolute("relative/path"), 0, "relative rejected");
+  CHECK_EQ_INT(rf_is_absolute(""), 0, "empty rejected");
+  CHECK_EQ_INT(rf_is_absolute(NULL), 0, "NULL rejected");
+  return fails;
+}
+
+/// Handle construction plus the three golden `rf_rlocation` paths.
+///
+/// Covers:
+///   - #rf_create_ex against an explicit manifest path (bypassing env
+///     and argv0 discovery).
+///   - Exact-match lookup: `"hello/world"` → `"resolved/hello/world"`.
+///   - Second exact-match to prove multiple entries in the parsed
+///     manifest are indexed correctly.
+///   - Longest-prefix fallback: `"nested/dir/inner/file"` should hit
+///     the `"nested/dir"` prefix and append the remainder.
+///   - Unknown key in manifest-only mode returns 0 (not -1, not the
+///     directory fallback — no directory was configured).
+static int test_create_and_lookup(void) {
+  int fails = 0;
+  rf_runfiles* rf = open_rf();
+  CHECK(rf != NULL, "rf_create_ex succeeds");
+  if (!rf) return fails + 1;
+
+  char buf[1024];
+  int n;
+
+  n = rf_rlocation(rf, "hello/world", buf, sizeof(buf));
+  CHECK(n > 0, "hello/world resolves");
+  if (n > 0) CHECK_EQ_STR(buf, "resolved/hello/world", "hello/world value");
+
+  n = rf_rlocation(rf, "data/config.json", buf, sizeof(buf));
+  CHECK(n > 0, "data/config.json resolves");
+  if (n > 0) CHECK_EQ_STR(buf, "config/config.json", "data/config.json value");
+
+  n = rf_rlocation(rf, "nested/dir/inner/file", buf, sizeof(buf));
+  CHECK(n > 0, "nested prefix match resolves");
+  if (n > 0)
+    CHECK_EQ_STR(buf, "resolved/nested/dir/inner/file", "prefix-match value");
+
+  n = rf_rlocation(rf, "does/not/exist", buf, sizeof(buf));
+  CHECK_EQ_INT(n, 0, "unknown key returns 0 (manifest-only mode)");
+
+  rf_free(rf);
+  return fails;
+}
+
+/// #rf_path_is_rlocation_valid rejection paths surfaced through
+/// #rf_rlocation.
+///
+/// Covers the malformed-input contract that the validator locks in:
+///   - Empty string → `-1`.
+///   - Forward-slash traversal (`../etc/passwd`).
+///   - **Backslash traversal (`..\etc\passwd`)** — a regression guard
+///     for the Windows path-traversal fix; the validator now treats
+///     `\` as a separator on all platforms so this input can never
+///     escape the runfiles tree.
+///   - Embedded `/../` mid-path.
+static int test_rejects_bad_paths(void) {
+  int fails = 0;
+  rf_runfiles* rf = open_rf();
+  CHECK(rf != NULL, "rf_create_ex succeeds");
+  if (!rf) return fails + 1;
+
+  char buf[1024];
+  CHECK_EQ_INT(rf_rlocation(rf, "", buf, sizeof(buf)), -1, "empty rejected");
+  CHECK_EQ_INT(rf_rlocation(rf, "../etc/passwd", buf, sizeof(buf)), -1,
+               "forward-slash traversal rejected");
+  CHECK_EQ_INT(rf_rlocation(rf, "..\\etc\\passwd", buf, sizeof(buf)), -1,
+               "backslash traversal rejected");
+  CHECK_EQ_INT(rf_rlocation(rf, "a/../b", buf, sizeof(buf)), -1,
+               "embedded /../ rejected");
+
+  rf_free(rf);
+  return fails;
+}
+
+/// Verify that an absolute input to #rf_rlocation passes through
+/// verbatim.
+///
+/// Absolute paths are the documented escape hatch for callers that
+/// already have a resolved on-disk path. The function must NOT prepend
+/// the runfiles directory, apply repo-mapping, or consult the manifest.
+static int test_absolute_passthrough(void) {
+  int fails = 0;
+  rf_runfiles* rf = open_rf();
+  CHECK(rf != NULL, "rf_create_ex succeeds");
+  if (!rf) return fails + 1;
+
+  char buf[1024];
+  int n = rf_rlocation(rf, "/tmp/already-absolute", buf, sizeof(buf));
+  CHECK(n > 0, "absolute path passes through");
+  if (n > 0)
+    CHECK_EQ_STR(buf, "/tmp/already-absolute", "absolute path unchanged");
+
+  rf_free(rf);
+  return fails;
+}
+
+/// #rf_env_vars_count and #rf_env_var: the subprocess-env-publish API.
+///
+/// Covers:
+///   - Fixed count of 3 (`RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`,
+///     `JAVA_RUNFILES`).
+///   - Reading the first pair returns the manifest key and the exact
+///     manifest path we passed to #rf_create_ex.
+///   - Out-of-range index returns 0 (does NOT crash and does NOT write
+///     past the buffers).
+static int test_env_var(void) {
+  int fails = 0;
+  rf_runfiles* rf = open_rf();
+  CHECK(rf != NULL, "rf_create_ex succeeds");
+  if (!rf) return fails + 1;
+
+  CHECK_EQ_INT(rf_env_vars_count(rf), 3, "3 env vars");
+  char k[128], v[4096];
+  CHECK_EQ_INT(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 1,
+               "env_var[0] readable");
+  CHECK_EQ_STR(k, "RUNFILES_MANIFEST_FILE", "env_var[0] key");
+  CHECK_EQ_STR(v, g_mf_path, "env_var[0] value is manifest path");
+  CHECK_EQ_INT(rf_env_var(rf, 42, k, sizeof(k), v, sizeof(v)), 0,
+               "out-of-range env_var rejected");
+
+  rf_free(rf);
+  return fails;
+}
+
+/// `rf_free(NULL)` is a documented no-op.
+///
+/// Guards against a common footgun (unconditional cleanup on the error
+/// path where the handle may never have been allocated). The check
+/// simply proves control returned; the test would crash instead of
+/// failing an assertion if the contract were violated.
+static int test_free_null(void) {
+  int fails = 0;
+  rf_free(NULL);  // NULL is documented as a no-op.
+  CHECK(1, "rf_free(NULL) returned without crashing");
+  return fails;
+}
+
+// ==========================================================================
+// Runner
+// ==========================================================================
+
+typedef int (*test_fn)(void);
+typedef struct {
+  const char* name;
+  test_fn fn;
+} test_case;
+
+static const test_case g_tests[] = {
+    {"IsAbsolute", test_is_absolute},
+    {"CreateAndLookup", test_create_and_lookup},
+    {"RejectsBadPaths", test_rejects_bad_paths},
+    {"AbsolutePassthrough", test_absolute_passthrough},
+    {"EnvVar", test_env_var},
+    {"FreeNull", test_free_null},
+};
+
+int main(void) {
+  printf("== runfiles_c_test.c (pure C smoketest) ==\n");
+  if (!create_manifest()) return 1;
+
+  const int n_tests = (int)(sizeof(g_tests) / sizeof(g_tests[0]));
+  int total_fails = 0;
+  int failed_tests = 0;
+
+  for (int i = 0; i < n_tests; i++) {
+    printf("[ RUN      ] %s\n", g_tests[i].name);
+    int f = g_tests[i].fn();
+    if (f == 0) {
+      printf("[       OK ] %s\n", g_tests[i].name);
+    } else {
+      printf("[  FAILED  ] %s (%d assertion failure(s))\n", g_tests[i].name, f);
+      failed_tests++;
+    }
+    total_fails += f;
+  }
+
+  printf("\n== %d test(s): %d passed, %d failed (%d assertion failure(s)) ==\n",
+         n_tests, n_tests - failed_tests, failed_tests, total_fails);
+  return total_fails == 0 ? 0 : 1;
+}

--- a/tests/runfiles/runfiles_c_test.c
+++ b/tests/runfiles/runfiles_c_test.c
@@ -12,20 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file runfiles_c_test.c
-/// @brief Pure-C smoketest for the runfiles C API.
-///
-/// Complements runfiles_c_test.cc (which is C++/googletest) by exercising
-/// the public C headers from a real C translation unit — proves the API
-/// compiles under C, that no C++-only syntax has leaked into the public
-/// header, and that the `extern "C"` boundary works end-to-end. Deliberately
-/// small: this is a smoketest, not a replacement for the full C++ suite.
-///
-/// ### Structure
-/// Each test is a `static int test_<name>(void)` returning the number of
-/// assertion failures it observed (0 = pass). `main()` iterates the
-/// `g_tests` array, prints gtest-style RUN/OK/FAILED banners, and exits
-/// non-zero if any test failed.
+// Pure-C smoketest. Proves the public C API compiles from a real C TU
+// (no C++-only syntax leaked into the header, extern "C" boundary
+// works). Deliberately tiny -- the full suite is in runfiles_c_test.cc.
 
 #include "rules_cc/cc/runfiles/runfiles_c.h"
 
@@ -43,9 +32,8 @@
 #define UNLINK(p) unlink(p)
 #endif
 
-// CHECK macros expect the enclosing test function to have an `int fails`
-// in scope; each failure increments it. The test returns `fails` as its
-// assertion-failure count.
+// The enclosing test must declare `int fails` -- each failed check
+// increments it, and the test returns `fails` as its failure count.
 #define CHECK(cond, msg)                                           \
   do {                                                             \
     if (cond) {                                                    \
@@ -82,9 +70,7 @@
     }                                                                          \
   } while (0)
 
-// Manifest created once in main and shared across tests via the C
-// library's per-(manifest, directory) cache. Bazel gives each test its
-// own TEST_TMPDIR so the fixed filename does not collide across tests.
+// Shared across tests via TEST_TMPDIR (which Bazel isolates per test).
 static char g_mf_path[4096];
 
 static void cleanup_mf(void) {
@@ -114,12 +100,10 @@ static int create_manifest(void) {
   return 1;
 }
 
-// Open a runfiles handle against the shared manifest. Returns NULL and
-// prints diagnostics on failure so the caller can bail early.
 static rf_runfiles* open_rf(void) {
   char err[256] = {0};
-  rf_runfiles* rf = rf_create_ex(NULL, "", g_mf_path, "", "", err, sizeof(err));
-  if (!rf) fprintf(stderr, "    rf_create_ex failed: %s\n", err);
+  rf_runfiles* rf = rf_create(NULL, "", g_mf_path, "", "", err, sizeof(err));
+  if (!rf) fprintf(stderr, "    rf_create failed: %s\n", err);
   return rf;
 }
 
@@ -127,13 +111,7 @@ static rf_runfiles* open_rf(void) {
 // Tests
 // ==========================================================================
 
-/// Standalone smoketest for #rf_is_absolute.
-///
-/// No runfiles state required — the function is pure and stateless.
-/// Covers: POSIX leading-`/`, Windows drive-letter (`C:/`), a relative
-/// path, the empty string, and `NULL`. Deliberately does NOT cover the
-/// Windows-only UNC (`\\host\share`) branch — that would need a
-/// platform-conditional expectation and lives in the C++ suite.
+// UNC (`\\host\share`) is in the C++ suite (needs platform ifdef).
 static int test_is_absolute(void) {
   int fails = 0;
   CHECK_EQ_INT(rf_is_absolute("/absolute/path"), 1, "unix absolute");
@@ -144,136 +122,151 @@ static int test_is_absolute(void) {
   return fails;
 }
 
-/// Handle construction plus the three golden `rf_rlocation` paths.
-///
-/// Covers:
-///   - #rf_create_ex against an explicit manifest path (bypassing env
-///     and argv0 discovery).
-///   - Exact-match lookup: `"hello/world"` → `"resolved/hello/world"`.
-///   - Second exact-match to prove multiple entries in the parsed
-///     manifest are indexed correctly.
-///   - Longest-prefix fallback: `"nested/dir/inner/file"` should hit
-///     the `"nested/dir"` prefix and append the remainder.
-///   - Unknown key in manifest-only mode returns 0 (not -1, not the
-///     directory fallback — no directory was configured).
 static int test_create_and_lookup(void) {
   int fails = 0;
   rf_runfiles* rf = open_rf();
-  CHECK(rf != NULL, "rf_create_ex succeeds");
+  CHECK(rf != NULL, "rf_create succeeds");
   if (!rf) return fails + 1;
 
   char buf[1024];
-  int n;
+  size_t needed = 0;
+  rf_rlocation_status s;
 
-  n = rf_rlocation(rf, "hello/world", buf, sizeof(buf));
-  CHECK(n > 0, "hello/world resolves");
-  if (n > 0) CHECK_EQ_STR(buf, "resolved/hello/world", "hello/world value");
+  s = rf_rlocation(rf, "hello/world", NULL, buf, sizeof(buf), &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_OK, "hello/world resolves");
+  if (s == RF_RLOCATION_OK) {
+    CHECK_EQ_STR(buf, "resolved/hello/world", "hello/world value");
+    CHECK_EQ_INT(needed, strlen("resolved/hello/world"),
+                 "needed == strlen(result)");
+  }
 
-  n = rf_rlocation(rf, "data/config.json", buf, sizeof(buf));
-  CHECK(n > 0, "data/config.json resolves");
-  if (n > 0) CHECK_EQ_STR(buf, "config/config.json", "data/config.json value");
+  s = rf_rlocation(rf, "data/config.json", NULL, buf, sizeof(buf), &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_OK, "data/config.json resolves");
+  if (s == RF_RLOCATION_OK)
+    CHECK_EQ_STR(buf, "config/config.json", "data/config.json value");
 
-  n = rf_rlocation(rf, "nested/dir/inner/file", buf, sizeof(buf));
-  CHECK(n > 0, "nested prefix match resolves");
-  if (n > 0)
+  s = rf_rlocation(rf, "nested/dir/inner/file", NULL, buf, sizeof(buf),
+                   &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_OK, "nested prefix match resolves");
+  if (s == RF_RLOCATION_OK)
     CHECK_EQ_STR(buf, "resolved/nested/dir/inner/file", "prefix-match value");
 
-  n = rf_rlocation(rf, "does/not/exist", buf, sizeof(buf));
-  CHECK_EQ_INT(n, 0, "unknown key returns 0 (manifest-only mode)");
+  s = rf_rlocation(rf, "does/not/exist", NULL, buf, sizeof(buf), &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_NOT_FOUND,
+               "unknown key returns NOT_FOUND (manifest-only mode)");
+  CHECK_EQ_INT(needed, 0, "NOT_FOUND leaves needed=0");
 
   rf_free(rf);
   return fails;
 }
 
-/// #rf_path_is_rlocation_valid rejection paths surfaced through
-/// #rf_rlocation.
-///
-/// Covers the malformed-input contract that the validator locks in:
-///   - Empty string → `-1`.
-///   - Forward-slash traversal (`../etc/passwd`).
-///   - **Backslash traversal (`..\etc\passwd`)** — a regression guard
-///     for the Windows path-traversal fix; the validator now treats
-///     `\` as a separator on all platforms so this input can never
-///     escape the runfiles tree.
-///   - Embedded `/../` mid-path.
+// Backslash traversal case is the regression guard for the
+// Windows path-traversal hole -- `\` is a separator on all platforms.
 static int test_rejects_bad_paths(void) {
   int fails = 0;
   rf_runfiles* rf = open_rf();
-  CHECK(rf != NULL, "rf_create_ex succeeds");
+  CHECK(rf != NULL, "rf_create succeeds");
   if (!rf) return fails + 1;
 
   char buf[1024];
-  CHECK_EQ_INT(rf_rlocation(rf, "", buf, sizeof(buf)), -1, "empty rejected");
-  CHECK_EQ_INT(rf_rlocation(rf, "../etc/passwd", buf, sizeof(buf)), -1,
-               "forward-slash traversal rejected");
-  CHECK_EQ_INT(rf_rlocation(rf, "..\\etc\\passwd", buf, sizeof(buf)), -1,
-               "backslash traversal rejected");
-  CHECK_EQ_INT(rf_rlocation(rf, "a/../b", buf, sizeof(buf)), -1,
-               "embedded /../ rejected");
+  size_t needed = 0;
+  CHECK_EQ_INT(rf_rlocation(rf, "", NULL, buf, sizeof(buf), &needed),
+               RF_RLOCATION_INVALID_PATH, "empty rejected");
+  CHECK_EQ_INT(
+      rf_rlocation(rf, "../etc/passwd", NULL, buf, sizeof(buf), &needed),
+      RF_RLOCATION_INVALID_PATH, "forward-slash traversal rejected");
+  CHECK_EQ_INT(
+      rf_rlocation(rf, "..\\etc\\passwd", NULL, buf, sizeof(buf), &needed),
+      RF_RLOCATION_INVALID_PATH, "backslash traversal rejected");
+  CHECK_EQ_INT(rf_rlocation(rf, "a/../b", NULL, buf, sizeof(buf), &needed),
+               RF_RLOCATION_INVALID_PATH, "embedded /../ rejected");
 
   rf_free(rf);
   return fails;
 }
 
-/// Verify that an absolute input to #rf_rlocation passes through
-/// verbatim.
-///
-/// Absolute paths are the documented escape hatch for callers that
-/// already have a resolved on-disk path. The function must NOT prepend
-/// the runfiles directory, apply repo-mapping, or consult the manifest.
 static int test_absolute_passthrough(void) {
   int fails = 0;
   rf_runfiles* rf = open_rf();
-  CHECK(rf != NULL, "rf_create_ex succeeds");
+  CHECK(rf != NULL, "rf_create succeeds");
   if (!rf) return fails + 1;
 
   char buf[1024];
-  int n = rf_rlocation(rf, "/tmp/already-absolute", buf, sizeof(buf));
-  CHECK(n > 0, "absolute path passes through");
-  if (n > 0)
+  size_t needed = 0;
+  rf_rlocation_status s = rf_rlocation(rf, "/tmp/already-absolute", NULL, buf,
+                                       sizeof(buf), &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_OK, "absolute path passes through");
+  if (s == RF_RLOCATION_OK)
     CHECK_EQ_STR(buf, "/tmp/already-absolute", "absolute path unchanged");
 
   rf_free(rf);
   return fails;
 }
 
-/// #rf_env_vars_count and #rf_env_var: the subprocess-env-publish API.
-///
-/// Covers:
-///   - Fixed count of 3 (`RUNFILES_MANIFEST_FILE`, `RUNFILES_DIR`,
-///     `JAVA_RUNFILES`).
-///   - Reading the first pair returns the manifest key and the exact
-///     manifest path we passed to #rf_create_ex.
-///   - Out-of-range index returns 0 (does NOT crash and does NOT write
-///     past the buffers).
-static int test_env_var(void) {
+static int test_buf_too_small(void) {
   int fails = 0;
   rf_runfiles* rf = open_rf();
-  CHECK(rf != NULL, "rf_create_ex succeeds");
+  CHECK(rf != NULL, "rf_create succeeds");
   if (!rf) return fails + 1;
 
-  CHECK_EQ_INT(rf_env_vars_count(rf), 3, "3 env vars");
-  char k[128], v[4096];
-  CHECK_EQ_INT(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 1,
-               "env_var[0] readable");
-  CHECK_EQ_STR(k, "RUNFILES_MANIFEST_FILE", "env_var[0] key");
-  CHECK_EQ_STR(v, g_mf_path, "env_var[0] value is manifest path");
-  CHECK_EQ_INT(rf_env_var(rf, 42, k, sizeof(k), v, sizeof(v)), 0,
-               "out-of-range env_var rejected");
+  // Try with a 4-byte buffer; result is "resolved/hello/world" (20 chars).
+  char tiny[4];
+  const char sentinel = '\x7f';
+  memset(tiny, sentinel, sizeof(tiny));
+  size_t needed = 0;
+  rf_rlocation_status s =
+      rf_rlocation(rf, "hello/world", NULL, tiny, sizeof(tiny), &needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_BUF_TOO_SMALL, "tiny buffer -> BUF_TOO_SMALL");
+  CHECK_EQ_INT(needed, strlen("resolved/hello/world"), "needed = full length");
+  CHECK_EQ_INT(tiny[0], sentinel, "buf untouched on BUF_TOO_SMALL[0]");
+  CHECK_EQ_INT(tiny[3], sentinel, "buf untouched on BUF_TOO_SMALL[3]");
+
+  // Query-only: NULL buf, 0 cap.
+  size_t query_needed = 0;
+  s = rf_rlocation(rf, "hello/world", NULL, NULL, 0, &query_needed);
+  CHECK_EQ_INT(s, RF_RLOCATION_BUF_TOO_SMALL,
+               "query-only NULL/0 -> BUF_TOO_SMALL");
+  CHECK_EQ_INT(query_needed, strlen("resolved/hello/world"),
+               "query needed = full length");
+
+  // Retry with exact size.
+  char* heap = (char*)malloc(needed + 1);
+  CHECK(heap != NULL, "malloc succeeded");
+  if (heap) {
+    s = rf_rlocation(rf, "hello/world", NULL, heap, needed + 1, &needed);
+    CHECK_EQ_INT(s, RF_RLOCATION_OK, "retry with exact size succeeds");
+    if (s == RF_RLOCATION_OK)
+      CHECK_EQ_STR(heap, "resolved/hello/world", "retry result correct");
+    free(heap);
+  }
 
   rf_free(rf);
   return fails;
 }
 
-/// `rf_free(NULL)` is a documented no-op.
-///
-/// Guards against a common footgun (unconditional cleanup on the error
-/// path where the handle may never have been allocated). The check
-/// simply proves control returned; the test would crash instead of
-/// failing an assertion if the contract were violated.
+static int test_env_var(void) {
+  int fails = 0;
+  rf_runfiles* rf = open_rf();
+  CHECK(rf != NULL, "rf_create succeeds");
+  if (!rf) return fails + 1;
+
+  CHECK_EQ_INT(rf_env_vars_count(), 3, "3 env vars");
+  const char* k = rf_env_var_key(0);
+  const char* v = rf_env_var_value(rf, 0);
+  CHECK(k != NULL, "env_var_key[0] readable");
+  CHECK(v != NULL, "env_var_value[0] readable");
+  if (k) CHECK_EQ_STR(k, "RUNFILES_MANIFEST_FILE", "env_var[0] key");
+  if (v) CHECK_EQ_STR(v, g_mf_path, "env_var[0] value is manifest path");
+  CHECK(rf_env_var_key(42) == NULL, "out-of-range key returns NULL");
+  CHECK(rf_env_var_value(rf, 42) == NULL, "out-of-range value returns NULL");
+
+  rf_free(rf);
+  return fails;
+}
+
 static int test_free_null(void) {
   int fails = 0;
-  rf_free(NULL);  // NULL is documented as a no-op.
+  rf_free(NULL);
   CHECK(1, "rf_free(NULL) returned without crashing");
   return fails;
 }
@@ -293,6 +286,7 @@ static const test_case g_tests[] = {
     {"CreateAndLookup", test_create_and_lookup},
     {"RejectsBadPaths", test_rejects_bad_paths},
     {"AbsolutePassthrough", test_absolute_passthrough},
+    {"BufTooSmall", test_buf_too_small},
     {"EnvVar", test_env_var},
     {"FreeNull", test_free_null},
 };

--- a/tests/runfiles/runfiles_c_test.cc
+++ b/tests/runfiles/runfiles_c_test.cc
@@ -1,0 +1,569 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern "C" {
+#include "rules_cc/cc/runfiles/runfiles_c.h"
+}
+
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+// MSVC's <direct.h> spells these _mkdir(path) (no mode) and _rmdir(path).
+// Alias them to the POSIX names so the test body reads identically on
+// both platforms.
+#define mkdir(path, mode) _mkdir(path)
+#define rmdir(path) _rmdir(path)
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace {
+
+#define RUNFILES_C_TEST_TOSTRING_HELPER(x) #x
+#define RUNFILES_C_TEST_TOSTRING(x) RUNFILES_C_TEST_TOSTRING_HELPER(x)
+#define LINE_AS_STRING() RUNFILES_C_TEST_TOSTRING(__LINE__)
+
+// Read TEST_TMPDIR (guaranteed set by Bazel) into a std::string, asserting
+// that it exists so a direct-run of the binary fails cleanly rather than
+// crashing on `std::string(nullptr)`.
+#define ASSERT_TMPDIR(local)                            \
+  const char* local##_env = std::getenv("TEST_TMPDIR"); \
+  ASSERT_TRUE(local##_env&& local##_env[0]);            \
+  const std::string local = local##_env
+
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+// Test helpers: shortcut the common rf_create_ex boilerplate (libc
+// allocator, empty-string defaults, 256-byte err buffer). The full
+// rf_create_ex is used only when a test needs a custom allocator or a
+// non-default source repo.
+static rf_runfiles* MakeFromArgv0(const string& argv0, char err[256]) {
+  return rf_create_ex(nullptr, argv0.c_str(), "", "", "", err, 256);
+}
+static rf_runfiles* MakeFromManifest(const string& manifest, char err[256]) {
+  return rf_create_ex(nullptr, "", manifest.c_str(), "", "", err, 256);
+}
+
+// Temp file that self-deletes.
+class MockFile {
+ public:
+  static MockFile* Create(const string& name) {
+    return Create(name, vector<string>());
+  }
+
+  static MockFile* Create(const string& name, const vector<string>& lines) {
+    if (name.find("..") != string::npos || rf_is_absolute(name.c_str())) {
+      return nullptr;
+    }
+    const char* tmp = std::getenv("TEST_TMPDIR");
+    if (!tmp || !tmp[0]) return nullptr;
+    string root(tmp);
+    string path = root + "/" + name;
+
+    string::size_type i = 0;
+    while ((i = name.find_first_of('/', i + 1)) != string::npos) {
+      string d = root + "/" + name.substr(0, i);
+      if (mkdir(d.c_str(), 0777) != 0 && errno != EEXIST) return nullptr;
+    }
+    std::ofstream stm(path);
+    for (const auto& l : lines) stm << l << std::endl;
+    return new MockFile(path);
+  }
+
+  ~MockFile() { std::remove(path_.c_str()); }
+  const string& Path() const { return path_; }
+  string DirName() const {
+    auto pos = path_.find_last_of('/');
+    return pos == string::npos ? "" : path_.substr(0, pos);
+  }
+
+ private:
+  explicit MockFile(const string& path) : path_(path) {}
+  MockFile(const MockFile&) = delete;
+  MockFile& operator=(const MockFile&) = delete;
+  const string path_;
+};
+
+// Convenience: rf_rlocation returning a std::string ("" on 0, throws on -1).
+static string Rloc(rf_runfiles* rf, const char* path) {
+  char buf[4096];
+  int n = rf_rlocation(rf, path, buf, sizeof(buf));
+  if (n < 0) {
+    ADD_FAILURE() << "rf_rlocation error for path \"" << path << "\"";
+    return "";
+  }
+  return string(buf, n);
+}
+static string RlocFrom(rf_runfiles* rf, const char* path, const char* sr) {
+  char buf[4096];
+  int n = rf_rlocation_from(rf, path, sr, buf, sizeof(buf));
+  if (n < 0) {
+    ADD_FAILURE() << "rf_rlocation_from error for path \"" << path << "\"";
+    return "";
+  }
+  return string(buf, n);
+}
+
+static void ExpectEnvvars(rf_runfiles* rf, const string& expected_manifest,
+                          const string& expected_dir) {
+  ASSERT_EQ(rf_env_vars_count(rf), 3);
+  char k[128], v[4096];
+  ASSERT_EQ(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 1);
+  EXPECT_STREQ(k, "RUNFILES_MANIFEST_FILE");
+  EXPECT_EQ(string(v), expected_manifest);
+  ASSERT_EQ(rf_env_var(rf, 1, k, sizeof(k), v, sizeof(v)), 1);
+  EXPECT_STREQ(k, "RUNFILES_DIR");
+  EXPECT_EQ(string(v), expected_dir);
+  ASSERT_EQ(rf_env_var(rf, 2, k, sizeof(k), v, sizeof(v)), 1);
+  EXPECT_STREQ(k, "JAVA_RUNFILES");
+  EXPECT_EQ(string(v), expected_dir);
+}
+
+// ==========================================================================
+// Basic tests: creation, discovery, rlocation, envvars
+// ==========================================================================
+
+// All tests that exercise argv0-based discovery pass explicit empty
+// manifest/dir strings (via rf_create_ex) so they bypass the ambient
+// RUNFILES_MANIFEST_FILE / RUNFILES_DIR that the Bazel test harness
+// sets in the process environment.
+
+TEST(RunfilesCTest, CreatesFromManifestNextToBinary) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles_manifest").size());
+
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_STREQ(err, "");
+  EXPECT_EQ(Rloc(rf, "a/b"), "c/d");
+  EXPECT_EQ(Rloc(rf, "unknown"), "");  // manifest-based: empty for unknown
+  ExpectEnvvars(rf, mf->Path(), "");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, CreatesFromManifestInRunfilesDir) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles/MANIFEST", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "a/b"), "c/d");
+  // Directory fallback for unknown key.
+  EXPECT_EQ(Rloc(rf, "foo"), argv0 + ".runfiles/foo");
+  ExpectEnvvars(rf, mf->Path(), argv0 + ".runfiles");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, CreatesExFromExplicitPaths) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "a/b"), "c/d");
+  ExpectEnvvars(rf, mf->Path(), "");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, ManifestEscapesAreDecoded) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest",
+      {
+          // First form (space in key): line starts with a space.
+          " \\swith\\sspace foo/bar",
+          // Second form: no space in key; value is verbatim (no escapes
+          // are applied to the value in the second form).
+          "no_space value-with-space",
+          // Backslash escape \\b -> '\\'
+          " k\\bwith\\bbslash x\\by",
+      }));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, " with space"), "foo/bar");
+  EXPECT_EQ(Rloc(rf, "no_space"), "value-with-space");
+  EXPECT_EQ(Rloc(rf, "k\\with\\bslash"), "x\\y");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, RejectsBadPaths) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  char buf[64];
+  EXPECT_EQ(rf_rlocation(rf, "", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "../x", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "./x", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a/../b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a/./b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a//b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a/.", buf, sizeof(buf)), -1);
+  // Backslash equivalents: the validator treats '\' as a separator on
+  // ALL platforms so Windows traversal attempts like "..\\etc\\passwd"
+  // are rejected instead of falling through to the directory-fallback
+  // (which would resolve backslashes as parent-dir via Win32 file APIs).
+  EXPECT_EQ(rf_rlocation(rf, "..\\x", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, ".\\x", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a\\..\\b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a\\.\\b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a\\\\b", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "a\\.", buf, sizeof(buf)), -1);
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, AbsolutePassthrough) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "/absolute/path"), "/absolute/path");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, BufferTooSmall) {
+  unique_ptr<MockFile> mf(
+      MockFile::Create("foo" LINE_AS_STRING() ".runfiles_manifest",
+                       {"a/b a-very-long-resolved-path-that-will-not-fit"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  char buf[10];
+  EXPECT_EQ(rf_rlocation(rf, "a/b", buf, sizeof(buf)), -1);
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, EnvvarLookupsFailOnTooSmallBuffer) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  char k[4], v[4];
+  EXPECT_EQ(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 0);
+  EXPECT_EQ(rf_env_var(rf, 42, k, 128, v, 128), 0);
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, DirectoryBasedNoManifest) {
+  ASSERT_TMPDIR(tmp);
+  string dir = tmp + "/foo" LINE_AS_STRING() ".runfiles";
+  ASSERT_EQ(mkdir(dir.c_str(), 0777), 0);
+
+  char err[256] = {0};
+  rf_runfiles* rf =
+      rf_create_ex(nullptr, "", "", dir.c_str(), "", err, sizeof(err));
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "any/file"), dir + "/any/file");
+  ExpectEnvvars(rf, "", dir);
+  rf_free(rf);
+  rmdir(dir.c_str());
+}
+
+TEST(RunfilesCTest, FailsWhenNothingFound) {
+  char err[256] = {0};
+  rf_runfiles* rf = rf_create_ex(nullptr, "", "", "", "", err, sizeof(err));
+  EXPECT_EQ(rf, nullptr);
+  EXPECT_NE(strstr(err, "cannot find runfiles"), nullptr);
+}
+
+TEST(RunfilesCTest, FailsOnBadManifest) {
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"line_without_space"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  EXPECT_EQ(rf, nullptr);
+  EXPECT_NE(strstr(err, "bad runfiles manifest"), nullptr);
+}
+
+TEST(RunfilesCTest, RlocationFromOverridesSourceRepo) {
+  // Manifest with a _repo_mapping that says: from source "src_repo", the
+  // apparent name "my_module" maps to canonical "canonical_v1". No
+  // mapping applies from the empty (main) source.
+  ASSERT_TMPDIR(tmp);
+  const string tag = std::to_string(__LINE__);
+  const string mf_name = "foo" + tag + ".runfiles/MANIFEST";
+  const string rmap_name = "foo" + tag + ".runfiles/_repo_mapping";
+  const string rmap_path = tmp + "/" + rmap_name;
+
+  unique_ptr<MockFile> mf(MockFile::Create(
+      mf_name, {"_repo_mapping " + rmap_path,
+                "canonical_v1/file resolved/canonical_v1/file"}));
+  ASSERT_TRUE(mf != nullptr);
+  unique_ptr<MockFile> rmap(
+      MockFile::Create(rmap_name, {"src_repo,my_module,canonical_v1"}));
+  ASSERT_TRUE(rmap != nullptr);
+
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  ASSERT_NE(rf, nullptr) << err;
+
+  // With default source_repository = "", "my_module/file" does not
+  // rewrite -> falls back to directory-based lookup.
+  EXPECT_EQ(Rloc(rf, "my_module/file"), argv0 + ".runfiles/my_module/file");
+  // With per-call source_repository = "src_repo", "my_module/file"
+  // rewrites to canonical_v1/file which IS in the manifest.
+  EXPECT_EQ(RlocFrom(rf, "my_module/file", "src_repo"),
+            "resolved/canonical_v1/file");
+  rf_free(rf);
+}
+
+// ==========================================================================
+// _repo_mapping tests: parity with the C++ suite
+// ==========================================================================
+
+// Each repo-mapping test captures __LINE__ once into a runtime `tag`
+// (instead of using LINE_AS_STRING() at multiple sites, which would
+// yield different values per occurrence and break the manifest ↔
+// MockFile path match).
+static string BuildRmapPathIn(const string& tmp, const string& tag) {
+  return tmp + "/foo" + tag + ".runfiles/_repo_mapping";
+}
+
+TEST(RunfilesCTest, RepoMappingFromMain) {
+  ASSERT_TMPDIR(tmp);
+  const string tag = std::to_string(__LINE__);
+  const string mf_name = "foo" + tag + ".runfiles/MANIFEST";
+  const string rmap_name = "foo" + tag + ".runfiles/_repo_mapping";
+  const string rmap_path = BuildRmapPathIn(tmp, tag);
+
+  unique_ptr<MockFile> mf(MockFile::Create(
+      mf_name, {"_repo_mapping " + rmap_path, "config.json config/config.json",
+                "protobuf+3.19.2/foo/runfile2 protobuf+3.19.2/foo/runfile2"}));
+  ASSERT_TRUE(mf != nullptr);
+  unique_ptr<MockFile> rmap(MockFile::Create(
+      rmap_name, {",my_module,my_workspace", ",my_protobuf,protobuf+3.19.2",
+                  "protobuf+3.19.2,protobuf,protobuf+3.19.2"}));
+  ASSERT_TRUE(rmap != nullptr);
+
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  ASSERT_NE(rf, nullptr) << err;
+
+  // From main workspace ("" source_repo), "my_protobuf" rewrites to
+  // "protobuf+3.19.2".
+  EXPECT_EQ(Rloc(rf, "my_protobuf/foo/runfile2"),
+            "protobuf+3.19.2/foo/runfile2");
+  // config.json is directly in the manifest.
+  EXPECT_EQ(Rloc(rf, "config.json"), "config/config.json");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, RepoMappingFromOtherRepo) {
+  ASSERT_TMPDIR(tmp);
+  const string tag = std::to_string(__LINE__);
+  const string mf_name = "foo" + tag + ".runfiles/MANIFEST";
+  const string rmap_name = "foo" + tag + ".runfiles/_repo_mapping";
+  const string rmap_path = BuildRmapPathIn(tmp, tag);
+
+  unique_ptr<MockFile> mf(MockFile::Create(
+      mf_name, {"_repo_mapping " + rmap_path,
+                "protobuf+3.19.2/foo/runfile2 protobuf+3.19.2/foo/runfile2"}));
+  ASSERT_TRUE(mf != nullptr);
+  unique_ptr<MockFile> rmap(MockFile::Create(
+      rmap_name, {"protobuf+3.19.2,protobuf,protobuf+3.19.2"}));
+  ASSERT_TRUE(rmap != nullptr);
+
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+  char err[256] = {0};
+  rf_runfiles* rf = rf_create_ex(nullptr, argv0.c_str(), "", "",
+                                 "protobuf+3.19.2", err, sizeof(err));
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "protobuf/foo/runfile2"), "protobuf+3.19.2/foo/runfile2");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, RepoMappingWildcardFromExtensionRepo) {
+  ASSERT_TMPDIR(tmp);
+  const string tag = std::to_string(__LINE__);
+  const string mf_name = "foo" + tag + ".runfiles/MANIFEST";
+  const string rmap_name = "foo" + tag + ".runfiles/_repo_mapping";
+  const string rmap_path = BuildRmapPathIn(tmp, tag);
+
+  unique_ptr<MockFile> mf(MockFile::Create(
+      mf_name, {"_repo_mapping " + rmap_path,
+                "my_module++ext+dep1/file/x resolved/dep1/file/x"}));
+  ASSERT_TRUE(mf != nullptr);
+  // Wildcard: for any source repo starting with "my_module++ext+",
+  // apparent name "dep" maps to "my_module++ext+dep1".
+  unique_ptr<MockFile> rmap(MockFile::Create(
+      rmap_name, {"my_module++ext+*,dep,my_module++ext+dep1"}));
+  ASSERT_TRUE(rmap != nullptr);
+
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+  char err[256] = {0};
+  rf_runfiles* rf = rf_create_ex(nullptr, argv0.c_str(), "", "",
+                                 "my_module++ext+other_repo", err, sizeof(err));
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "dep/file/x"), "resolved/dep1/file/x");
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, InvalidRepoMappingRejected) {
+  ASSERT_TMPDIR(tmp);
+  const string tag = std::to_string(__LINE__);
+  const string mf_name = "foo" + tag + ".runfiles/MANIFEST";
+  const string rmap_name = "foo" + tag + ".runfiles/_repo_mapping";
+  const string rmap_path = BuildRmapPathIn(tmp, tag);
+
+  unique_ptr<MockFile> mf(MockFile::Create(
+      mf_name, {"_repo_mapping " + rmap_path, "canonical/file resolved/x"}));
+  ASSERT_TRUE(mf != nullptr);
+  unique_ptr<MockFile> rmap(
+      MockFile::Create(rmap_name, {"only_one_comma,here"}));
+  ASSERT_TRUE(rmap != nullptr);
+
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles/MANIFEST").size());
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  EXPECT_EQ(rf, nullptr);
+  EXPECT_NE(strstr(err, "bad repository mapping"), nullptr);
+}
+
+// ==========================================================================
+// Regression test for the UB in the prefix-fallback search: the original
+// code cast away const and wrote a NUL into the caller's path string,
+// crashing when passed a string literal.
+// ==========================================================================
+
+TEST(RunfilesCTest, PrefixFallbackDoesNotMutatePath) {
+  // Manifest has "a" as a directory entry — prefix search will match "a"
+  // for path "a/nested/file". The old code would try to write NUL into
+  // path[1] to isolate the prefix, which segfaults on a string literal.
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a resolved/dir"}));
+  ASSERT_TRUE(mf != nullptr);
+  string argv0 = mf->Path().substr(
+      0, mf->Path().size() - string(".runfiles_manifest").size());
+
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromArgv0(argv0, err);
+  ASSERT_NE(rf, nullptr) << err;
+
+  char buf[1024];
+  // Pass a bona-fide string LITERAL — must not be mutated.
+  int n = rf_rlocation(rf, "a/nested/file", buf, sizeof(buf));
+  ASSERT_GT(n, 0);
+  EXPECT_STREQ(buf, "resolved/dir/nested/file");
+  rf_free(rf);
+}
+
+// ==========================================================================
+// Allocator hook tests
+// ==========================================================================
+
+struct AllocStats {
+  int malloc_count = 0;
+  int realloc_count = 0;
+  int free_count_nonnull = 0;
+};
+
+static void* CountingMalloc(void* ud, size_t n) {
+  static_cast<AllocStats*>(ud)->malloc_count++;
+  return std::malloc(n);
+}
+static void* CountingRealloc(void* ud, void* p, size_t n) {
+  static_cast<AllocStats*>(ud)->realloc_count++;
+  return std::realloc(p, n);
+}
+static void CountingFree(void* ud, void* p) {
+  if (p) static_cast<AllocStats*>(ud)->free_count_nonnull++;
+  std::free(p);
+}
+
+TEST(RunfilesCTest, CustomAllocatorInvokedByCreateAndFree) {
+  AllocStats stats;
+  rf_allocator a = {CountingMalloc, CountingRealloc, CountingFree, &stats};
+
+  unique_ptr<MockFile> mf(
+      MockFile::Create("foo" LINE_AS_STRING() ".runfiles_manifest",
+                       {"a/b c/d", "e/f g/h", "i/j k/l"}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf =
+      rf_create_ex(&a, "", mf->Path().c_str(), "", "", err, sizeof(err));
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_GT(stats.malloc_count, 0);
+  EXPECT_EQ(Rloc(rf, "a/b"), "c/d");
+
+  int free_before = stats.free_count_nonnull;
+  rf_free(rf);
+  // The handle stored the allocator vtable at Create time and reused it
+  // in Free — every parsed byte + the handle itself came out through
+  // CountingFree.
+  EXPECT_GT(stats.free_count_nonnull, free_before);
+}
+
+// ==========================================================================
+// rf_is_absolute standalone
+// ==========================================================================
+
+TEST(RunfilesCTest, IsAbsolute) {
+  EXPECT_EQ(rf_is_absolute("/foo"), 1);
+  EXPECT_EQ(rf_is_absolute("/foo/bar"), 1);
+  EXPECT_EQ(rf_is_absolute("//host/share"),
+            0);  // UNC-style not treated absolute
+  EXPECT_EQ(rf_is_absolute("C:\\Windows"), 1);
+  EXPECT_EQ(rf_is_absolute("c:/foo"), 1);
+  EXPECT_EQ(rf_is_absolute("relative/path"), 0);
+  EXPECT_EQ(rf_is_absolute(""), 0);
+  EXPECT_EQ(rf_is_absolute(nullptr), 0);
+}
+
+// ==========================================================================
+// rf_free(NULL) is a no-op
+// ==========================================================================
+
+TEST(RunfilesCTest, FreeNullIsNoOp) { rf_free(nullptr); }
+
+}  // namespace

--- a/tests/runfiles/runfiles_c_test.cc
+++ b/tests/runfiles/runfiles_c_test.cc
@@ -46,9 +46,8 @@ namespace {
 #define RUNFILES_C_TEST_TOSTRING(x) RUNFILES_C_TEST_TOSTRING_HELPER(x)
 #define LINE_AS_STRING() RUNFILES_C_TEST_TOSTRING(__LINE__)
 
-// Read TEST_TMPDIR (guaranteed set by Bazel) into a std::string, asserting
-// that it exists so a direct-run of the binary fails cleanly rather than
-// crashing on `std::string(nullptr)`.
+// TEST_TMPDIR into a std::string, asserting it exists so a direct-run
+// fails cleanly rather than crashing on std::string(nullptr).
 #define ASSERT_TMPDIR(local)                            \
   const char* local##_env = std::getenv("TEST_TMPDIR"); \
   ASSERT_TRUE(local##_env&& local##_env[0]);            \
@@ -58,15 +57,13 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
-// Test helpers: shortcut the common rf_create_ex boilerplate (libc
-// allocator, empty-string defaults, 256-byte err buffer). The full
-// rf_create_ex is used only when a test needs a custom allocator or a
-// non-default source repo.
+// Common-case shortcuts; tests reach for full rf_create when they
+// need a custom allocator or a non-default source repo.
 static rf_runfiles* MakeFromArgv0(const string& argv0, char err[256]) {
-  return rf_create_ex(nullptr, argv0.c_str(), "", "", "", err, 256);
+  return rf_create(nullptr, argv0.c_str(), "", "", "", err, 256);
 }
 static rf_runfiles* MakeFromManifest(const string& manifest, char err[256]) {
-  return rf_create_ex(nullptr, "", manifest.c_str(), "", "", err, 256);
+  return rf_create(nullptr, "", manifest.c_str(), "", "", err, 256);
 }
 
 // Temp file that self-deletes.
@@ -109,49 +106,50 @@ class MockFile {
   const string path_;
 };
 
-// Convenience: rf_rlocation returning a std::string ("" on 0, throws on -1).
-static string Rloc(rf_runfiles* rf, const char* path) {
-  char buf[4096];
-  int n = rf_rlocation(rf, path, buf, sizeof(buf));
-  if (n < 0) {
-    ADD_FAILURE() << "rf_rlocation error for path \"" << path << "\"";
-    return "";
-  }
-  return string(buf, n);
-}
+// Mirrors the C++ facade's own shape: 4 KB stack buffer, one
+// grow-and-retry via std::string on BUF_TOO_SMALL.
 static string RlocFrom(rf_runfiles* rf, const char* path, const char* sr) {
-  char buf[4096];
-  int n = rf_rlocation_from(rf, path, sr, buf, sizeof(buf));
-  if (n < 0) {
-    ADD_FAILURE() << "rf_rlocation_from error for path \"" << path << "\"";
-    return "";
+  char stack[4096];
+  size_t needed = 0;
+  rf_rlocation_status s =
+      rf_rlocation(rf, path, sr, stack, sizeof(stack), &needed);
+  if (s == RF_RLOCATION_OK) return string(stack, needed);
+  if (s == RF_RLOCATION_BUF_TOO_SMALL) {
+    string big(needed + 1, '\0');
+    s = rf_rlocation(rf, path, sr, &big[0], big.size(), &needed);
+    if (s == RF_RLOCATION_OK) {
+      big.resize(needed);
+      return big;
+    }
   }
-  return string(buf, n);
+  if (s == RF_RLOCATION_INVALID_PATH || s == RF_RLOCATION_ALLOC_FAILED) {
+    ADD_FAILURE() << "rf_rlocation error " << s << " for path \"" << path
+                  << "\"";
+  }
+  return "";
+}
+static string Rloc(rf_runfiles* rf, const char* path) {
+  return RlocFrom(rf, path, nullptr);
 }
 
 static void ExpectEnvvars(rf_runfiles* rf, const string& expected_manifest,
                           const string& expected_dir) {
-  ASSERT_EQ(rf_env_vars_count(rf), 3);
-  char k[128], v[4096];
-  ASSERT_EQ(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 1);
-  EXPECT_STREQ(k, "RUNFILES_MANIFEST_FILE");
-  EXPECT_EQ(string(v), expected_manifest);
-  ASSERT_EQ(rf_env_var(rf, 1, k, sizeof(k), v, sizeof(v)), 1);
-  EXPECT_STREQ(k, "RUNFILES_DIR");
-  EXPECT_EQ(string(v), expected_dir);
-  ASSERT_EQ(rf_env_var(rf, 2, k, sizeof(k), v, sizeof(v)), 1);
-  EXPECT_STREQ(k, "JAVA_RUNFILES");
-  EXPECT_EQ(string(v), expected_dir);
+  ASSERT_EQ(rf_env_vars_count(), 3);
+  EXPECT_STREQ(rf_env_var_key(0), "RUNFILES_MANIFEST_FILE");
+  EXPECT_EQ(string(rf_env_var_value(rf, 0)), expected_manifest);
+  EXPECT_STREQ(rf_env_var_key(1), "RUNFILES_DIR");
+  EXPECT_EQ(string(rf_env_var_value(rf, 1)), expected_dir);
+  EXPECT_STREQ(rf_env_var_key(2), "JAVA_RUNFILES");
+  EXPECT_EQ(string(rf_env_var_value(rf, 2)), expected_dir);
 }
 
 // ==========================================================================
-// Basic tests: creation, discovery, rlocation, envvars
+// Basic tests
 // ==========================================================================
-
-// All tests that exercise argv0-based discovery pass explicit empty
-// manifest/dir strings (via rf_create_ex) so they bypass the ambient
-// RUNFILES_MANIFEST_FILE / RUNFILES_DIR that the Bazel test harness
-// sets in the process environment.
+//
+// argv0-discovery tests pass explicit empty mf/dir strings so they
+// bypass the ambient RUNFILES_MANIFEST_FILE / RUNFILES_DIR that the
+// Bazel test harness sets in the process env.
 
 TEST(RunfilesCTest, CreatesFromManifestNextToBinary) {
   unique_ptr<MockFile> mf(MockFile::Create(
@@ -187,7 +185,7 @@ TEST(RunfilesCTest, CreatesFromManifestInRunfilesDir) {
   rf_free(rf);
 }
 
-TEST(RunfilesCTest, CreatesExFromExplicitPaths) {
+TEST(RunfilesCTest, CreatesFromExplicitPaths) {
   unique_ptr<MockFile> mf(MockFile::Create(
       "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
   ASSERT_TRUE(mf != nullptr);
@@ -230,23 +228,39 @@ TEST(RunfilesCTest, RejectsBadPaths) {
   rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
   ASSERT_NE(rf, nullptr) << err;
   char buf[64];
-  EXPECT_EQ(rf_rlocation(rf, "", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "../x", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "./x", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a/../b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a/./b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a//b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a/.", buf, sizeof(buf)), -1);
+  size_t needed = 0;
+  const size_t cap = sizeof(buf);
+  EXPECT_EQ(rf_rlocation(rf, "", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "../x", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "./x", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a/../b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a/./b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a//b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a/.", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
   // Backslash equivalents: the validator treats '\' as a separator on
   // ALL platforms so Windows traversal attempts like "..\\etc\\passwd"
   // are rejected instead of falling through to the directory-fallback
   // (which would resolve backslashes as parent-dir via Win32 file APIs).
-  EXPECT_EQ(rf_rlocation(rf, "..\\x", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, ".\\x", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a\\..\\b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a\\.\\b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a\\\\b", buf, sizeof(buf)), -1);
-  EXPECT_EQ(rf_rlocation(rf, "a\\.", buf, sizeof(buf)), -1);
+  EXPECT_EQ(rf_rlocation(rf, "..\\x", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, ".\\x", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a\\..\\b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a\\.\\b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a\\\\b", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(rf_rlocation(rf, "a\\.", nullptr, buf, cap, &needed),
+            RF_RLOCATION_INVALID_PATH);
+  EXPECT_EQ(needed, 0u);
   rf_free(rf);
 }
 
@@ -261,32 +275,6 @@ TEST(RunfilesCTest, AbsolutePassthrough) {
   rf_free(rf);
 }
 
-TEST(RunfilesCTest, BufferTooSmall) {
-  unique_ptr<MockFile> mf(
-      MockFile::Create("foo" LINE_AS_STRING() ".runfiles_manifest",
-                       {"a/b a-very-long-resolved-path-that-will-not-fit"}));
-  ASSERT_TRUE(mf != nullptr);
-  char err[256] = {0};
-  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
-  ASSERT_NE(rf, nullptr) << err;
-  char buf[10];
-  EXPECT_EQ(rf_rlocation(rf, "a/b", buf, sizeof(buf)), -1);
-  rf_free(rf);
-}
-
-TEST(RunfilesCTest, EnvvarLookupsFailOnTooSmallBuffer) {
-  unique_ptr<MockFile> mf(MockFile::Create(
-      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b c/d"}));
-  ASSERT_TRUE(mf != nullptr);
-  char err[256] = {0};
-  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
-  ASSERT_NE(rf, nullptr) << err;
-  char k[4], v[4];
-  EXPECT_EQ(rf_env_var(rf, 0, k, sizeof(k), v, sizeof(v)), 0);
-  EXPECT_EQ(rf_env_var(rf, 42, k, 128, v, 128), 0);
-  rf_free(rf);
-}
-
 TEST(RunfilesCTest, DirectoryBasedNoManifest) {
   ASSERT_TMPDIR(tmp);
   string dir = tmp + "/foo" LINE_AS_STRING() ".runfiles";
@@ -294,7 +282,7 @@ TEST(RunfilesCTest, DirectoryBasedNoManifest) {
 
   char err[256] = {0};
   rf_runfiles* rf =
-      rf_create_ex(nullptr, "", "", dir.c_str(), "", err, sizeof(err));
+      rf_create(nullptr, "", "", dir.c_str(), "", err, sizeof(err));
   ASSERT_NE(rf, nullptr) << err;
   EXPECT_EQ(Rloc(rf, "any/file"), dir + "/any/file");
   ExpectEnvvars(rf, "", dir);
@@ -304,7 +292,7 @@ TEST(RunfilesCTest, DirectoryBasedNoManifest) {
 
 TEST(RunfilesCTest, FailsWhenNothingFound) {
   char err[256] = {0};
-  rf_runfiles* rf = rf_create_ex(nullptr, "", "", "", "", err, sizeof(err));
+  rf_runfiles* rf = rf_create(nullptr, "", "", "", "", err, sizeof(err));
   EXPECT_EQ(rf, nullptr);
   EXPECT_NE(strstr(err, "cannot find runfiles"), nullptr);
 }
@@ -319,7 +307,7 @@ TEST(RunfilesCTest, FailsOnBadManifest) {
   EXPECT_NE(strstr(err, "bad runfiles manifest"), nullptr);
 }
 
-TEST(RunfilesCTest, RlocationFromOverridesSourceRepo) {
+TEST(RunfilesCTest, RlocationOverridesSourceRepo) {
   // Manifest with a _repo_mapping that says: from source "src_repo", the
   // apparent name "my_module" maps to canonical "canonical_v1". No
   // mapping applies from the empty (main) source.
@@ -357,10 +345,9 @@ TEST(RunfilesCTest, RlocationFromOverridesSourceRepo) {
 // _repo_mapping tests: parity with the C++ suite
 // ==========================================================================
 
-// Each repo-mapping test captures __LINE__ once into a runtime `tag`
-// (instead of using LINE_AS_STRING() at multiple sites, which would
-// yield different values per occurrence and break the manifest ↔
-// MockFile path match).
+// Each test captures __LINE__ into `tag` -- using LINE_AS_STRING() at
+// multiple sites would give different values per occurrence and break
+// the manifest <-> MockFile path match.
 static string BuildRmapPathIn(const string& tmp, const string& tag) {
   return tmp + "/foo" + tag + ".runfiles/_repo_mapping";
 }
@@ -414,8 +401,8 @@ TEST(RunfilesCTest, RepoMappingFromOtherRepo) {
   string argv0 = mf->Path().substr(
       0, mf->Path().size() - string(".runfiles/MANIFEST").size());
   char err[256] = {0};
-  rf_runfiles* rf = rf_create_ex(nullptr, argv0.c_str(), "", "",
-                                 "protobuf+3.19.2", err, sizeof(err));
+  rf_runfiles* rf = rf_create(nullptr, argv0.c_str(), "", "", "protobuf+3.19.2",
+                              err, sizeof(err));
   ASSERT_NE(rf, nullptr) << err;
   EXPECT_EQ(Rloc(rf, "protobuf/foo/runfile2"), "protobuf+3.19.2/foo/runfile2");
   rf_free(rf);
@@ -441,8 +428,8 @@ TEST(RunfilesCTest, RepoMappingWildcardFromExtensionRepo) {
   string argv0 = mf->Path().substr(
       0, mf->Path().size() - string(".runfiles/MANIFEST").size());
   char err[256] = {0};
-  rf_runfiles* rf = rf_create_ex(nullptr, argv0.c_str(), "", "",
-                                 "my_module++ext+other_repo", err, sizeof(err));
+  rf_runfiles* rf = rf_create(nullptr, argv0.c_str(), "", "",
+                              "my_module++ext+other_repo", err, sizeof(err));
   ASSERT_NE(rf, nullptr) << err;
   EXPECT_EQ(Rloc(rf, "dep/file/x"), "resolved/dep1/file/x");
   rf_free(rf);
@@ -470,16 +457,9 @@ TEST(RunfilesCTest, InvalidRepoMappingRejected) {
   EXPECT_NE(strstr(err, "bad repository mapping"), nullptr);
 }
 
-// ==========================================================================
-// Regression test for the UB in the prefix-fallback search: the original
-// code cast away const and wrote a NUL into the caller's path string,
-// crashing when passed a string literal.
-// ==========================================================================
-
+// Regression: an earlier impl cast const away and wrote NUL into the
+// caller's path string to isolate the prefix, crashing on literals.
 TEST(RunfilesCTest, PrefixFallbackDoesNotMutatePath) {
-  // Manifest has "a" as a directory entry — prefix search will match "a"
-  // for path "a/nested/file". The old code would try to write NUL into
-  // path[1] to isolate the prefix, which segfaults on a string literal.
   unique_ptr<MockFile> mf(MockFile::Create(
       "foo" LINE_AS_STRING() ".runfiles_manifest", {"a resolved/dir"}));
   ASSERT_TRUE(mf != nullptr);
@@ -490,11 +470,8 @@ TEST(RunfilesCTest, PrefixFallbackDoesNotMutatePath) {
   rf_runfiles* rf = MakeFromArgv0(argv0, err);
   ASSERT_NE(rf, nullptr) << err;
 
-  char buf[1024];
-  // Pass a bona-fide string LITERAL — must not be mutated.
-  int n = rf_rlocation(rf, "a/nested/file", buf, sizeof(buf));
-  ASSERT_GT(n, 0);
-  EXPECT_STREQ(buf, "resolved/dir/nested/file");
+  // Pass a bona-fide string LITERAL -- must not be mutated.
+  EXPECT_EQ(Rloc(rf, "a/nested/file"), "resolved/dir/nested/file");
   rf_free(rf);
 }
 
@@ -531,17 +508,67 @@ TEST(RunfilesCTest, CustomAllocatorInvokedByCreateAndFree) {
   ASSERT_TRUE(mf != nullptr);
   char err[256] = {0};
   rf_runfiles* rf =
-      rf_create_ex(&a, "", mf->Path().c_str(), "", "", err, sizeof(err));
+      rf_create(&a, "", mf->Path().c_str(), "", "", err, sizeof(err));
   ASSERT_NE(rf, nullptr) << err;
   EXPECT_GT(stats.malloc_count, 0);
   EXPECT_EQ(Rloc(rf, "a/b"), "c/d");
 
   int free_before = stats.free_count_nonnull;
   rf_free(rf);
-  // The handle stored the allocator vtable at Create time and reused it
-  // in Free — every parsed byte + the handle itself came out through
-  // CountingFree.
+  // Every parsed byte + the handle itself frees through the vtable.
   EXPECT_GT(stats.free_count_nonnull, free_before);
+}
+
+TEST(RunfilesCTest, BufTooSmallReportsRequiredSize) {
+  // Value "a-very-long-resolved-path-that-will-not-fit" is 42 chars.
+  const string big_value = "a-very-long-resolved-path-that-will-not-fit";
+  unique_ptr<MockFile> mf(MockFile::Create(
+      "foo" LINE_AS_STRING() ".runfiles_manifest", {"a/b " + big_value}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+
+  // Too-tiny buffer -- reports exact required size, leaves buf untouched.
+  char tiny[8];
+  const char sentinel = '\x7f';
+  std::memset(tiny, sentinel, sizeof(tiny));
+  size_t needed = 0;
+  ASSERT_EQ(rf_rlocation(rf, "a/b", nullptr, tiny, sizeof(tiny), &needed),
+            RF_RLOCATION_BUF_TOO_SMALL);
+  EXPECT_EQ(needed, big_value.size());
+  for (char c : tiny) EXPECT_EQ(c, sentinel);
+
+  // Query-only: NULL buf, 0 cap -- pure size lookup.
+  size_t query_needed = 0;
+  ASSERT_EQ(rf_rlocation(rf, "a/b", nullptr, nullptr, 0, &query_needed),
+            RF_RLOCATION_BUF_TOO_SMALL);
+  EXPECT_EQ(query_needed, big_value.size());
+
+  // Retry with exactly-sized buffer.
+  string sized(needed + 1, '\0');
+  ASSERT_EQ(rf_rlocation(rf, "a/b", nullptr, &sized[0], sized.size(), &needed),
+            RF_RLOCATION_OK);
+  EXPECT_EQ(needed, big_value.size());
+  sized.resize(needed);
+  EXPECT_EQ(sized, big_value);
+
+  rf_free(rf);
+}
+
+TEST(RunfilesCTest, LongResolvedPathViaGrowAndRetry) {
+  // 64 KB value -- larger than Rloc's 4 KB stack buffer, so this
+  // exercises the std::string grow-and-retry path end-to-end.
+  string big_value(64 * 1024, 'x');
+  unique_ptr<MockFile> mf(
+      MockFile::Create("foo" LINE_AS_STRING() ".runfiles_manifest",
+                       {string("a/b ") + big_value}));
+  ASSERT_TRUE(mf != nullptr);
+  char err[256] = {0};
+  rf_runfiles* rf = MakeFromManifest(mf->Path(), err);
+  ASSERT_NE(rf, nullptr) << err;
+  EXPECT_EQ(Rloc(rf, "a/b"), big_value);
+  rf_free(rf);
 }
 
 // ==========================================================================

--- a/tests/runfiles/runfiles_test.cc
+++ b/tests/runfiles/runfiles_test.cc
@@ -747,7 +747,8 @@ TEST_F(RunfilesTest, ManifestBasedRlocationWithRepoMapping_fromExtensionRepo) {
   EXPECT_TRUE(error.empty());
 
   EXPECT_EQ(r->Rlocation("my_module/foo"), "/the/path/to/my_module+/runfile");
-  EXPECT_EQ(r->Rlocation("repo1/foo"), "/the/path/to/my_module++ext+repo1/runfile");
+  EXPECT_EQ(r->Rlocation("repo1/foo"),
+            "/the/path/to/my_module++ext+repo1/runfile");
   EXPECT_EQ(r->Rlocation("repo2+/foo"), "/the/path/to/repo2+/runfile");
 }
 
@@ -859,10 +860,10 @@ TEST_F(RunfilesTest,
   string argv0(dir.substr(0, dir.size() - string(".runfiles").size()));
 
   string error;
-  unique_ptr<Runfiles> r(Runfiles::Create(argv0, /*runfiles_manifest_file=*/"",
-                                          /*runfiles_dir=*/"",
-                                          /*source_repository=*/"", &error));
-  r = r->WithSourceRepository("protobuf+3.19.2");
+  unique_ptr<Runfiles> r(
+      Runfiles::Create(argv0, /*runfiles_manifest_file=*/"",
+                       /*runfiles_dir=*/"",
+                       /*source_repository=*/"protobuf+3.19.2", &error));
   ASSERT_TRUE(r != nullptr);
   EXPECT_TRUE(error.empty());
 
@@ -905,10 +906,10 @@ TEST_F(RunfilesTest, DirectoryBasedRlocationWithRepoMapping_fromExtensionRepo) {
   string argv0(dir.substr(0, dir.size() - string(".runfiles").size()));
 
   string error;
-  unique_ptr<Runfiles> r(Runfiles::Create(argv0, /*runfiles_manifest_file=*/"",
-                                          /*runfiles_dir=*/"",
-                                          /*source_repository=*/"", &error));
-  r = r->WithSourceRepository("my_module++ext+repo1");
+  unique_ptr<Runfiles> r(
+      Runfiles::Create(argv0, /*runfiles_manifest_file=*/"",
+                       /*runfiles_dir=*/"",
+                       /*source_repository=*/"my_module++ext+repo1", &error));
   ASSERT_TRUE(r != nullptr);
   EXPECT_TRUE(error.empty());
 

--- a/tests/runfiles/runfiles_test.cc
+++ b/tests/runfiles/runfiles_test.cc
@@ -934,6 +934,68 @@ TEST_F(RunfilesTest, InvalidRepoMapping) {
   EXPECT_TRUE(error.find("bad repository mapping") != string::npos);
 }
 
+// Exercises Runfiles::WithSourceRepository:
+//   - The derived instance sees repo-mapping entries as if it were built
+//     from `source_repository`.
+//   - The original instance is unaffected.
+//   - Both instances share the same underlying handle (the derived one
+//     stays valid even after the original is dropped).
+//   - EnvVars() on the derived instance still returns the three
+//     env pairs.
+TEST_F(RunfilesTest, WithSourceRepositoryReRoutesRepoMappingLookups) {
+  string uid = LINE_AS_STRING();
+  unique_ptr<MockFile> rm(MockFile::Create(
+      "foo" + uid + ".runfiles/_repo_mapping",
+      {",my_module,_main", "protobuf+3.19.2,protobuf,protobuf+3.19.2"}));
+  ASSERT_TRUE(rm != nullptr);
+  string dir = rm->DirName();
+  string argv0(dir.substr(0, dir.size() - string(".runfiles").size()));
+
+  string error;
+  unique_ptr<Runfiles> r_main(
+      Runfiles::Create(argv0, /*runfiles_manifest_file=*/"",
+                       /*runfiles_dir=*/"",
+                       /*source_repository=*/"", &error));
+  ASSERT_TRUE(r_main != nullptr);
+  EXPECT_TRUE(error.empty());
+
+  // As the main workspace, `my_module/foo` rewrites to `_main/foo`.
+  EXPECT_EQ(r_main->Rlocation("my_module/foo/runfile"),
+            dir + "/_main/foo/runfile");
+  // As the main workspace there's no `protobuf,protobuf` entry, so
+  // `protobuf/foo` stays un-rewritten.
+  EXPECT_EQ(r_main->Rlocation("protobuf/foo/runfile"),
+            dir + "/protobuf/foo/runfile");
+
+  // Derive a sibling that acts as if built from `protobuf+3.19.2`.
+  unique_ptr<Runfiles> r_pb = r_main->WithSourceRepository("protobuf+3.19.2");
+  ASSERT_TRUE(r_pb != nullptr);
+
+  // In the protobuf+3.19.2 source, `protobuf/foo` rewrites to
+  // `protobuf+3.19.2/foo`.
+  EXPECT_EQ(r_pb->Rlocation("protobuf/foo/runfile"),
+            dir + "/protobuf+3.19.2/foo/runfile");
+  // `my_module/foo` doesn't have a matching entry from this source, so
+  // it stays as-is.
+  EXPECT_EQ(r_pb->Rlocation("my_module/foo/runfile"),
+            dir + "/my_module/foo/runfile");
+
+  // Original still resolves the same way it did before deriving.
+  EXPECT_EQ(r_main->Rlocation("my_module/foo/runfile"),
+            dir + "/_main/foo/runfile");
+
+  // EnvVars() on the sibling matches the original's (three entries,
+  // same paths).
+  ASSERT_EQ(r_pb->EnvVars(), r_main->EnvVars());
+  ASSERT_EQ(r_pb->EnvVars().size(), size_t{3});
+
+  // Drop the original -- the sibling must remain functional (shared
+  // handle keeps the underlying rf_runfiles alive).
+  r_main.reset();
+  EXPECT_EQ(r_pb->Rlocation("protobuf/foo/runfile"),
+            dir + "/protobuf+3.19.2/foo/runfile");
+}
+
 }  // namespace
 }  // namespace runfiles
 }  // namespace cc


### PR DESCRIPTION
This change re-implements the backbone of the runfiles library in C from C++ and introduces a new top level C interface at `@rules_cc//cc/runfiles:runfiles_c`. Documentation for the interfaces and high level differences between the C and C++ interfaces have been added to `./docs/runfiles.md`

closes https://github.com/bazelbuild/rules_cc/issues/400