### PR TITLE
Add missing bsd link libraries

### DIFF
--- a/cc/private/toolchain/bsd_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/bsd_cc_toolchain_config.bzl
@@ -60,6 +60,10 @@ def _impl(ctx):
     if cpu not in ("freebsd", "openbsd"):
         fail("unsupported BSD CPU: %s" % cpu)
 
+    extra_default_link_flags = []
+    if cpu == "openbsd":
+        extra_default_link_flags = ["-lc++abi", "-lpthread"]
+
     default_link_flags_feature = feature(
         name = "default_link_flags",
         enabled = True,
@@ -72,7 +76,7 @@ def _impl(ctx):
                             "-lc++",
                             "-Wl,-z,relro,-z,now,-z,origin",
                             "-no-canonical-prefixes",
-                        ],
+                        ] + extra_default_link_flags,
                     ),
                 ],
             ),

--- a/cc/private/toolchain/bsd_cc_toolchain_config.bzl
+++ b/cc/private/toolchain/bsd_cc_toolchain_config.bzl
@@ -74,6 +74,7 @@ def _impl(ctx):
                     flag_group(
                         flags = [
                             "-lc++",
+                            "-lm",
                             "-Wl,-z,relro,-z,now,-z,origin",
                             "-no-canonical-prefixes",
                         ] + extra_default_link_flags,


### PR DESCRIPTION
This mirrors this behavior from the clang driver:

https://github.com/llvm/llvm-project/blob/3e892fad65730692057da27bebb2e34d3ad7bde7/clang/lib/Driver/ToolChains/OpenBSD.cpp#L365-L366

The same does not apply for freebsd (I didn't check netbsd which isn't
supported here right now).

Alternatively we could use clang++ for linking directly instead of
clang, which would add these automatically, but that would make it
harder to disable these in the case you are linking pure C

Fixes https://github.com/bazelbuild/rules_cc/issues/857
