### PR TITLE
Add imported module files to module codegen action inputs

### DIFF
--- a/cc/private/compile/compile.bzl
+++ b/cc/private/compile/compile.bzl
@@ -2079,6 +2079,19 @@ def _create_module_codegen_action(
     if fdo_context_has_artifacts:
         additional_inputs = auxiliary_fdo_inputs.to_list()
 
+    # Compiling the module file into an object file causes Clang to load it, which in turn loads
+    # the module files it imports (if the module was compiled with use_header_modules). Bazel adds
+    # the transitive modules as inputs of compiles that use header modules themselves, but not of
+    # module codegen actions, whose source isn't compiled with header modules.
+    # TODO: Remove once the minimum supported Bazel version includes
+    # https://github.com/bazelbuild/bazel/pull/30396.
+    if feature_configuration.is_enabled("use_header_modules"):
+        if use_pic:
+            transitive_modules = cc_compilation_context._transitive_pic_modules
+        else:
+            transitive_modules = cc_compilation_context._transitive_modules
+        additional_inputs = additional_inputs + transitive_modules.to_list()
+
     _create_compile_action(
         action_construction_context = action_construction_context,
         cc_compilation_context = cc_compilation_context,

--- a/tests/cc/common/BUILD
+++ b/tests/cc/common/BUILD
@@ -15,6 +15,7 @@ load(":cc_output_groups_test.bzl", "cc_output_groups_tests")
 load(":compile_build_variables_tests.bzl", "compile_build_variables_tests")
 load(":cpp_modules_test.bzl", "cpp_modules_tests")
 load(":debug_info_packaging_test.bzl", "debug_info_packaging_tests")
+load(":header_modules_test.bzl", "header_modules_tests")
 load(":link_build_variables_test.bzl", "link_build_variables_tests")
 
 cc_binary_configured_target_tests(name = "cc_binary_configured_target_tests")
@@ -52,3 +53,5 @@ cc_link_action_tests(name = "cc_link_action_tests")
 cc_linkstamp_compile_tests(name = "cc_linkstamp_compile_tests")
 
 cc_binary_fdo_tests(name = "cc_binary_fdo_tests")
+
+header_modules_tests(name = "header_modules_tests")

--- a/tests/cc/common/header_modules_test.bzl
+++ b/tests/cc/common/header_modules_test.bzl
@@ -1,0 +1,71 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Clang header modules."""
+
+load("@bazel_features//:features.bzl", "bazel_features")
+load("@rules_testing//lib:analysis_test.bzl", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//cc:cc_library.bzl", "cc_library")
+load("//tests/cc/testutil:cc_analysis_test.bzl", "cc_analysis_test")
+
+_HEADER_MODULE_FEATURES = [
+    "header_modules",
+    "use_header_modules",
+    "header_module_codegen",
+]
+
+def _test_module_codegen_action_inputs(name, **kwargs):
+    util.helper_target(
+        cc_library,
+        name = name + "/a",
+        hdrs = ["a.h"],
+        features = _HEADER_MODULE_FEATURES,
+    )
+    util.helper_target(
+        cc_library,
+        name = name + "/b",
+        hdrs = ["b.h"],
+        deps = [name + "/a"],
+        features = _HEADER_MODULE_FEATURES,
+    )
+
+    cc_analysis_test(
+        name = name,
+        target = name + "/b",
+        test_features = ["header_modules_feature_configuration"],
+        impl = _test_module_codegen_action_inputs_impl,
+        **kwargs
+    )
+
+def _test_module_codegen_action_inputs_impl(env, target):
+    # Compiling b's module file into an object file loads it, which in turn loads the module files
+    # it imports, so those are inputs even though the codegen action's source isn't itself compiled
+    # with header modules.
+    codegen_action = env.expect.that_target(target).action_generating(
+        "{package}/_objs/{test_name}/b/b.pcm.o",
+    )
+    codegen_action.inputs().contains("{package}/_objs/{test_name}/a/a.pcm")
+
+def header_modules_tests(name):
+    tests = []
+    if bazel_features.cc.cc_common_is_in_rules_cc:
+        tests = [
+            _test_module_codegen_action_inputs,
+        ]
+
+    test_suite(
+        name = name,
+        tests = tests,
+    )


### PR DESCRIPTION
Module codegen actions (`header_module_codegen`) compile a module file into an object file. Clang loads the module file, which in turn loads the module files it imports, i.e. the modules of the target's dependencies if the module was compiled with `use_header_modules`.

Without include scanning, Bazel adds the transitive modules as inputs of compile actions that use header modules themselves, but not of module codegen actions: their source is a `.pcm`, which isn't compiled with header modules as far as `CppCompileActionBuilder` is concerned. With sandboxing or remote execution, the codegen action then fails with e.g.

```
fatal error: module file 'bazel-out/.../_objs/a/a.pic.pcm' not found
```

Since the set of imported modules isn't known at analysis time, add the transitive modules of the compilation context as an upper bound of the codegen action's inputs when `use_header_modules` is enabled. This mirrors what https://github.com/bazelbuild/bazel/pull/30396 does on the Bazel side and can be dropped once that fix is in the minimum supported Bazel version.

Found while enabling header modules in the hermetic LLVM toolchain (hermeticbuild/hermetic-llvm#676), which currently vendors this change as a patch.
