### PR TITLE
Ship llvm-cov and llvm-profdata with coverage_files

### DIFF
--- a/cc/toolchains/legacy_file_group.bzl
+++ b/cc/toolchains/legacy_file_group.bzl
@@ -33,11 +33,12 @@ LEGACY_FILE_GROUPS = {
         Label("//cc/toolchains/actions:cpp_module_deps_scanning"),
     ],
     # There are no actions listed for coverage and objcopy in action_names.bzl.
-    # The llvm-cov and llvm-profdata tools are what collect_cc_coverage.sh
-    # runs from inside the coverage test action, so their files have to ship
-    # with it -- the legacy cc_toolchain got this by defaulting coverage_files
-    # to all_files.
+    # The gcov, llvm-cov and llvm-profdata tools are what
+    # collect_cc_coverage.sh runs from inside the coverage test action, so
+    # their files have to ship with it -- the legacy cc_toolchain got this by
+    # defaulting coverage_files to all_files.
     "coverage_files": [
+        Label("//cc/toolchains/actions:gcov"),
         Label("//cc/toolchains/actions:llvm_cov"),
         Label("//cc/toolchains/actions:llvm_profdata"),
     ],

--- a/cc/toolchains/legacy_file_group.bzl
+++ b/cc/toolchains/legacy_file_group.bzl
@@ -33,7 +33,14 @@ LEGACY_FILE_GROUPS = {
         Label("//cc/toolchains/actions:cpp_module_deps_scanning"),
     ],
     # There are no actions listed for coverage and objcopy in action_names.bzl.
-    "coverage_files": [],
+    # The llvm-cov and llvm-profdata tools are what collect_cc_coverage.sh
+    # runs from inside the coverage test action, so their files have to ship
+    # with it -- the legacy cc_toolchain got this by defaulting coverage_files
+    # to all_files.
+    "coverage_files": [
+        Label("//cc/toolchains/actions:llvm_cov"),
+        Label("//cc/toolchains/actions:llvm_profdata"),
+    ],
     "dwp_files": [
         Label("//cc/toolchains/actions:dwp"),
     ],


### PR DESCRIPTION
The rule-based cc_toolchain's coverage_files group was empty (a TODO: action_names.bzl lists no actions for coverage), so a toolchain whose llvm_cov / llvm_profdata tools are files -- a hermetic LLVM distribution -- cannot collect llvm-format coverage: the environment points collect_cc_coverage.sh at the right execroot-relative llvm-profdata path, but the binary is not among the coverage test action's inputs, and collection fails with

  .../bin/llvm-profdata: No such file or directory

The legacy cc_toolchain never hit this because its coverage_files attribute defaults to all_files. Toolchains whose coverage tools are absolute paths (xcrun shims, /usr/bin/gcov) are unaffected either way.

Verified with toolchains_llvm's darwin toolchain: with this change, `bazel coverage --experimental_use_llvm_covmap
--experimental_generate_llvm_lcov` produces a populated lcov report where it previously failed outright.