### PR TITLE
Remove MODULE.bazel.lock usage from integration tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -51,7 +51,6 @@ filegroup(
     srcs = [
         "BUILD",
         "MODULE.bazel",
-        "MODULE.bazel.lock",
         "//cc:srcs",
     ],
     visibility = ["//:__subpackages__"],

--- a/tests/integration/test_launcher.sh
+++ b/tests/integration/test_launcher.sh
@@ -55,41 +55,17 @@ scratch_workspace="$TEST_TMPDIR/scratch"
 mkdir -p "$scratch_workspace"
 cd "$scratch_workspace"
 
-
-
-# Extract the module version used in the default lock file.
-function get_version_from_default_lock_file() {
-  lockfile=$(rlocation rules_cc/MODULE.bazel.lock)
-  module=$1
-  local version=$(sed -n "s|.*modules/$module/\([^/]*\)/source\.json.*|\1|p" "$lockfile")
-  if [[ -z $version ]]; then
-      echo "Version not found for module $module in $lockfile"
-      exit 1
-  else
-      echo "$version"
-  fi
-}
-
-function add_bazel_dep() {
-  version=$(get_version_from_default_lock_file "$1")
-  cat >> "$2" <<EOF
-bazel_dep(name = "$1", version = "$version")
-EOF
-}
-
 # Make rules_cc available
 cat > MODULE.bazel << EOF
 module(name = "test_module")
 
 bazel_dep(name = "rules_cc", version = "0.0.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 local_path_override(
     module_name = "rules_cc",
     path = "$rules_cc_dir"
 )
 EOF
-add_bazel_dep "rules_shell" MODULE.bazel
-
-
 
 test_runner_path="$(rlocation "$TEST_RUNNER")" || (echo >&2 "FAILED TO LOAD TEST RUNNER" && exit 1)
 test_runner_cmd=( "${test_runner_path}" )


### PR DESCRIPTION
This failed in the release job where this gitignored file didn't exist
yet. We can just bump this version manually, having the oldest possible
version here is good anyways.
