### PR TITLE
Default cc_sysroot data to sysroot if not passed

### DIFF
--- a/cc/toolchains/args/sysroot.bzl
+++ b/cc/toolchains/args/sysroot.bzl
@@ -36,6 +36,9 @@ def cc_sysroot(*, name, sysroot, actions = _DEFAULT_SYSROOT_ACTIONS, args = [], 
       args: (List[str]) Extra command-line args to add.
       **kwargs: kwargs to pass to cc_args.
     """
+    if "data" not in kwargs:
+        kwargs["data"] = [sysroot]
+
     cc_args(
         name = name,
         actions = actions,

--- a/tests/rule_based_toolchain/toolchain_config/BUILD
+++ b/tests/rule_based_toolchain/toolchain_config/BUILD
@@ -73,6 +73,7 @@ cc_sysroot(
         "//tests/rule_based_toolchain/actions:c_compile",
         "//tests/rule_based_toolchain/actions:cpp_compile",
     ],
+    data = [],
     sysroot = "//tests/rule_based_toolchain/testdata:directory",
 )
 


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_cc/issues/243
