### PR TITLE
Exclude assemble actions from include/random-seed cc_args

### DIFF
--- a/cc/toolchains/actions/BUILD
+++ b/cc/toolchains/actions/BUILD
@@ -273,6 +273,16 @@ cc_action_type_set(
 )
 
 cc_action_type_set(
+    name = "source_compile_actions_without_assemble",
+    actions = [
+        ":source_compile_actions",
+    ],
+    excludes = [
+        ":assemble",
+    ],
+)
+
+cc_action_type_set(
     name = "cpp20_module_actions",
     actions = [
         ":cpp20_module_compile",

--- a/cc/toolchains/args/include_flags/BUILD
+++ b/cc/toolchains/args/include_flags/BUILD
@@ -19,7 +19,7 @@ cc_feature(
 
 cc_args(
     name = "includes_flags",
-    actions = ["//cc/toolchains/actions:source_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions_without_assemble"],
     args = [
         "-include",
         "{includes}",
@@ -42,7 +42,7 @@ cc_feature(
 
 cc_args(
     name = "quote_include_paths_flags",
-    actions = ["//cc/toolchains/actions:source_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions_without_assemble"],
     args = [
         "-iquote",
         "{quote_include_paths}",
@@ -53,7 +53,7 @@ cc_args(
 
 cc_args(
     name = "include_paths_flags",
-    actions = ["//cc/toolchains/actions:source_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions_without_assemble"],
     args = [
         "-I{include_paths}",
     ],
@@ -63,7 +63,7 @@ cc_args(
 
 cc_args(
     name = "system_include_paths_flags",
-    actions = ["//cc/toolchains/actions:source_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions_without_assemble"],
     args = [
         "-isystem",
         "{system_include_paths}",
@@ -74,7 +74,7 @@ cc_args(
 
 cc_args(
     name = "framework_include_paths_flags",
-    actions = ["//cc/toolchains/actions:source_compile_actions"],
+    actions = ["//cc/toolchains/actions:source_compile_actions_without_assemble"],
     args = [
         "-F{framework_include_paths}",
     ],

--- a/cc/toolchains/args/random_seed/BUILD
+++ b/cc/toolchains/args/random_seed/BUILD
@@ -11,7 +11,11 @@ cc_feature(
 
 cc_args(
     name = "random_seed",
-    actions = ["//cc/toolchains/actions:compile_actions"],
+    actions = [
+        "//cc/toolchains/actions:c_compile_actions",
+        "//cc/toolchains/actions:cpp_compile_actions",
+        "//cc/toolchains/actions:objc_compile",
+    ],
     args = ["-frandom-seed={output_file}"],
     format = {"output_file": "//cc/toolchains/variables:output_file"},
     requires_not_none = "//cc/toolchains/variables:output_file",


### PR DESCRIPTION
-frandom-seed has no effect on assembly and causes Clang to warn with -Wunused-command-line-argument when assembling .s files.

Related to #698